### PR TITLE
feat: Tooltips and xrefs for options

### DIFF
--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "979a5789253d3ca679edb90449a6533f07d33f26",
+   "rev": "84302ae695e0e3b21f1f0ad24b5420b12ee1312c",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "979a5789253d3ca679edb90449a6533f07d33f26",
+   "rev": "84302ae695e0e3b21f1f0ad24b5420b12ee1312c",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
Adds cross-reference support for option names (and a few other tokens), and updates to the version of SubVerso that correctly generates them.