### PR TITLE
feat: support name references in subprojects

### DIFF
--- a/examples/website-examples/Examples/Basic.lean
+++ b/examples/website-examples/Examples/Basic.lean
@@ -18,3 +18,5 @@ def Tree.flip : Tree α → Tree α
   | .leaf => .leaf
   | .branch l v r => %ex{flopped}{.branch r.flip v l.flip}
 %end
+
+%show_name Tree.flip as FLIP

--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "c4622e3ed9d63d342be89dbd1262ab58efa5ceb3",
+   "rev": "54396d8b6e88895407c679c838069ea27e69e91b",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/examples/website/DemoSite/Blog/Subprojects.lean
+++ b/examples/website/DemoSite/Blog/Subprojects.lean
@@ -35,7 +35,7 @@ Here's a tree:
 
 {leanCommand examples Examples.Basic.Tree}
 
-They can be flipped around:
+They can be flipped around with {leanTerm examples}`FLIP`:
 
 {leanCommand examples Examples.Basic.Tree.flip}
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "c4622e3ed9d63d342be89dbd1262ab58efa5ceb3",
+   "rev": "54396d8b6e88895407c679c838069ea27e69e91b",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This bumps SubVerso to allow references to names that aren't elaborated as terms.