### PR TITLE
fix: leading zero for single-digit days and months in ISO 8601 dates

### DIFF
--- a/src/verso-blog/Verso/Genre/Blog/Basic.lean
+++ b/src/verso-blog/Verso/Genre/Blog/Basic.lean
@@ -97,6 +97,14 @@ structure Date where
   day : Nat
 deriving Inhabited, Repr
 
+-- FIXME replace this primitive implementation with proper ISO 8601
+-- date formatting when available
+def Date.toIso8601String (date : Date) : String :=
+  s!"{date.year}-{pad date.month}-{pad date.day}"
+where
+  pad (n : Nat) : String :=
+    (if n ≤ 9 then "0" else "") ++ toString n
+
 def defaultPostName (date : Date) (title : String) : String :=
   s!"{date.year}-{date.month}-{date.day}-{slugify title}"
 where

--- a/src/verso-blog/Verso/Genre/Blog/Theme.lean
+++ b/src/verso-blog/Verso/Genre/Blog/Theme.lean
@@ -116,7 +116,7 @@ def post : Template := do
             {{(md : Post.PartMetadata).authors.map ({{<span class="author">{{Html.text true ·}}</span>}}) |>.toArray}}
           </div>
           <div class="date">
-            s!"{md.date.year}-{md.date.month}-{md.date.day}"
+            {{md.date.toIso8601String}}
           </div>
           {{if md.categories.isEmpty then Html.empty
             else {{
@@ -161,7 +161,7 @@ def archiveEntry : Template := do
               {{(md : Post.PartMetadata).authors.map ({{<span class="author">{{Html.text true ·}}</span>}}) |>.toArray}}
             </div>
             <div class="date">
-              s!"{md.date.year}-{md.date.month}-{md.date.day}"
+              {{md.date.toIso8601String}}
             </div>
             {{if md.categories.isEmpty then Html.empty
               else {{


### PR DESCRIPTION
I hope this PR is welcome.

To the best of my knowledge, 2024-7-17 is not a valid ISO 8601 date (I don't have access to ISO 8601 itself, the closest I could come was RFC 3339, according to which it is not a valid date). Of course I don't claim that my proposed change is anything close to a proper date formatting routine, but it should ensure that at least all of the dates on the Lean blog are valid. With Time.lean moving to core, we will hopefully have access to a good formatter in the not-too-distant future. The only reason why I'm proposing to change this beforehand is because it keeps annoying me whenever I open the Lean blog :)

Post URLs are unaffected by this change.