### PR TITLE
chore: remove Std dependency

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,14 +1,5 @@
 {"version": 7,
  "packagesDir": ".lake/packages",
- "packages":
- [{"url": "https://github.com/leanprover/std4",
-   "type": "git",
-   "subDir": null,
-   "rev": "a178ab58c07c37d919079ac3a5e4514fd85b791b",
-   "name": "std",
-   "manifestFile": "lake-manifest.json",
-   "inputRev": "nightly-testing-2024-02-22",
-   "inherited": false,
-   "configFile": "lakefile.lean"}],
+ "packages": [],
  "name": "verso",
  "lakeDir": ".lake"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,8 +1,6 @@
 import Lake
 open Lake DSL
 
-require std from git "https://github.com/leanprover/std4" @ "nightly-testing-2024-02-22"
-
 package verso where
   -- add package configuration options here
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-02-22
+leanprover/lean4:nightly-2024-02-26

--- a/src/verso/Verso/Doc.lean
+++ b/src/verso/Verso/Doc.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 import Lean
-import Std.Tactic.GuardMsgs
 
 namespace Verso
 

--- a/src/verso/Verso/Doc/Html.lean
+++ b/src/verso/Verso/Doc/Html.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Std.Tactic.GuardMsgs
 
 import Verso.Doc
 import Verso.Examples

--- a/src/verso/Verso/Examples.lean
+++ b/src/verso/Verso/Examples.lean
@@ -3,8 +3,6 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Std.Tactic.GuardMsgs
-
 import Verso.Doc.Concrete
 
 

--- a/src/verso/Verso/Method.lean
+++ b/src/verso/Verso/Method.lean
@@ -3,7 +3,6 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Std.Tactic.GuardMsgs
 import Lean
 
 namespace Verso.Method

--- a/src/verso/Verso/Output/Html.lean
+++ b/src/verso/Verso/Output/Html.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 import Lean
-import Std.Tactic.GuardMsgs
 
 namespace Verso.Output
 

--- a/src/verso/Verso/Output/TeX.lean
+++ b/src/verso/Verso/Output/TeX.lean
@@ -1,5 +1,4 @@
 import Lean
-import Std.Tactic.GuardMsgs
 
 open Lean
 

--- a/src/verso/Verso/Parser.lean
+++ b/src/verso/Verso/Parser.lean
@@ -6,8 +6,6 @@ Author: David Thrane Christiansen
 
 import Lean
 
-import Std
-
 import Verso.Parser.Lean
 import Verso.SyntaxUtils
 import Verso.Syntax


### PR DESCRIPTION
Now that the code uses Lean nightlies anyway, and all the needed bits have been upstreamed, might as well not have the extra dependency for now.