### PR TITLE
fix: include trailing slashes in links

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -61,7 +61,7 @@ def ref.descr : InlineDescr where
       match (← get).resolveDomainObject domain name with
       | .error _ => return none
       | .ok (path, htmlId) =>
-        let dest := String.join (path.map ("/" ++ ·) |>.toList) ++ "#" ++ htmlId.toString
+        let dest := path.link (some htmlId.toString)
         return some <| .other {Inline.ref with data := ToJson.toJson (name, some domain, some dest)} content
     | .ok (_, domain, some (dest : String)) =>
       pure none

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -27,6 +27,18 @@ deriving DecidableEq, BEq, Hashable
 
 abbrev Path := Array String
 
+def Path.link (path : Path) (htmlId : Option String := none) : String :=
+  "/" ++ String.join (path.toList.map (· ++ "/")) ++
+  (htmlId.map ("#" ++ ·)).getD ""
+
+/-- info: "/" -/
+#guard_msgs in
+#eval Path.link #[]
+
+/-- info: "/a/b/" -/
+#guard_msgs in
+#eval Path.link #["a", "b"]
+
 
 /--
 Tags are used to refer to parts through tables of contents, cross-references, and the like.
@@ -620,19 +632,19 @@ def TraverseState.linkTargets (state : TraverseState) : Code.LinkTargets where
   const := fun x =>
     match state.resolveDomainObject `Verso.Manual.doc x.toString with
     | .ok (path, htmlId) =>
-      path.map ("/" ++ ·) |>.toList |> (String.join · ++ "#" ++ htmlId.toString) |> some
+      some <| path.link (some htmlId.toString)
     | .error _ =>
       none
   option := fun x =>
     match state.resolveDomainObject `Verso.Manual.doc.option x.toString with
     | .ok (path, htmlId) =>
-      path.map ("/" ++ ·) |>.toList |> (String.join · ++ "#" ++ htmlId.toString) |> some
+      some <| path.link (some htmlId.toString)
     | .error _ =>
       none
   keyword := fun k =>
     match state.resolveDomainObject `Verso.Manual.doc.tactic k.toString with
     | .ok (path, htmlId) =>
-      path.map ("/" ++ ·) |>.toList |> (String.join · ++ "#" ++ htmlId.toString) |> some
+      some <| path.link (some htmlId.toString)
     | .error _ =>
       none
 

--- a/src/verso-manual/VersoManual/Glossary.lean
+++ b/src/verso-manual/VersoManual/Glossary.lean
@@ -145,8 +145,8 @@ def tech.descr : InlineDescr where
           | .ok id =>
             let xref ← Doc.Html.HtmlT.state
             if let some (path, htmlId) := xref.externalTags.get? id then
-              let addr := String.join (path.map ("/" ++ ·) |>.toList)
-              pure {{<a class="technical-term" href=s!"{addr}#{htmlId}">{{← content.mapM go}}</a>}}
+              let addr := path.link (some htmlId.toString)
+              pure {{<a class="technical-term" href={{addr}}>{{← content.mapM go}}</a>}}
             else
               Doc.Html.HtmlT.logError s!"No external tag for {id}"
               content.mapM go

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -45,7 +45,7 @@ partial def Toc.html (depth : Option Nat) : Toc → Html
     else
       let page :=
         if path.isEmpty then "/"
-        else path.map ("/" ++ ·) |>.toList |> String.join
+        else path.link
       let sectionNum :=
         match num with
         | none => {{<span class="unnumbered"></span>}}
@@ -130,12 +130,10 @@ where
         }}
       </div>
     }}
-  toUrl (path : Path) : String :=
-    if path.isEmpty then "/" else String.join <| path.toList.map ("/" ++ ·)
   linkify (path : Path) (id : Option String) (html : Html) :=
     match html with
     | .tag "a" _ _ => html
-    | other => {{<a href=s!"{toUrl path}{id.map ("#" ++ ·) |>.getD ""}">{{other}}</a>}}
+    | other => {{<a href={{path.link id}}>{{other}}</a>}}
   sectionNum num :=
       match num with
       | none => {{<span class="unnumbered"></span>}}

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -205,16 +205,16 @@ where
     | 0 => pure termHtml
     | 1 =>
       if let some (path, htmlId) := xref.externalTags[links[0]]? then
-        let addr := String.join (path.map ("/" ++ ·) |>.toList)
-        pure {{<a href=s!"{addr}#{htmlId}">{{termHtml}}</a>}}
+        let addr := path.link (some htmlId.toString)
+        pure {{<a href={{addr}}>{{termHtml}}</a>}}
       else
         HtmlT.logError s!"No external tag for {id.toString}"
         pure .empty
     | _ =>
       let links ← links.mapIdxM fun i id => do
         if let some (path, htmlId) := xref.externalTags[id]? then
-          let addr := String.join (path.map ("/" ++ ·) |>.toList)
-          pure {{" " <a href=s!"{addr}#{htmlId}"> s!"({i.val})" </a>}}
+          let addr := path.link (some htmlId.toString)
+          pure {{" " <a href={{addr}}> s!"({i.val})" </a>}}
         else
           HtmlT.logError s!"No external tag for {id}"
           pure .empty


### PR DESCRIPTION
This is required for relative URLs to work as they should, and not all hosts add them.