### PR TITLE
Allow manual genre to be hosted not at the root

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -22,6 +22,7 @@ open Std (HashSet)
 open Verso.Doc.Elab.PartElabM
 open Verso.Code
 open Verso.ArgParse
+open Verso.Code.Highlighted.WebAssets
 
 open SubVerso.Highlighting
 
@@ -396,6 +397,8 @@ def docstring.descr : BlockDescr where
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
   extraCss := [highlightingStyle, docstringStyle]
   extraJs := [highlightingJs]
+  extraJsFiles := [("popper.js", popper), ("tippy.js", tippy)]
+  extraCssFiles := [("tippy-border.css", tippy.border.css)]
 where
   md2html (goB) (str : String) : Verso.Doc.Html.HtmlT Manual (ReaderT ExtensionImpls IO) Verso.Output.Html :=
     open Verso.Doc.Html in

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -134,40 +134,44 @@ def page
     (extraCss : HashSet String)
     (extraJs : HashSet String)
     (extraStylesheets : List String := [])
-    (extraJsFiles : Array String := #[]) : Html := {{
-<html>
-  <head>
-    <meta charset="utf-8"/>
-    <title>{{textTitle}}</title>
-    <link rel="stylesheet" href="/book.css" />
-    <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js" integrity="sha384-zbcZAIxlvJtNE3Dp5nxLXdXtXyxwOdnILY1TDPVmKFhl4r4nSUG1r8bcFXGVa4Te" crossorigin="anonymous"></script>
-    {{extraJsFiles.map ({{<script src=s!"{·}"></script>}})}}
-    {{extraStylesheets.map (fun url => {{<link rel="stylesheet" href={{url}}/> }})}}
-    {{extraCss.toArray.map ({{<style>{{Html.text false ·}}</style>}})}}
-    {{extraJs.toArray.map ({{<script>{{Html.text false ·}}</script>}})}}
-  </head>
-  <body>
-    <div class="with-toc">
-      <header>
-        <h1>{{htmlTitle}}</h1>
-        <div id="controls">
-          <label for="toggle-toc" id="toggle-toc-click">"📖"</label>
+    (extraJsFiles : Array String := #[]) : Html :=
+  let relativeRoot :=
+    String.join <| "./" :: path.toList.map (fun _ => "../")
+  {{
+    <html>
+      <head>
+        <meta charset="utf-8"/>
+        <title>{{textTitle}}</title>
+        <link rel="stylesheet" href="/book.css" />
+        <script>s!"const __versoSiteRoot =\"{relativeRoot}\""</script>
+        <script src="https://cdn.jsdelivr.net/npm/marked@11.1.1/marked.min.js" integrity="sha384-zbcZAIxlvJtNE3Dp5nxLXdXtXyxwOdnILY1TDPVmKFhl4r4nSUG1r8bcFXGVa4Te" crossorigin="anonymous"></script>
+        {{extraJsFiles.map ({{<script src=s!"{·}"></script>}})}}
+        {{extraStylesheets.map (fun url => {{<link rel="stylesheet" href={{url}}/> }})}}
+        {{extraCss.toArray.map ({{<style>{{Html.text false ·}}</style>}})}}
+        {{extraJs.toArray.map ({{<script>{{Html.text false ·}}</script>}})}}
+      </head>
+      <body>
+        <div class="with-toc">
+          <header>
+            <h1>{{htmlTitle}}</h1>
+            <div id="controls">
+              <label for="toggle-toc" id="toggle-toc-click">"📖"</label>
+            </div>
+            <div id="print">
+              <span>"🖨"</span>
+            </div>
+          </header>
+          <nav id="toc">
+            <input type="checkbox" id="toggle-toc" checked="checked"/>
+            {{toc.localHtml path}}
+          </nav>
+          <main>
+            {{contents}}
+          </main>
         </div>
-        <div id="print">
-          <span>"🖨"</span>
-        </div>
-      </header>
-      <nav id="toc">
-        <input type="checkbox" id="toggle-toc" checked="checked"/>
-        {{toc.localHtml path}}
-      </nav>
-      <main>
-        {{contents}}
-      </main>
-    </div>
-  </body>
-</html>
-}}
+      </body>
+    </html>
+  }}
 
 def relativize (path : Path) (html : Html) : Html :=
   html.visitM (m := ReaderT Path Id) (tag := rwTag) |>.run path

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -972,7 +972,8 @@ window.onload = () => {
         }
     }
     // Add hovers
-    fetch(\"/-verso-docs.json\").then((resp) => resp.json()).then((versoDocData) => {
+    let siteRoot = __versoSiteRoot ? __versoSiteRoot : \"/\";
+    fetch(siteRoot + \"-verso-docs.json\").then((resp) => resp.json()).then((versoDocData) => {
 
       const defaultTippyProps = {
         /* DEBUG -- remove the space: * /


### PR DESCRIPTION
Before, hovers only worked when the site was hosted at the root, because the link-relativization pass doesn't reach into JS string literals. This simple fix seems to take care of it.