### PR TITLE
fix: incremental message logs - off-by-one fix and footgun removal

### DIFF
--- a/src/verso/Verso/Doc/Concrete.lean
+++ b/src/verso/Verso/Doc/Concrete.lean
@@ -205,22 +205,19 @@ elab (name := completeDoc) "#doc" "(" genre:term ")" title:inlineStr "=>" text:c
       | dbg_trace "nope {ppSyntax title}" throwUnsupportedSyntax
     let titleString := inlinesToString (← getEnv) titleParts
     let initState : PartElabM.State := .init titleName
-    let (indicateFinished, ⟨st, st', _⟩) ←
-      withTraceNode `Elab.Verso (fun _ => pure m!"Document AST elab") <|
+    withTraceNode `Elab.Verso (fun _ => pure m!"Document AST elab") <|
       incrementallyElabCommand blocks
         (initAct := do setTitle titleString (← liftDocElabM <| titleParts.mapM elabInline))
-        (endAct := closePartsUntil 0 endPos)
+        (endAct := fun ⟨st, st', _⟩ => withTraceNode `Elab.Verso (fun _ => pure m!"Document def") do
+          let st' := st'.closeAll endPos
+          let finished := st'.partContext.toPartFrame.close endPos
+          pushInfoLeaf <| .ofCustomInfo {stx := (← getRef) , value := Dynamic.mk finished.toTOC}
+          saveRefs st st'
+          let n ← currentDocName
+          let docName := mkIdentFrom title n
+          elabCommand (← `(def $docName : Part $genre := $(← finished.toSyntax' genre st'.linkDefs st'.footnoteDefs))))
         (handleStep := partCommand)
-        (lift := fun act => liftTermElabM <| Prod.fst <$> PartElabM.run {} initState act)
-
-    withTraceNode `Elab.Verso (fun _ => pure m!"Document def") do
-      let finished := st'.partContext.toPartFrame.close endPos
-      pushInfoLeaf <| .ofCustomInfo {stx := (← getRef) , value := Dynamic.mk finished.toTOC}
-      saveRefs st st'
-      let n ← currentDocName
-      let docName := mkIdentFrom title n
-      elabCommand (← `(def $docName : Part $genre := $(← finished.toSyntax' genre st'.linkDefs st'.footnoteDefs)))
-      indicateFinished
+        (run := fun act => liftTermElabM <| Prod.fst <$> PartElabM.run {} initState act)
 
 /--
 Make the single elaborator for some syntax kind become incremental

--- a/src/verso/Verso/Doc/Concrete.lean
+++ b/src/verso/Verso/Doc/Concrete.lean
@@ -191,7 +191,10 @@ where
     | ⟨docState, partState, termState⟩ => do
       set docState
       set partState
-      termState.restore
+      -- SavedState.restore doesn't  restore enough state, so dig in!
+      set termState.elab
+      (show MetaM Unit from set termState.meta.meta)
+      (show CoreM Unit from set termState.meta.core.toState)
 
 elab (name := completeDoc) "#doc" "(" genre:term ")" title:inlineStr "=>" text:completeDocument eof:eoi : command => open Lean Elab Term Command PartElabM DocElabM in do
   findGenreCmd genre

--- a/src/verso/Verso/Doc/Elab.lean
+++ b/src/verso/Verso/Doc/Elab.lean
@@ -252,6 +252,17 @@ partial def _root_.Verso.Syntax.link_ref.command : PartCommand
     addLinkDef name url.getString
   | stx => dbg_trace  "{stx}"; throwUnsupportedSyntax
 
+partial def PartElabM.State.close (endPos : String.Pos) (state : PartElabM.State) : Option PartElabM.State :=
+  state.partContext.close endPos |>.map ({state with partContext := ·})
+
+partial def PartElabM.State.closeAll (endPos : String.Pos) (state : PartElabM.State) : PartElabM.State :=
+  match state.close endPos with
+  | none => state
+  | some state' =>
+    if state'.currentLevel > 0 then
+      state'.closeAll endPos
+    else state'
+
 partial def closePartsUntil (outer : Nat) (endPos : String.Pos) : PartElabM Unit := do
   let level ← currentLevel
   if outer ≤ level then

--- a/src/verso/Verso/Doc/Elab/Incremental.lean
+++ b/src/verso/Verso/Doc/Elab/Incremental.lean
@@ -118,7 +118,7 @@ The parameters are:
 
  * `handleStep` describes the DSL's elaboration procedure for a single step from `steps`.
 
- * `lift` is a means of running the DSL's monad inside `CommandElabM`.
+ * `run` is a means of running the DSL's monad inside `CommandElabM`.
 
 The caller is responsible for invoking the returned `CommandElabM` action to indicate to Lean that
 it is finished. This should be the last thing it does after any further state changes.
@@ -134,14 +134,14 @@ def incrementallyElabCommand
     [MonadStateOf σ m]
     (steps : Array Syntax)
     (initAct : m Unit)
-    (endAct : m Unit)
+    (endAct : σ → CommandElabM Unit)
     (handleStep : Syntax → m Unit)
-    (lift : {α : _} → m α → CommandElabM α)
-    : CommandElabM (CommandElabM Unit × σ) := do
+    (run : {α : _} → m α → CommandElabM α)
+    : CommandElabM Unit := do
   let cmd := mkNullNode steps
   if let some snap := (← read).snap? then
     withReader (fun ρ => {ρ with snap? := none}) do
-      lift <| do
+      let (finalState, nextPromise) ← run <| do
         let mut oldSnap? := snap.old?.bind (·.val.get.toTyped? (α := Internal.IncrementalSnapshot))
         let mut nextPromise ← IO.Promise.new
 
@@ -153,14 +153,17 @@ def incrementallyElabCommand
           let mut reuseState := false
           if let some oldSnap := oldSnap? then
             if let some next := oldSnap.next then
-              -- if next.get.data.stx.structRangeEqWithTraceReuse (← getOptions) b then
-              if next.get.syntax |>.structRangeEq b then
+              -- The message log of a snapshot contains the messages that are present at the
+              -- beginning of its elaboration, so its message log should be restored whether or not
+              -- we'll re-use its state.
+              Core.setMessageLog next.get.toLeanSnapshot.diagnostics.msgLog
+              if next.get.syntax.structRangeEqWithTraceReuse (← getOptions) b then
                 let some data := next.get.data (α := snapshot)
                   | logErrorAt next.get.syntax
                       m!"Internal error: failed to re-used incremental state. Expected '{TypeName.typeName snapshot}' but got a '{next.get.typeName}'"
-                -- If they match, do nothing and advance the snapshot
-                let σ := data |> getIncrState |>.get
-                set σ
+                -- If they match, restore the state, do nothing, and advance the snapshot
+                let st := getIncrState data |>.get
+                set st
                 oldSnap? := next.get
                 reuseState := true
           let nextNextPromise ← IO.Promise.new
@@ -184,16 +187,17 @@ def incrementallyElabCommand
             -- no-op the rest of the time.
             nextPromise.resolve <| .mk (← freshSnapshot (ownMessageLog := false)) (.mk <| mkSnap (.pure (← get))) none b
             updatedState.resolve <| ← get -- some old state goes here
-        endAct
 
-        let finalState ← get
-        let allDone : CommandElabM Unit := do
-          nextPromise.resolve <| .mk (← liftCoreM (freshSnapshot (ownMessageLog := false))) (.mk <| mkSnap (.pure finalState)) none cmd
-        pure (allDone, finalState)
+        pure (← get, nextPromise)
+      try
+        withReader ({ · with snap? := none }) <| endAct finalState
+      finally
+        nextPromise.resolve <| .mk (← liftCoreM (freshSnapshot (ownMessageLog := false))) (.mk <| mkSnap (.pure finalState)) none cmd
+
   else -- incrementality not available - just do the action the easy way
-    lift <| do
+    let finalState ← run <| do
       initAct
       for b in steps do
         handleStep b
-      endAct
-      pure (pure (), ← get)
+      get
+    endAct finalState

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -353,7 +353,9 @@ def PartElabM.liftDocElabM (act : DocElabM α) : PartElabM α := do
 
 instance : MonadLift DocElabM PartElabM := ⟨PartElabM.liftDocElabM⟩
 
-def PartElabM.currentLevel : PartElabM Nat := do return (← getThe State).partContext.level
+def PartElabM.State.currentLevel (state : PartElabM.State) : Nat := state.partContext.level
+
+def PartElabM.currentLevel : PartElabM Nat := do return (← getThe State).currentLevel
 
 def PartElabM.setTitle (titlePreview : String) (titleInlines : Array (TSyntax `term)) : PartElabM Unit := modifyThe State fun st =>
   {st with partContext.expandedTitle := some (titlePreview, titleInlines)}


### PR DESCRIPTION
Fixes incremental reporting, which previously suffered from two problems:

1. Snapshot message logs were restored only when states were to be re-used, but message logs capture the log at the _start_ of the elaboration step and thus should be unconditionally restored. This led to the step immediately prior to buffer damage losing its messages.

2. It was inconvenient to disable incrementality for "finishing" commands, so it didn't happen in practice. Now, the finishing command is provided as a parameter to incrementallyElabCommand, so the framework can arrange for it to be run correctly and the details of promises that need resolving are not exposed. This led to the final messages getting lost, while now they're saved. Footgun removal!