### PR TITLE
feat: --draft flag

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -19,6 +19,7 @@ import VersoManual.Slug
 import VersoManual.TeX
 import VersoManual.Html
 import VersoManual.Html.Style
+import VersoManual.Draft
 import VersoManual.Index
 import VersoManual.Glossary
 import VersoManual.Docstring
@@ -119,6 +120,7 @@ structure Config where
   extraFiles : List (System.FilePath × String) := []
   extraCss : List String := []
   extraJs : List String := []
+  draft : Bool := false
 
 def ensureDir (dir : System.FilePath) : IO Unit := do
   if !(← dir.pathExists) then
@@ -150,7 +152,7 @@ where
   traverseBlock := Verso.Doc.Genre.traverse.block Manual
 
 def traverse (logError : String → IO Unit) (text : Part Manual) (config : Config) : ReaderT ExtensionImpls IO (Part Manual × TraverseState) := do
-  let topCtxt : Manual.TraverseContext := {logError}
+  let topCtxt : Manual.TraverseContext := {logError, draft := config.draft}
   let mut state : Manual.TraverseState := {}
   let mut text := text
   let extensionImpls ← readThe ExtensionImpls
@@ -401,6 +403,7 @@ where
     | ("--without-html-multi"::more) => opts {cfg with emitHtmlMulti := false} more
     | ("--with-word-count"::file::more) => opts {cfg with wordCount := some file} more
     | ("--without-word-count"::more) => opts {cfg with wordCount := none} more
+    | ("--draft"::more) => opts {cfg with draft := true} more
     | (other :: _) => throw (↑ s!"Unknown option {other}")
     | [] => pure cfg
 

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -314,6 +314,8 @@ structure TraverseContext where
   path : Path := #[]
   /-- The path from the root to the current header -/
   headers : Array PartHeader := #[]
+  /-- Whether the current build is a draft (used for hiding TODOs, etc from public builds) -/
+  draft : Bool := false
   logError : String → IO Unit
 
 def TraverseContext.inFile (self : TraverseContext) (file : String) : TraverseContext :=
@@ -548,6 +550,9 @@ instance : MonadWithReader Manual.TraverseContext TraverseM where
 
 def logError [Monad m] [MonadLiftT IO m] [MonadReaderOf Manual.TraverseContext m] (err : String) : m Unit := do
   (← readThe Manual.TraverseContext).logError err
+
+def isDraft [Functor m] [MonadReaderOf Manual.TraverseContext m] : m Bool :=
+  (·.draft) <$> (readThe Manual.TraverseContext)
 
 /--
 Get or create the external tag assigned to an ID.

--- a/src/verso-manual/VersoManual/Draft.lean
+++ b/src/verso-manual/VersoManual/Draft.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2024 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+import Lean.Data.Json
+import Lean.Data.Json.FromToJson
+import Std.Data.HashMap
+import Std.Data.HashSet
+
+import Verso.Doc.ArgParse
+import VersoManual.Basic
+
+open Verso.ArgParse
+open Verso Genre Manual
+open Verso.Doc.Elab
+open Lean (ToJson FromJson)
+open Std (HashMap HashSet)
+
+namespace Verso.Genre.Manual
+
+def Inline.draft : Inline where
+  name := `Verso.Genre.Manual.draft
+
+def Block.draft : Block where
+  name := `Verso.Genre.Manual.draft
+
+/-- Hide draft-only content when in not in draft mode -/
+@[role_expander draft]
+def draft : RoleExpander
+  | args, contents => do
+    ArgParse.done.run args
+    pure #[← ``(Verso.Doc.Inline.other Inline.draft #[$[$(← contents.mapM elabInline)],*])]
+
+/-- Hide draft-only content when in not in draft mode -/
+@[directive_expander draft]
+def draftBlock : DirectiveExpander
+  | args, contents => do
+    ArgParse.done.run args
+    pure #[← ``(Verso.Doc.Block.other Block.draft #[$[$(← contents.mapM elabBlock)],*])]
+
+@[inline_extension draft]
+def draft.descr : InlineDescr where
+  traverse _id _data _contents := do
+    if (← isDraft) then
+      pure none
+    else
+      pure (some <| .concat #[])
+  toTeX := none
+  toHtml :=
+    open Verso.Output.Html in
+    some <| fun go _ _ content => do
+      content.mapM go
+
+@[block_extension draft]
+def draft.blockDescr : BlockDescr where
+  traverse _id _data _contents := do
+    if (← isDraft) then
+      pure none
+    else
+      pure (some <| .concat #[])
+  toTeX := none
+  toHtml :=
+    open Verso.Output.Html in
+    some <| fun _ goB _ _ content => do
+      content.mapM goB


### PR DESCRIPTION
Building a manual can now be done in draft mode, which can cause draft-conditional content to appear (this can be useful for e.g. reviews of PRs)