### PR TITLE
fix: double scrolling in chrome and horizontal scrolling

### DIFF
--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -442,6 +442,7 @@ main .authors {
 
 main > section {
     margin: auto;
+    position: relative;
 }
 
 main section {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -19,6 +19,8 @@ def pageStyle : String := r####"
     --verso-code-font-family: monospace;
     /* What's the maximum line width, for legibility? */
     --verso-content-max-width: 45em;
+    /* How much space to add on the sides of content for small screens and to place widgets. */
+    --verso-content-padding-x: 1.5em;
 
     /** Table of Contents appearance **/
     --verso-toc-background-color: #fafafa;
@@ -443,6 +445,7 @@ main .authors {
 main > section {
     margin: auto;
     position: relative;
+    padding: var(--verso-content-padding-x);
 }
 
 main section {
@@ -505,7 +508,7 @@ main .section-toc a:hover {
 
 .permalink-widget.block {
     position: absolute;
-    right: -1.5em;
+    right: calc(-1 * var(--verso-content-padding-x));
     top: 0;
     opacity: 0.1;
     transition: opacity 0.5s;


### PR DESCRIPTION
Fixes https://github.com/leanprover/reference-manual/issues/128 by adding `position: relative`.

Unfortunately not very clear why this works.


---

This PR also adds some horizontal padding to prevent horizontal scrolling from widgets in the margins like permalinks. (Although there's also horizontal scrolling due to long `code` lines that should be fixed separately.)

<img width="815" alt="image" src="https://github.com/user-attachments/assets/e84bfe2a-1b19-4051-8a47-982c25064c06">
