### PR TITLE
chore: ignore .lake and _out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /lake-packages/*
 /_site
 .DS_Store
+.lake
+_out


### PR DESCRIPTION
Ignore the outputs of `lake build`.