### PR TITLE
feat: automatic finding of extension descriptors in manual

### DIFF
--- a/UsersGuideMain.lean
+++ b/UsersGuideMain.lean
@@ -4,7 +4,4 @@ import UsersGuide
 
 open Verso.Genre.Manual
 
--- TODO: metaprogram this away
-def impls := ExtensionImpls.fromLists [] [(``Block.paragraph, paragraph.descr), (``Block.docstring, docstring.descr)]
-
-def main := manualMain impls (%doc UsersGuide.Basic)
+def main := manualMain (%doc UsersGuide.Basic)

--- a/examples/textbook/DemoTextbook/Exts/Exercises.lean
+++ b/examples/textbook/DemoTextbook/Exts/Exercises.lean
@@ -24,24 +24,6 @@ namespace DemoTextbook.Exts
 def Block.lean : Block where
   name := `DemoTextbook.Exts.lean
 
-def lean.descr : BlockDescr where
-  traverse _ _ _ := do
-    pure none
-  toTeX :=
-    some <| fun _ go _ _ content => do
-      pure <| .seq <| ← content.mapM fun b => do
-        pure <| .seq #[← go b, .raw "\n"]
-  extraCss := highlightingStyle
-  extraJs := highlightingJs
-  toHtml :=
-    open Verso.Output.Html in
-    some <| fun _ _ _ data _ => do
-      match FromJson.fromJson? data with
-      | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
-        pure .empty
-      | .ok (hl : Highlighted) =>
-        pure <| hl.blockHtml "exercises"
 
 
 
@@ -142,3 +124,23 @@ def lean : CodeBlockExpander
       pure #[← `(Block.other {Block.lean with data := ToJson.toJson $(quote hls)} #[Block.code $(quote str.getString)])]
     else
       pure #[]
+
+@[block_extension lean]
+def lean.descr : BlockDescr where
+  traverse _ _ _ := do
+    pure none
+  toTeX :=
+    some <| fun _ go _ _ content => do
+      pure <| .seq <| ← content.mapM fun b => do
+        pure <| .seq #[← go b, .raw "\n"]
+  extraCss := highlightingStyle
+  extraJs := highlightingJs
+  toHtml :=
+    open Verso.Output.Html in
+    some <| fun _ _ _ data _ => do
+      match FromJson.fromJson? data with
+      | .error err =>
+        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
+        pure .empty
+      | .ok (hl : Highlighted) =>
+        pure <| hl.blockHtml "exercises"

--- a/examples/textbook/DemoTextbook/Exts/Index.lean
+++ b/examples/textbook/DemoTextbook/Exts/Index.lean
@@ -81,6 +81,11 @@ def Inline.index : Inline where
 
 def indexState := `DemoTextbook.Exts.Index
 
+def index (args : Array (Doc.Inline Manual)) (subterm : Option String := none) (index : Option String := none) : Doc.Inline Manual :=
+  let entry : Index.Entry := {term := .concat args, subterm := subterm.map Doc.Inline.text, index}
+  Doc.Inline.other {Inline.index with data := ToJson.toJson entry} #[]
+
+@[inline_extension index]
 def index.descr : InlineDescr where
   traverse id data _contents := do
     -- TODO use internal tags in the first round to respect users' assignments (cf part tag assignment)
@@ -108,10 +113,6 @@ def index.descr : InlineDescr where
         | panic! s!"Untagged index target with data {inl}"
       return {{<span id={{t}}></span>}}
 
-def index (args : Array (Doc.Inline Manual)) (subterm : Option String := none) (index : Option String := none) : Doc.Inline Manual :=
-  let entry : Index.Entry := {term := .concat args, subterm := subterm.map Doc.Inline.text, index}
-  Doc.Inline.other {Inline.index with data := ToJson.toJson entry} #[]
-
 def Inline.see : Inline where
   name := `DemoTextbook.Exts.see
 
@@ -123,6 +124,7 @@ def seeAlso (args : Array (Doc.Inline Manual)) (target : String) (subterm : Opti
   let data : Index.See := {source := .concat args, target := .text target, subTarget := subterm.map .text, also := true, index}
   Doc.Inline.other {Inline.see with data := ToJson.toJson data} #[]
 
+@[inline_extension see]
 def see.descr : InlineDescr where
   traverse _id data _contents := do
     match FromJson.fromJson? data with
@@ -310,6 +312,10 @@ def Index.render (index : Index) : Array (IndexCat × Array RenderedEntry) := Id
   pure grouped
 
 
+def theIndex (index : Option String := none) : Doc.Block Manual :=
+  Doc.Block.other {Block.theIndex with data := ToJson.toJson index} #[]
+
+@[block_extension theIndex]
 def theIndex.descr : BlockDescr where
   traverse _ _ _ := do
     pure none
@@ -411,6 +417,3 @@ where
       width: auto;
     }
     "###
-
-def theIndex (index : Option String := none) : Doc.Block Manual :=
-  Doc.Block.other {Block.theIndex with data := ToJson.toJson index} #[]

--- a/examples/textbook/DemoTextbookMain.lean
+++ b/examples/textbook/DemoTextbookMain.lean
@@ -10,15 +10,7 @@ import DemoTextbook
 
 open Verso.Genre.Manual
 
--- TODO: metaprogram this away
-def impls := ExtensionImpls.fromLists
-  [(``DemoTextbook.Exts.index, DemoTextbook.Exts.index.descr),
-   (``DemoTextbook.Exts.see, DemoTextbook.Exts.see.descr),
-   (``DemoTextbook.Exts.seeAlso, DemoTextbook.Exts.seeAlso.descr)]
-  [(``Block.paragraph, paragraph.descr),
-   (``Block.docstring, docstring.descr),
-   (``DemoTextbook.Exts.theIndex, DemoTextbook.Exts.theIndex.descr),
-   (``DemoTextbook.Exts.lean, DemoTextbook.Exts.lean.descr)]
+def impls := ExtensionImpls.fromLists inline_extensions% block_extensions%
 
 def buildExercises (_ctxt : TraverseContext) (_state : TraverseState) : IO Unit :=
   IO.println "Placeholder generator for output exercise and solution Lean code"

--- a/examples/textbook/DemoTextbookMain.lean
+++ b/examples/textbook/DemoTextbookMain.lean
@@ -10,9 +10,7 @@ import DemoTextbook
 
 open Verso.Genre.Manual
 
-def impls := ExtensionImpls.fromLists inline_extensions% block_extensions%
-
 def buildExercises (_ctxt : TraverseContext) (_state : TraverseState) : IO Unit :=
   IO.println "Placeholder generator for output exercise and solution Lean code"
 
-def main := manualMain impls (%doc DemoTextbook) (extraSteps := [buildExercises])
+def main := manualMain (%doc DemoTextbook) (extraSteps := [buildExercises])

--- a/generate.sh
+++ b/generate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "Building the user's guide as TeX and HTML"
 lake exe usersguide --depth 2
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-06-19
+leanprover/lean4:nightly-2024-06-26

--- a/src/verso-manual/Verso/Genre/Manual/Basic.lean
+++ b/src/verso-manual/Verso/Genre/Manual/Basic.lean
@@ -395,7 +395,7 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
   part go _meta txt := go txt
   block goI goB b content := do
     let some id := b.id
-      | panic! "Block {b.name} wasn't assigned an ID during traversal"
+      | panic! s!"Block {b.name} wasn't assigned an ID during traversal"
     let some descr := (← readThe ExtensionImpls).getBlock? b.name
       | panic! s!"Unknown block {b.name} while rendering"
     let some impl := descr.toTeX
@@ -421,11 +421,11 @@ instance : Html.GenreHtml Manual (ReaderT ExtensionImpls IO) where
 
   block goI goB b content := do
     let some id := b.id
-      | panic! "Block {b.name} wasn't assigned an ID during traversal"
+      | panic! s!"Block {b.name} wasn't assigned an ID during traversal"
     let some descr := (← readThe ExtensionImpls).getBlock? b.name
-      | panic! "Unknown block {b.name} while rendering"
+      | panic! s!"Unknown block {b.name} while rendering"
     let some impl := descr.toHtml
-      | panic! "Block {b.name} doesn't support HTML"
+      | panic! s!"Block {b.name} doesn't support HTML"
     impl goI goB id b.data content
 
   inline go i content := do

--- a/src/verso-manual/Verso/Genre/Manual/Docstring.lean
+++ b/src/verso-manual/Verso/Genre/Manual/Docstring.lean
@@ -23,12 +23,11 @@ def docstring (name : Name) : Block where
 
 end Block
 
+@[block_extension Block.docstring]
 def docstring.descr : BlockDescr where
   traverse _ _ _ := pure none
   toHtml := some <| fun _goI goB _id _info contents => contents.mapM goB
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
-
-
 
 open Verso.Doc.Elab
 

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -408,6 +408,7 @@ structure DocListInfo where
   items : Array Syntax
 deriving Repr, TypeName
 
+
 abbrev InlineExpander := Syntax → DocElabM (TSyntax `term)
 
 initialize inlineExpanderAttr : KeyedDeclsAttribute InlineExpander ←


### PR DESCRIPTION
It's no longer necessary to manually pass a list of extension implementations to `manualMain` - they're saved in a registry and inserted automatically.