### PR TITLE
feat: redo keyword highlighting

### DIFF
--- a/examples/website/DemoSite/Blog/Conditionals.lean
+++ b/examples/website/DemoSite/Blog/Conditionals.lean
@@ -90,6 +90,19 @@ def squish'' (n : Option Nat) : Nat :=
 
 ```
 
+Here is a mutual block:
+```lean demo
+mutual
+  def f : Nat → Nat
+    | 0 => 1
+    | n + 1 => g n
+
+  def g : Nat → Nat
+    | 0 => 0
+    | n + 1 => f n
+end
+```
+
 Here is a proof with some lambdas and big terms in it, to check highlighting:
 ```lean demo
 def grow : Nat → α → α

--- a/src/verso-blog/Verso/Genre/Blog/Highlighted.lean
+++ b/src/verso-blog/Verso/Genre/Blog/Highlighted.lean
@@ -8,7 +8,8 @@ deriving instance Repr for Std.Format.FlattenBehavior
 deriving instance Repr for Std.Format
 
 inductive Highlighted.Token.Kind where
-  | keyword (name : Option Name) (docs : Option String)
+  | /-- `occurrence` is a unique identifier that unites the various keyword tokens from a given production -/
+    keyword (name : Option Name) (occurrence : Option String) (docs : Option String)
   | const (name : Name) (signature : String) (docs : Option String)
   | var (name : FVarId) (type : String)
   | str (string : String)
@@ -22,7 +23,7 @@ open Highlighted.Token.Kind in
 open Syntax (mkCApp) in
 instance : Quote Highlighted.Token.Kind where
   quote
-    | .keyword n docs => mkCApp ``keyword #[quote n, quote docs]
+    | .keyword n occ docs => mkCApp ``keyword #[quote n, quote occ, quote docs]
     | .const n sig docs => mkCApp ``const #[quote n, quote sig, quote docs]
     | .option n docs => mkCApp ``option #[quote n, quote docs]
     | .var (.mk n) type => mkCApp ``var #[mkCApp ``FVarId.mk #[quote n], quote type]

--- a/src/verso-blog/Verso/Genre/Blog/Template.lean
+++ b/src/verso-blog/Verso/Genre/Blog/Template.lean
@@ -46,13 +46,14 @@ defmethod Highlighted.Token.Kind.«class» : Highlighted.Token.Kind → String
   | .const _ _ _ => "const"
   | .option _ _ => "option"
   | .docComment => "doc-comment"
-  | .keyword _ _ => "keyword"
+  | .keyword _ _ _ => "keyword"
   | .unknown => "unknown"
 
 defmethod Highlighted.Token.Kind.data : Highlighted.Token.Kind → String
   | .const n _ _ => "const-" ++ toString n
   | .var ⟨v⟩ _ => "var-" ++ toString v
   | .option n _ => "option-" ++ toString n
+  | .keyword _ (some occ) _ => "kw-occ-" ++ toString occ
   | _ => ""
 
 
@@ -66,11 +67,13 @@ defmethod Highlighted.Token.Kind.hover? : (tok : Highlighted.Token.Kind) → Opt
       | none => .empty
       | some txt => {{<hr/><pre class="docstring">{{txt}}</pre>}}
     some <| hover {{ <code>{{sig}}</code> {{docs}} }}
-  | .option n doc | .keyword (some n) doc =>
+  | .option n doc =>
     let docs := match doc with
       | none => .empty
       | some txt => {{<hr/><pre class="docstring">{{txt}}</pre>}}
     some <| hover {{ <code>{{toString n}}</code> {{docs}} }}
+  | .keyword _ _ none => none
+  | .keyword _ _ (some doc) => some <| hover {{<pre class="docstring">{{doc}}</pre>}}
   | .var _ type =>
     some <| hover {{ <code>{{type}}</code> }}
   | .str s =>


### PR DESCRIPTION
Now keywords don't show their parser names, and they participate in occurrence highlighting