### PR TITLE
fix: stack info hovers in a single window

### DIFF
--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "9f51556e14f14fbf7880b69e3cb1654e60ab66a2",
+   "rev": "3d2c5f27dcd33e2681ab16bc2e53eb9bf5d20daf",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/examples/website/DemoSite/Blog/Conditionals.lean
+++ b/examples/website/DemoSite/Blog/Conditionals.lean
@@ -136,5 +136,27 @@ example [Monad m] [MonadQuotation m] [MonadRef m] : ¬(quotedStx (m := m) = fun 
   sorry
 ```
 
+It's possible to render a lot of info on one example:
+```lean demo
+elab "%much_info(" t:term ")" : term => open Lean Elab Term in do
+  for i in [0:20] do
+    logInfoAt t m!"Hello! ({i})"
+  logInfoAt t "Some multi-line\ninfo too"
+  elabTerm t none
+
+elab "%more_info(" t:term ")" : term => open Lean Elab Term in do
+  for i in [0:20] do
+    logInfoAt t m!"Hello again! ({i})"
+  logErrorAt t "And a great big error, much wider than the other info!"
+  elabTerm t none
+```
+
+````lean demo error:=true
+example := %much_info(22)
+
+example := %more_info(25)
+````
+
+The info gets stacked up, with the greatest severity highlighting the range in question.
 
 Thank you for looking at my test/demo post.

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "9f51556e14f14fbf7880b69e3cb1654e60ab66a2",
+   "rev": "3d2c5f27dcd33e2681ab16bc2e53eb9bf5d20daf",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/src/verso-blog/Verso/Genre/Blog/Basic.lean
+++ b/src/verso-blog/Verso/Genre/Blog/Basic.lean
@@ -340,10 +340,10 @@ def highlightingStyle : String := "
 }
 
 .hover-container {
-    width: 0;
-    height: 0;
-    position: relative;
-    display: inline;
+  width: 0;
+  height: 0;
+  position: relative;
+  display: inline;
 }
 
 .hl.lean .hover-info {
@@ -360,8 +360,34 @@ def highlightingStyle : String := "
   font-size: inherit;
 }
 
+.hl.lean .has-info .hover-info.messages {
+  max-height: 10em;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0;
+  background-color: #e5e5e5;
+}
+
 .hl.lean .hover-info code {
   white-space: pre;
+}
+
+.hl.lean .hover-info.messages > code {
+  padding: 0.5em;
+  display: block;
+  width: fit-content;
+}
+
+.hl.lean .hover-info.messages > code:only-child {
+  margin: 0;
+}
+
+.hl.lean .hover-info.messages > code {
+  margin: 0.1em;
+}
+
+.hl.lean .hover-info.messages > code:not(:first-child) {
+  margin-top: 0em;
 }
 
 @media (hover: hover) {
@@ -425,7 +451,7 @@ def highlightingStyle : String := "
   }
 }
 
-.hl.lean .has-info.error > .hover-container > .hover-info {
+.hl.lean .has-info > .hover-container > .hover-info > code.error {
   background-color: #ffb3b3;
 }
 
@@ -437,7 +463,13 @@ def highlightingStyle : String := "
   text-decoration-color: yellow;
 }
 
-.hl.lean .has-info.warning .hover-info {
+@media (hover: hover) {
+  .hl.lean .has-info.warning:hover {
+    background-color: yellow;
+  }
+}
+
+.hl.lean .has-info .hover-info.messages > code.warning {
   background-color: yellow;
 }
 
@@ -445,7 +477,14 @@ def highlightingStyle : String := "
   text-decoration-color: blue;
 }
 
-.hl.lean .has-info.info .hover-info {
+@media (hover: hover) {
+  .hl.lean .has-info.info:hover {
+    background-color: #4777ff;
+  }
+}
+
+
+.hl.lean .has-info .hover-info.messages > code.info {
   background-color: #4777ff;
 }
 


### PR DESCRIPTION
This prevents horrible nests of info hovers when there's more than one on a source span.

Incorporates https://github.com/leanprover/subverso/pull/13.