### PR TITLE
feat: permalink widgets

### DIFF
--- a/doc/UsersGuide/Markup.lean
+++ b/doc/UsersGuide/Markup.lean
@@ -50,6 +50,9 @@ def markupPreview : CodeBlockExpander
 
 
 #doc (Manual) "Lean Markup" =>
+%%%
+tag := "lean-markup"
+%%%
 
 Lean's documentation markup language is a close relative of Markdown, but it's not identical to it.
 

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -359,7 +359,12 @@ where
     let thisFile := part.metadata.bind (·.file) |>.getD (part.titleString.sluggify.toString)
     let dir := if root then dir else dir.join thisFile
     let sectionNum := sectionHtml ctxt
-    let titleHtml := sectionNum ++ (← Html.seq <$> part.title.mapM (Manual.toHtml opts.lift ctxt state linkTargets codeOptions))
+    let titleHtml :=
+      sectionNum ++
+      (← Html.seq <$> part.title.mapM (Manual.toHtml opts.lift ctxt state linkTargets codeOptions)) ++
+      if let some id := part.metadata.bind (·.id) then
+        permalink id state
+      else .empty
     let introHtml ← Html.seq <$> part.content.mapM (Manual.toHtml opts.lift ctxt state linkTargets codeOptions)
     let contents ←
       if depth == 0 || part.htmlSplit == .never then

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -387,6 +387,7 @@ def docstring.descr : BlockDescr where
 
       return {{
         <div class="namedocs" {{idAttr}}>
+          {{permalink id xref false}}
           <span class="label">{{declType.label}}</span>
           <pre class="signature hl lean block">{{sig}}</pre>
           <div class="text">

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -105,8 +105,6 @@ where
           break
     return (none, none, none)
 
-
-
 def Toc.localHtml (path : Path) (toc : Toc) : Html := Id.run do
   let mut toc := toc
   let mut fallbackId : Nat := 0
@@ -187,7 +185,6 @@ where
       match num with
       | none => {{<span class="unnumbered"></span>}}
       | some ns => {{<span class="number">{{sectionNumberString ns}}</span>" "}}
-
 
 def titlePage (title : Html) (authors : List String) (intro : Html) : Html := {{
   <div class="titlepage">

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -463,6 +463,49 @@ main .section-toc a, main .section-toc a:visited {
 main .section-toc a:hover {
     text-decoration: underline;
 }
+
+/******** Permalink widgets ********/
+
+.permalink-widget.inline {
+  display: none;
+  text-decoration: none;
+  font-size: 50%;
+  vertical-align: 10%;
+  margin-left: 0.5em;
+}
+
+:hover > .permalink-widget.inline {
+  display: inline-block;
+}
+
+
+:has(> .permalink-widget.block) {
+    position: relative;
+}
+
+:hover > .permalink-widget.block {
+    opacity: 1;
+}
+
+.permalink-widget.block {
+    position: absolute;
+    right: -1.5em;
+    top: 0;
+    opacity: 0.1;
+    transition: opacity 0.5s;
+}
+
+.permalink-widget > a {
+  /* Don't show the colors here */
+  color: transparent;
+  text-shadow: 0 0 0 gray;
+  text-decoration: none;
+}
+
+.permalink-widget > a:hover {
+  text-decoration: none;
+}
+
 "####
 
 def pageStyleJs : String := r####"

--- a/static-web/find.js
+++ b/static-web/find.js
@@ -1,9 +1,9 @@
 let params = new URLSearchParams(document.location.search);
 let domains = params.getAll("domain");
-let target = params.get("target");
+let name = params.get("name");
 console.log("Domains: " + domains);
-console.log("target: " + target);
-if(target) {
+console.log("name: " + name);
+if(name) {
     let options = [];
     if (domains && domains.length > 0) {
         for (const i in domains) {
@@ -12,15 +12,15 @@ if(target) {
             if (xref.hasOwnProperty(domain)) {
                 console.log('Found domain ' + domain);
                 let opts = xref[domain];
-                if (opts['contents'].hasOwnProperty(target)) {
-                    options = opts['contents'][target].map(x => Object.assign(x, {'domain': domain}));
+                if (opts['contents'].hasOwnProperty(name)) {
+                    options = opts['contents'][name].map(x => Object.assign(x, {'domain': domain}));
                 }
             }
         }
     } else {
         for (const [dom, opts] of Object.entries(xref)) {
-            if (opts['contents'].hasOwnProperty(target)) {
-                for (const i of opts['contents'][target]) {
+            if (opts['contents'].hasOwnProperty(name)) {
+                for (const i of opts['contents'][name]) {
                     options.push(Object.assign(i, {'domain': dom}));
                 }
             }
@@ -29,8 +29,8 @@ if(target) {
 
     if (options.length == 0) {
         addEventListener('DOMContentLoaded', event => {
-            document.title = "Not found: '" + target + "'";
-            document.querySelector("#title").innerHTML = "Not found: target '" + target + "'";
+            document.title = "Not found: '" + name + "'";
+            document.querySelector("#title").innerHTML = "Not found: name '" + name + "'";
             let allDomains = [];
             for (const d in xref) {
                 allDomains.push(d);
@@ -45,8 +45,8 @@ if(target) {
         window.location.replace(addr);
     } else {
         addEventListener('DOMContentLoaded', event => {
-            document.title = "Ambiguous: '" + target + "'";
-            document.querySelector("#title").innerHTML = "Ambiguous: target '" + target + "'";
+            document.title = "Ambiguous: '" + name + "'";
+            document.querySelector("#title").innerHTML = "Ambiguous: name '" + name + "'";
             document.querySelector("#message").innerHTML = "<p>Options:</p><ul>" +
                 options.map((x, idx) => '<li><p><a href="' + x['address'] + '#' + x['id'] + '">From ' + xref[x['domain']]['title'] + '</a></p></li>').join('\n') +
                 "</ul>";
@@ -54,8 +54,8 @@ if(target) {
     }
 } else {
     addEventListener('DOMContentLoaded', event => {
-        document.title = "No target provided";
-        document.querySelector("#title").innerHTML = "No target provided";
-        document.querySelector("#message").innerHTML = "<p>This script expects a 'target' query parameter, along with documentation domains.</p>";
+        document.title = "No name provided";
+        document.querySelector("#title").innerHTML = "No name provided";
+        document.querySelector("#message").innerHTML = "<p>This page expects a 'name' query parameter, along with documentation domains.</p>";
     });
 }


### PR DESCRIPTION
Now objects in the HTML output from the manual genre can opt in to permalink widgets.

Fixes #200, for more than just section names, though it will only create links to sections with assigned stable names. Next step: assign them over in leanprover/reference-manual :)