### PR TITLE
feat: working example definition link targets

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -26,7 +26,7 @@ def vanish : RoleExpander
 def rev : RoleExpander
   | _args, stxs => .reverse <$> stxs.mapM elabInline
 
-def html [Monad m] (doc : Part .none) : m Html := (·.fst) <$> Genre.none.toHtml {logError := fun _ => pure ()} () () {} {} doc .empty
+def html [Monad m] (doc : Part .none) : m Html := (·.fst) <$> Genre.none.toHtml {logError := fun _ => pure ()} () () {} {} {} doc .empty
 
 def main : IO Unit := do
   IO.println <| Html.asString <| Html.embody <| ← html <| #doc (.none) "My wonderful document" =>

--- a/examples/custom-genre/SimplePage.lean
+++ b/examples/custom-genre/SimplePage.lean
@@ -252,7 +252,7 @@ def render (doc : Part SimplePage) : IO UInt32 := do
   IO.println "Rendering HTML"
   -- toHtml returns both deduplicated hover contents and the actual content.
   -- Since we're not rendering Lean code, we can ignore the hover contents.
-  let (content, _) ← SimplePage.toHtml {logError} context state {} {} doc .empty
+  let (content, _) ← SimplePage.toHtml {logError} context state {} {} {} doc .empty
   let html := {{
     <html>
       <head>

--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "dbb71c2c988eed363313103356bbbbdc86e9b322",
+   "rev": "83bf19c22c4a2a6e9949f65841f88d6861d16f4a",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/examples/website/DemoSite/Blog/Conditionals.lean
+++ b/examples/website/DemoSite/Blog/Conditionals.lean
@@ -129,6 +129,18 @@ end
 example := 99
 ```
 
+Here's an inductive type and a structure:
+```lean demo
+inductive A where
+  | a1 | a2
+  | a3 (n : Nat)
+  | a4 : (n : Nat) → n = 3 → A
+
+structure S where
+  x : A
+  y : String
+```
+
 
 Here is a proof with some lambdas and big terms in it, to check highlighting:
 ```lean demo

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "dbb71c2c988eed363313103356bbbbdc86e9b322",
+   "rev": "83bf19c22c4a2a6e9949f65841f88d6861d16f4a",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/src/verso-blog/VersoBlog/Generate.lean
+++ b/src/verso-blog/VersoBlog/Generate.lean
@@ -67,6 +67,7 @@ def GenerateM.toHtml (g : Genre) [BlogGenre g] [ToHtml g IO α] (x : α) : Gener
     {logError := fun x => ctxt.config.logError x, headerLevel := 2}
     (BlogGenre.traverseContextEq (genre := g) ▸ ctxt)
     (traverseStateEq (genre := g) ▸ state)
+    {}
     linkTargets
     {}
     x

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -28,11 +28,6 @@ open SubVerso.Highlighting
 
 namespace Verso.Genre.Manual
 
-def docstringDomain := `Verso.Genre.Manual.doc
-def tacticDomain := `Verso.Genre.Manual.doc.tactic
-def optionDomain := `Verso.Genre.Manual.doc.option
-def convDomain := `Verso.Genre.Manual.doc.tactic.conv
-
 namespace Block
 
 namespace Docstring
@@ -187,7 +182,7 @@ def DocName.ofName (c : Name) (showNamespace := true) (openDecls : List OpenDecl
     }
     let sig := Lean.Widget.tagCodeInfos ctx infos tt
 
-    pure ⟨c, ← renderTagged {} none sig, ← findDocString? env c⟩
+    pure ⟨c, ← renderTagged none sig ⟨{}, false⟩, ← findDocString? env c⟩
   else pure ⟨c, Highlighted.seq #[], none⟩
 
 open Meta in
@@ -209,8 +204,8 @@ def DeclType.ofName (c : Name) : MetaM DeclType := do
                 let type ← inferType proj >>= instantiateMVars
                 let type' ← withOptions (·.setInt `format.width 40 |>.setBool `pp.tagAppFns true) <| (Widget.ppExprTagged type)
                 let projType ← withOptions (·.setInt `format.width 40 |>.setBool `pp.tagAppFns true) <| ppExpr type
-                let fieldName' := Highlighted.token ⟨.const projFn projType.pretty (← findDocString? env projFn), fieldName.toString⟩
-                pure {fieldName := fieldName', type := ← renderTagged {} none type', name, projFn, subobject?, binderInfo, autoParam := autoParam?.isSome, docString? := ← findDocString? env projFn}
+                let fieldName' := Highlighted.token ⟨.const projFn projType.pretty (← findDocString? env projFn) false, fieldName.toString⟩
+                pure {fieldName := fieldName', type := ← renderTagged none type' ⟨{}, false⟩, name, projFn, subobject?, binderInfo, autoParam := autoParam?.isSome, docString? := ← findDocString? env projFn}
         return .structure (isClass env c) (← DocName.ofName ctor.name) info.fieldNames fieldInfo parents ancestors
 
       else
@@ -551,7 +546,7 @@ def docstring : BlockRoleExpander
         ngen          := (← getNGen)
       }
       let sig := Lean.Widget.tagCodeInfos ctx infos tt
-      let signature ← some <$> renderTagged {} none sig
+      let signature ← some <$> renderTagged none sig ⟨{}, false⟩
       pure #[← ``(Verso.Doc.Block.other (Verso.Genre.Manual.Block.docstring $(quote name) $(quote declType) $(quote signature)) #[$blockStx,*])]
     | _ => throwError "Expected exactly one positional argument that is a name"
   | _, more => throwErrorAt more[0]! "Unexpected block argument"
@@ -582,9 +577,9 @@ def highlightDataValue (v : DataValue) : Highlighted :=
     | .ofString (v : String) => ⟨.str v, toString v⟩
     | .ofBool b =>
       if b then
-        ⟨.const ``true (sig_for% true) (some <| docs_for% true), "true"⟩
+        ⟨.const ``true (sig_for% true) (some <| docs_for% true) false, "true"⟩
       else
-        ⟨.const ``false (sig_for% false) (some <| docs_for% false), "false"⟩
+        ⟨.const ``false (sig_for% false) (some <| docs_for% false) false, "false"⟩
     | .ofName (v : Name) => ⟨.unknown, v.toString⟩
     | .ofNat (v : Nat) => ⟨.unknown, toString v⟩
     | .ofInt (v : Int) => ⟨.unknown, toString v⟩


### PR DESCRIPTION
Code samples can now detect defined names and generate links to them, just as there were previously links to docstrings from code samples. This will help make the Markdown docstrings render usefully in the manual genre.