### PR TITLE
feat: cross-references from code

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -26,7 +26,7 @@ def vanish : RoleExpander
 def rev : RoleExpander
   | _args, stxs => .reverse <$> stxs.mapM elabInline
 
-def html [Monad m] (doc : Part .none) : m Html := (·.fst) <$> Genre.none.toHtml {logError := fun _ => pure ()} () () doc .empty
+def html [Monad m] (doc : Part .none) : m Html := (·.fst) <$> Genre.none.toHtml {logError := fun _ => pure ()} () () {} doc .empty
 
 def main : IO Unit := do
   IO.println <| Html.asString <| Html.embody <| ← html <| #doc (.none) "My wonderful document" =>

--- a/examples/custom-genre/SimplePage.lean
+++ b/examples/custom-genre/SimplePage.lean
@@ -250,7 +250,7 @@ def render (doc : Part SimplePage) : IO UInt32 := do
   IO.println "Rendering HTML"
   -- toHtml returns both deduplicated hover contents and the actual content.
   -- Since we're not rendering Lean code, we can ignore the hover contents.
-  let (content, _) ← SimplePage.toHtml {logError} context state doc .empty
+  let (content, _) ← SimplePage.toHtml {logError} context state {} doc .empty
   let html := {{
     <html>
       <head>

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -539,7 +539,15 @@ def blogMain (theme : Theme) (site : Site) (relativizeUrls := true) (options : L
   let rw := if relativizeUrls then
       some <| relativize
     else none
-  let initGenCtx : Generate.Context := {site := site, ctxt := ⟨[], cfg⟩, xref := xref, dir := cfg.destination, config := cfg, rewriteHtml := rw}
+  let initGenCtx : Generate.Context := {
+    site := site,
+    ctxt := ⟨[], cfg⟩,
+    xref := xref,
+    dir := cfg.destination,
+    config := cfg,
+    rewriteHtml := rw,
+    linkTargets := {}
+  }
   let ((), docs) ← site.generate theme initGenCtx .empty
   IO.FS.writeFile (cfg.destination.join "-verso-docs.json") (toString docs.docJson)
   for (name, content) in xref.jsFiles do

--- a/src/verso-blog/VersoBlog/Template.lean
+++ b/src/verso-blog/VersoBlog/Template.lean
@@ -18,7 +18,7 @@ import Verso.Code
 open Std (HashSet)
 open Lean (RBMap)
 
-open Verso Doc Output Html
+open Verso Doc Output Html HtmlT
 open Verso.Genre Blog
 open SubVerso.Highlighting
 
@@ -30,23 +30,19 @@ private def next (xs : Array α) : Option (α × Array α) :=
 
 instance [Monad m] : MonadPath (HtmlT Post m) where
   currentPath := do
-    let (_, ctxt, _) ← read
-    pure ctxt.path
+    return (← context).path
 
 instance [Monad m] : MonadPath (HtmlT Page m) where
   currentPath := do
-    let (_, ctxt, _) ← read
-    pure ctxt.path
+    return (← context).path
 
 instance [Monad m] : MonadConfig (HtmlT Post m) where
   currentConfig := do
-    let (_, ctxt, _) ← read
-    pure ctxt.config
+    return (← context).config
 
 instance [Monad m] : MonadConfig (HtmlT Page m) where
   currentConfig := do
-    let (_, ctxt, _) ← read
-    pure ctxt.config
+    return (← context).config
 
 open HtmlT
 

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -31,6 +31,7 @@ open Verso.Doc Elab
 
 open Verso.Genre.Manual.TeX
 
+open Verso.Code (LinkTargets)
 open Verso.Code.Hover (Dedup)
 
 namespace Verso.Genre
@@ -188,9 +189,12 @@ Generate a ToC structure for a document.
 Here, `depth` is the current depth at which pages no longer recieve their own HTML files, not the
 depth of the table of contents in the document (which is controlled by a parameter to `Toc.html`).
 -/
-partial def toc (depth : Nat) (opts : Html.Options Manual IO) (ctxt : TraverseContext) (state : TraverseState) : Part Manual → StateT (Dedup Html) (ReaderT ExtensionImpls IO) Html.Toc
+partial def toc (depth : Nat) (opts : Html.Options Manual IO)
+    (ctxt : TraverseContext)
+    (state : TraverseState)
+    (linkTargets : LinkTargets) : Part Manual → StateT (Dedup Html) (ReaderT ExtensionImpls IO) Html.Toc
   | .mk title sTitle meta _ sub => do
-    let titleHtml ← Html.seq <$> title.mapM (Manual.toHtml (m := ReaderT ExtensionImpls IO) opts.lift ctxt state ·)
+    let titleHtml ← Html.seq <$> title.mapM (Manual.toHtml (m := ReaderT ExtensionImpls IO) opts.lift ctxt state linkTargets ·)
     let some {id := some id, number, ..} := meta
       | throw <| .userError s!"No ID for {sTitle} - {repr meta}"
     let some (_, v) := state.externalTags[id]?
@@ -200,7 +204,7 @@ partial def toc (depth : Nat) (opts : Html.Options Manual IO) (ctxt : TraverseCo
       if depth > 0 then
         {ctxt with path := ctxt.path.push (meta.bind (·.file) |>.getD (sTitle.sluggify.toString))}
       else ctxt
-    let children ← sub.mapM (toc (depth - 1) opts ctxt' state)
+    let children ← sub.mapM (toc (depth - 1) opts ctxt' state linkTargets)
     pure <| .entry titleHtml ctxt'.path v number children
 
 def emitXrefs (dir : System.FilePath) (state : TraverseState) : IO Unit := do
@@ -214,7 +218,11 @@ where
   jsonRef (data : Json) (ref : Path × String) : Json :=
     Json.mkObj [("address", String.join (ref.1.map ("/" ++ ·)).toList), ("id", ref.2), ("data", data)]
 
-def emitHtmlSingle (logError : String → IO Unit) (config : Config) (text : Part Manual) : ReaderT ExtensionImpls IO Unit := do
+
+
+def emitHtmlSingle
+    (logError : String → IO Unit) (config : Config)
+    (text : Part Manual) : ReaderT ExtensionImpls IO Unit := do
   let dir := config.destination.join "html-single"
   ensureDir dir
   let ((), docs) ← emitContent dir .empty
@@ -227,12 +235,12 @@ where
     let date := text.metadata.bind (·.date) |>.getD ""
     let opts : Html.Options Manual IO := {logError := fun msg => logError msg}
     let ctxt := {logError}
-    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state)
-    let introHtml ← Html.seq <$> text.content.mapM (Manual.toHtml opts.lift ctxt state)
-    let contents ← Html.seq <$> text.subParts.mapM (Manual.toHtml {opts.lift with headerLevel := 2} ctxt state ·)
+    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state state.linkTargets)
+    let introHtml ← Html.seq <$> text.content.mapM (Manual.toHtml opts.lift ctxt state state.linkTargets)
+    let contents ← Html.seq <$> text.subParts.mapM (Manual.toHtml {opts.lift with headerLevel := 2} ctxt state state.linkTargets ·)
     let pageContent := open Verso.Output.Html in
       {{<section>{{Html.titlePage titleHtml authors introHtml ++ contents}}</section>}}
-    let toc ← text.subParts.mapM (toc 0 opts ctxt state)
+    let toc ← text.subParts.mapM (toc 0 opts ctxt state state.linkTargets)
     IO.FS.withFile (dir.join "book.css") .write fun h => do
       h.putStrLn Html.Css.pageStyle
     for (src, dest) in config.extraFiles do
@@ -250,7 +258,8 @@ where
       h.putStrLn (Html.page toc text.titleString titleHtml pageContent state.extraCss state.extraJs (extraStylesheets := config.extraCss ++ state.extraCssFiles.toList.map ("/-verso-css/" ++ ·.1)) (extraJsFiles := config.extraJs.toArray ++ state.extraJsFiles.map ("/-verso-js/" ++ ·.1))).asString
 
 open Verso.Output.Html in
-def emitHtmlMulti (logError : String → IO Unit) (config : Config) (text : Part Manual) : ReaderT ExtensionImpls IO Unit := do
+def emitHtmlMulti (logError : String → IO Unit) (config : Config)
+    (text : Part Manual) : ReaderT ExtensionImpls IO Unit := do
   let root := config.destination.join "html-multi"
   ensureDir root
   let ((), docs) ← emitContent root Dedup.empty
@@ -263,8 +272,8 @@ where
     let date := text.metadata.bind (·.date) |>.getD ""
     let opts : Html.Options _ IO := {logError := fun msg => logError msg}
     let ctxt := {logError}
-    let toc ← text.subParts.mapM (toc config.htmlDepth opts ctxt state)
-    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state ·)
+    let toc ← text.subParts.mapM (toc config.htmlDepth opts ctxt state state.linkTargets)
+    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state state.linkTargets ·)
     IO.FS.withFile (root.join "book.css") .write fun h => do
       h.putStrLn Html.Css.pageStyle
     for (src, dest) in config.extraFiles do
@@ -277,17 +286,17 @@ where
       ensureDir (root.join "-verso-css")
       IO.FS.withFile (root.join "-verso-css" |>.join name) .write fun h => do
         h.putStr contents
-    emitPart titleHtml authors toc opts.lift ctxt state true config.htmlDepth root text
+    emitPart titleHtml authors toc opts.lift ctxt state state.linkTargets true config.htmlDepth root text
   emitPart (bookTitle : Html) (authors : List String) (bookContents)
-      (opts ctxt state)
+      (opts ctxt state linkTargets)
       (root : Bool) (depth : Nat) (dir : System.FilePath) (part : Part Manual) : StateT (Dedup Html) (ReaderT ExtensionImpls IO) Unit := do
-    let titleHtml ← Html.seq <$> part.title.mapM (Manual.toHtml opts.lift ctxt state)
-    let introHtml ← Html.seq <$> part.content.mapM (Manual.toHtml opts.lift ctxt state)
+    let titleHtml ← Html.seq <$> part.title.mapM (Manual.toHtml opts.lift ctxt state linkTargets)
+    let introHtml ← Html.seq <$> part.content.mapM (Manual.toHtml opts.lift ctxt state linkTargets)
     let contents ←
       if depth == 0 then
-        Html.seq <$> part.subParts.mapM (Manual.toHtml {opts.lift with headerLevel := 2} ctxt state)
+        Html.seq <$> part.subParts.mapM (Manual.toHtml {opts.lift with headerLevel := 2} ctxt state linkTargets)
       else pure .empty
-    let subToc ← part.subParts.mapM (toc depth opts ctxt state)
+    let subToc ← part.subParts.mapM (toc depth opts ctxt state linkTargets)
     let pageContent :=
       if root then
         let subTocHtml := if subToc.size > 0 then {{<ol class="section-toc">{{subToc.map (·.html (some 2))}}</ol>}} else .empty
@@ -305,7 +314,7 @@ where
     if depth > 0 then
       for p in part.subParts do
         let nextFile := p.metadata.bind (·.file) |>.getD (p.titleString.sluggify.toString)
-        emitPart bookTitle authors bookContents opts {ctxt with path := ctxt.path.push nextFile} state false (depth - 1) dir p
+        emitPart bookTitle authors bookContents opts {ctxt with path := ctxt.path.push nextFile} state linkTargets false (depth - 1) dir p
 
   urlAttr (name : String) : Bool := name ∈ ["href", "src", "data", "poster"]
   rwAttr (attr : String × String) : ReaderT Path Id (String × String) := do

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -527,6 +527,12 @@ def TraverseState.linkTargets (state : TraverseState) : Code.LinkTargets where
       path.map ("/" ++ ·) |>.toList |> (String.join · ++ "#" ++ htmlId) |> some
     | .error _ =>
       none
+  option := fun x =>
+    match state.resolveDomainObject `Verso.Manual.doc.option x.toString with
+    | .ok (path, htmlId) =>
+      path.map ("/" ++ ·) |>.toList |> (String.join · ++ "#" ++ htmlId) |> some
+    | .error _ =>
+      none
 
 
 instance : Traverse Manual TraverseM where

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -520,6 +520,15 @@ def TraverseState.resolveTag (st : TraverseState) (tag : String) : Option (Path 
     else panic! s!"No location for ID {id}, but it came from external tag '{tag}'"
   else none
 
+def TraverseState.linkTargets (state : TraverseState) : Code.LinkTargets where
+  const := fun x =>
+    match state.resolveDomainObject `Verso.Manual.doc x.toString with
+    | .ok (path, htmlId) =>
+      path.map ("/" ++ ·) |>.toList |> (String.join · ++ "#" ++ htmlId) |> some
+    | .error _ =>
+      none
+
+
 instance : Traverse Manual TraverseM where
   part p :=
     if p.metadata.isNone then pure (some {}) else pure none

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -607,7 +607,7 @@ def optionDocs.descr : BlockDescr where
         | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring data"; pure .empty
       let x : Html := Html.text true <| Name.toString name
 
-      let (_, _, xref) ← read
+      let xref ← HtmlT.state
       let idAttr :=
         if let some (_, htmlId) := xref.externalTags[id]? then
           #[("id", htmlId)]

--- a/src/verso-manual/VersoManual/Glossary.lean
+++ b/src/verso-manual/VersoManual/Glossary.lean
@@ -87,9 +87,9 @@ def deftech.descr : InlineDescr where
       pure <| .seq <| ← content.mapM fun b => do
         pure <| .seq #[← go b, .raw "\n"]
   toHtml :=
-    open Verso.Output.Html in
+    open Verso.Output.Html Doc.Html.HtmlT in
     some <| fun go id inl content => do
-      let some (_, t) := (← read).2.2.externalTags[id]?
+      let some (_, t) := (← state).externalTags[id]?
         | panic! s!"Untagged index target with data {inl}"
       return {{<span id={{t}}>{{← content.mapM go}}</span>}}
 


### PR DESCRIPTION
Adds the ability to provide a link target specifier to HTML code rendering, as well as support for code/docs cross-references in the manual genre.