### PR TITLE
fix: use better mobile CSS for highlighted code and in manuals

### DIFF
--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -843,7 +843,8 @@ def sectionString (ctxt : TraverseContext) : Option String :=
 def sectionHtml (ctxt : TraverseContext) : Html :=
   match sectionString ctxt with
   | none => .empty
-  | some s => .text true (s ++ " ")
+   -- Non-breaking space because section numbers shouldn't end up on a line alone
+  | some s => .text true (s ++ " ")
 
 open Html in
 /--

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -254,14 +254,14 @@ def docstringStyle := r#"
   padding-left: 1px;
   padding-right: 1px;
   padding-bottom: 1px;
-  padding-top: 1.5em;
-  margin-bottom: 1em;
+  padding-top: 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .namedocs .text {
   background-color: white;
-  padding: 1.5em;
-  margin-top: 0.5em;
+  padding: 1.5rem;
+  margin-top: 0.5rem;
 }
 
 .namedocs .text > pre {
@@ -272,16 +272,16 @@ def docstringStyle := r#"
   font-family: var(--verso-code-font-family);
   font-size: larger;
   margin-top: 0 !important;
-  margin-left: 1.5em !important;
-  margin-right: 1.5em;
+  margin-left: 1.5rem !important;
+  margin-right: 1.5rem;
 }
 
 .namedocs .label {
   font-size: smaller;
   font-family: var(--verso-structure-font-family);
   position: absolute;
-  right: 0.5em;
-  top: 0.5em;
+  right: 0.5rem;
+  top: 0.5rem;
 }
 .namedocs h1 {
   font-size: inherit;

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -283,6 +283,16 @@ def docstringStyle := r#"
   right: 0.5rem;
   top: 0.5rem;
 }
+
+/* Sticking content into the right margin is not good on narrow screens,
+   so move the label to the left to make space for the permalink widget. */
+
+@media screen and (max-width: 700px) {
+  .namedocs:has(.permalink-widget.block) .label {
+    right: 1.5rem;
+  }
+}
+
 .namedocs h1 {
   font-size: inherit;
   font-weight: bold;

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -215,7 +215,7 @@ def page
       <head>
         {{base.map ({{<base href={{·}}/>}}) |>.getD .empty}}
         <meta charset="utf-8"/>
-        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <meta name="viewport" content="height=device-height, width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1"/>
         <title>{{textTitle}}</title>
         <link rel="stylesheet" href="/book.css" />
         <script>{{pageStyleJs}}</script>

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -215,6 +215,7 @@ def page
       <head>
         {{base.map ({{<base href={{·}}/>}}) |>.getD .empty}}
         <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
         <title>{{textTitle}}</title>
         <link rel="stylesheet" href="/book.css" />
         <script>{{pageStyleJs}}</script>

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -92,17 +92,12 @@ pre, code {
 /******** Page Layout ********/
 
 .with-toc #toc {
-    height: 100vh;
     position: fixed;
     z-index: 10;
 }
 
 /** Non-mobile **/
 @media screen and (min-width: 701px) {
-    .with-toc #toc {
-        height: 100vh;
-    }
-
     .with-toc > main {
         /* NB main > section also has padding that's added to this in practice */
         padding-left: var(--verso-toc-width);
@@ -128,7 +123,7 @@ pre, code {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    height: 100vh;
+    height: 100dvh;
     width: var(--verso-toc-width);
 }
 

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -516,15 +516,23 @@ main .section-toc a:hover {
 /******** Permalink widgets ********/
 
 .permalink-widget.inline {
-  display: none;
-  text-decoration: none;
-  font-size: 50%;
-  vertical-align: 10%;
-  margin-left: 0.5rem;
+    opacity: 0;
+    text-decoration: none;
+    font-size: 50%;
+    vertical-align: 10%;
+    margin-left: 0.5rem;
+    width: 0;
+    position: relative;
+}
+
+.permalink-widget.inline > a {
+    position: absolute;
+    bottom: 0;
+    left: 0;
 }
 
 :hover > .permalink-widget.inline {
-  display: inline-block;
+    opacity: 1;
 }
 
 

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -369,17 +369,6 @@ header #print {
     text-align: right;
 }
 
-/*
-header #print > *, header #controls > * {
-    height: 3rem;
-    width: 3rem;
-    line-height: 3rem;
-    display: inline-block;
-    text-align: center;
-    vertical-align: center;
-}
-*/
-
 #toggle-toc-click {
     cursor: pointer;
     /* This is the default, but it's needed to make the math work out so nice to be explicit: */

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -487,7 +487,9 @@ main ol.section-toc, main .section-toc ol {
 }
 
 main ol.section-toc {
-    padding-left: 0;
+    /* This is to "undo" the text-indent: -3rem on the LI elements, which indents
+       subsequent lines but not the section number. */
+    padding-left: 3rem;
 }
 
 main .section-toc > li {
@@ -502,6 +504,8 @@ main .section-toc li {
     font-weight: bold;
     font-family: var(--verso-structure-font-family);
     margin-left: 1rem;
+    /* Indent text that isn't a section number */
+    text-indent: -3rem;
 }
 
 main .section-toc a, main .section-toc a:visited {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -27,13 +27,25 @@ def pageStyle : String := r####"
     /* How long should the ToC animation take? */
     --verso-toc-transition-time: 0.4s;
 
+    /* How wide should the ToC be on non-mobile? */
+    --verso-toc-width: 15rem;
+
     /** Variables that control the “burger menu” appearance **/
     --verso-burger-height: 1.25rem;
     --verso-burger-width: 1.25rem;
     --verso-burger-line-width: 0.2rem;
     --verso-burger-line-radius: 0.2rem;
     --verso-burger-toc-visible-color: var(--verso-toc-text-color);
+    --verso-burger-toc-visible-shadow-color: #ffffff;
     --verso-burger-toc-hidden-color: #0e2431;
+    --verso-burger-toc-hidden-shadow-color: #ffffff;
+
+    /* The "burger menu" may need to get bigger for mobile screens */
+    --verso-mobile-burger-height: 2rem;
+    --verso-mobile-burger-width: 2rem;
+    --verso-mobile-burger-line-width: 0.4rem;
+    --verso-mobile-burger-line-radius: 0.4rem;
+
 }
 
 /******** Global parameters not intended for customization by themes ********/
@@ -78,40 +90,33 @@ pre, code {
 
 /******** Page Layout ********/
 
-.with-toc {
-    display: grid;
-    grid-template-columns: min-content auto;
-    grid-template-rows: auto;
-    grid-template-areas:
-        "toc text";
-    height: 100vh;
-    overflow: hidden;
-}
-
 .with-toc #toc {
-    grid-area: toc;
     height: 100vh;
+    position: fixed;
+    z-index: 10;
 }
 
-.with-toc #top-menu {
-    grid-area: toggle;
+/** Non-mobile **/
+@media screen and (min-width: 701px) {
+    .with-toc #toc {
+        height: 100vh;
+    }
+
+    .with-toc > main {
+        /* NB main > section also has padding that's added to this in practice */
+        padding-left: var(--verso-toc-width);
+    }
+}
+
+/** Mobile **/
+@media screen and (max-width: 700px) {
+    .with-toc > main {
+        padding-left: 1.5rem;
+    }
 }
 
 .with-toc #toc {
     overflow-y: auto;
-}
-
-.with-toc > header {
-    grid-area: header;
-}
-
-.with-toc > main {
-    grid-area: text;
-    overflow-y: auto;
-}
-
-.with-toc > #top-menu {
-    grid-area: burger
 }
 
 /******** Table of Contents ********/
@@ -122,10 +127,8 @@ pre, code {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-}
-
-#toc {
-  width: 15rem;
+    height: 100vh;
+    width: var(--verso-toc-width);
 }
 
 
@@ -134,7 +137,6 @@ pre, code {
        the ToC off the screen. */
     transition: transform var(--verso-toc-transition-time) ease, width 0.1s linear var(--verso-toc-transition-time);
     transform: translateX(-20rem);
-    width: 0;
 }
 
 #toc:has(#toggle-toc:checked) {
@@ -143,7 +145,6 @@ pre, code {
      */
     transition: transform var(--verso-toc-transition-time) ease 0.1s, width 0.1s linear;
     transform: translateX(0);
-    width: 15rem;
 }
 
 
@@ -334,6 +335,7 @@ pre, code {
   max-height: 4rem;
   display: block;
   margin-left: calc(var(--verso-burger-width) + 1rem); /* Make space for the menu button */
+  transition: height var(--verso-toc-transition-time) ease-in-out;
 }
 
 /******** Headerline ********/
@@ -386,25 +388,48 @@ header #print > *, header #controls > * {
     cursor: pointer;
     /* This is the default, but it's needed to make the math work out so nice to be explicit: */
     box-sizing: content-box;
-    width: var(--verso-burger-height);
+    width: var(--verso-burger-width);
     height: var(--verso-burger-height);
     display: inline-flex;
     flex-direction: column;
     justify-content: space-between;
     padding: 0.5rem;
-    position: absolute;
+    position: fixed;
     z-index: 100; /* Show on top of ToC/content */
+    filter: drop-shadow(1px 1px var(--verso-burger-toc-hidden-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-hidden-shadow-color));
+    transition:
+        height var(--verso-toc-transition-time) ease-in-out,
+        width var(--verso-toc-transition-time) ease-in-out;
+}
+
+body:has(#toggle-toc:checked) #toggle-toc-click {
+    filter: drop-shadow(1px 1px var(--verso-burger-toc-visible-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-visible-shadow-color));
+}
+
+@media screen and (max-width: 700px) {
+    body {
+        --verso-burger-width: var(--verso-mobile-burger-width);
+        --verso-burger-height: var(--verso-mobile-burger-height);
+        --verso-burger-line-width: var(--verso-mobile-burger-line-width);
+        --verso-burger-line-radius: var(--verso-mobile-burger-line-radius);
+    }
 }
 
 #toggle-toc-click .line {
     display: block;
-    height: var(--verso-burger-line-width);
+    position: relative;
     width: 100%;
+    height: var(--verso-burger-line-width);
     border-radius: var(--verso-burger-line-radius);
     background-color: var(--verso-burger-toc-hidden-color);
     /* The background color has a transition in case a theme needs to override the line color
        when the ToC menu is open */
-    transition: background-color var(--verso-toc-transition-time) ease-in-out, transform var(--verso-toc-transition-time) ease-in-out;
+    transition:
+        background-color var(--verso-toc-transition-time) ease-in-out,
+        height var(--verso-toc-transition-time) ease-in-out,
+        width var(--verso-toc-transition-time) ease-in-out,
+        transform var(--verso-toc-transition-time) ease-in-out;
+    z-index: 15;
 }
 
 body:has(#toggle-toc:checked) #toggle-toc-click .line {
@@ -449,7 +474,6 @@ main .authors {
 }
 
 main > section {
-    margin: auto;
     position: relative;
     padding: var(--verso--content-padding-x);
 }

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -86,6 +86,7 @@ dd > p:first-child {
 pre, code {
     font-family: var(--verso-code-font-family);
     font-variant-ligatures: none;
+    overflow-x: auto;
 }
 
 /******** Page Layout ********/
@@ -554,6 +555,15 @@ main .section-toc a:hover {
     top: 0;
     opacity: 0.1;
     transition: opacity 0.5s;
+}
+
+/* On narrow screens, float the widget over the block instead of
+   putting it in the margin to avoid horizontal scrolling. */
+@media screen and (max-width: 700px) {
+    .permalink-widget.block {
+        right: 0;
+        opacity: 1;
+    }
 }
 
 .permalink-widget > a {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -18,7 +18,7 @@ def pageStyle : String := r####"
     /* The font family used for code */
     --verso-code-font-family: monospace;
     /* What's the maximum line width, for legibility? */
-    --verso-content-max-width: 45em;
+    --verso-content-max-width: 45rem;
 
     /** Table of Contents appearance **/
     --verso-toc-background-color: #fafafa;
@@ -28,10 +28,10 @@ def pageStyle : String := r####"
     --verso-toc-transition-time: 0.4s;
 
     /** Variables that control the “burger menu” appearance **/
-    --verso-burger-height: 1.25em;
-    --verso-burger-width: 1.25em;
-    --verso-burger-line-width: 0.2em;
-    --verso-burger-line-radius: 0.2em;
+    --verso-burger-height: 1.25rem;
+    --verso-burger-width: 1.25rem;
+    --verso-burger-line-width: 0.2rem;
+    --verso-burger-line-radius: 0.2rem;
     --verso-burger-toc-visible-color: var(--verso-toc-text-color);
     --verso-burger-toc-hidden-color: #0e2431;
 }
@@ -40,7 +40,7 @@ def pageStyle : String := r####"
 
 :root {
     /* How much space to add on the sides of content for small screens and to place widgets. */
-    --verso--content-padding-x: 1.5em;
+    --verso--content-padding-x: 1.5rem;
 
 }
 
@@ -125,7 +125,7 @@ pre, code {
 }
 
 #toc {
-  width: 15em;
+  width: 15rem;
 }
 
 
@@ -133,7 +133,7 @@ pre, code {
     /* Here, the width transition is delayed until after the translation has pushed
        the ToC off the screen. */
     transition: transform var(--verso-toc-transition-time) ease, width 0.1s linear var(--verso-toc-transition-time);
-    transform: translateX(-20em);
+    transform: translateX(-20rem);
     width: 0;
 }
 
@@ -143,7 +143,7 @@ pre, code {
      */
     transition: transform var(--verso-toc-transition-time) ease 0.1s, width 0.1s linear;
     transform: translateX(0);
-    width: 15em;
+    width: 15rem;
 }
 
 
@@ -163,12 +163,12 @@ pre, code {
 
 #toc .split-tocs {
     padding-left: 0;
-    padding-right: 0.5em;
-    margin-top: 1.5em;
+    padding-right: 0.5rem;
+    margin-top: 1.5rem;
 }
 
 #toc .split-toc.book {
-    margin-bottom: 2em;
+    margin-bottom: 2rem;
 }
 
 #toc .split-toc.book .title {
@@ -176,7 +176,7 @@ pre, code {
 }
 
 #toc .split-toc {
-    margin-bottom: 1.5em;
+    margin-bottom: 1.5rem;
     font-family: var(--verso-structure-font-family);
 }
 
@@ -201,10 +201,10 @@ pre, code {
 }
 
 :root {
-    --verso-toc-triangle-width: 0.6em;
-    --verso-toc-triangle-height: 0.6em;
-    --verso-toc-triangle-left-space: 0.5em;
-    --verso-toc-triangle-margin: 0.5em;
+    --verso-toc-triangle-width: 0.6rem;
+    --verso-toc-triangle-height: 0.6rem;
+    --verso-toc-triangle-left-space: 0.5rem;
+    --verso-toc-triangle-margin: 0.5rem;
 }
 
 #toc .split-toc label.toggle-split-toc::before {
@@ -253,8 +253,8 @@ pre, code {
 
 #toc .split-toc table {
     border-left: 1px dotted;
-    padding-left: 1.2em;
-    padding-top: 0.2em;
+    padding-left: 1.2rem;
+    padding-top: 0.2rem;
 }
 
 #toc .split-toc td {
@@ -273,28 +273,28 @@ pre, code {
 
 /* Add a bit of visual space between numbered and unnumbered rows */
 #toc .split-toc tr:has(+ tr.unnumbered) td, #toc .split-toc tr.unnumbered:has(+ tr.numbered) td {
-  padding-bottom: 0.5em;
+  padding-bottom: 0.5rem;
 }
 
 #local-buttons {
-    margin-top: 2.5em;
+    margin-top: 2.5rem;
     font-weight: bold;
     font-family: var(--verso-structure-font-family);
     display: flex;
     justify-content: space-between;
-    margin-left: 0.5em;
-    margin-right: 0.5em
+    margin-left: 0.5rem;
+    margin-right: 0.5rem
 }
 
 #local-buttons > * {
-    width: 4.5em;
+    width: 4.5rem;
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
 #local-buttons .local-button .where {
-    margin: 0 0.3em;
+    margin: 0 0.3rem;
 }
 
 .local-button.active {
@@ -330,10 +330,10 @@ pre, code {
 }
 
 #logo {
-  max-width: min(80%, calc(100% - calc(var(--verso-burger-width) + 1em)));
-  max-height: 4em;
+  max-width: min(80%, calc(100% - calc(var(--verso-burger-width) + 1rem)));
+  max-height: 4rem;
   display: block;
-  margin-left: calc(var(--verso-burger-width) + 1em); /* Make space for the menu button */
+  margin-left: calc(var(--verso-burger-width) + 1rem); /* Make space for the menu button */
 }
 
 /******** Headerline ********/
@@ -346,11 +346,11 @@ header {
 }
 
 header h1 {
-    margin-top: 0.2em;
-    margin-bottom: 0.2em;
+    margin-top: 0.2rem;
+    margin-bottom: 0.2rem;
     text-align: center;
     grid-area: pagetitle;
-    font-size: 1.25em;
+    font-size: 1.25rem;
 }
 
 header h1 a, header h1 a:link, header h1 a:visited {
@@ -373,9 +373,9 @@ header #print {
 
 /*
 header #print > *, header #controls > * {
-    height: 3em;
-    width: 3em;
-    line-height: 3em;
+    height: 3rem;
+    width: 3rem;
+    line-height: 3rem;
     display: inline-block;
     text-align: center;
     vertical-align: center;
@@ -391,7 +391,7 @@ header #print > *, header #controls > * {
     display: inline-flex;
     flex-direction: column;
     justify-content: space-between;
-    padding: 0.5em;
+    padding: 0.5rem;
     position: absolute;
     z-index: 100; /* Show on top of ToC/content */
 }
@@ -432,7 +432,7 @@ body:has(#toggle-toc:checked) #toggle-toc-click .line3 {
     font-size: 90%;
     display: flex;
     justify-content: space-between;
-    padding: 0 1em;
+    padding: 0 1rem;
 }
 #meta-links li {
     display: inline-block;
@@ -467,17 +467,17 @@ main ol.section-toc {
 }
 
 main .section-toc > li {
-    padding-bottom: 0.25em;
+    padding-bottom: 0.25rem;
 }
 
 main .section-toc ol {
-    padding-left: 0.5em
+    padding-left: 0.5rem
 }
 
 main .section-toc li {
     font-weight: bold;
     font-family: var(--verso-structure-font-family);
-    margin-left: 1em;
+    margin-left: 1rem;
 }
 
 main .section-toc a, main .section-toc a:visited {
@@ -496,7 +496,7 @@ main .section-toc a:hover {
   text-decoration: none;
   font-size: 50%;
   vertical-align: 10%;
-  margin-left: 0.5em;
+  margin-left: 0.5rem;
 }
 
 :hover > .permalink-widget.inline {

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -401,8 +401,8 @@ where
     }
 
     main .theIndex nav ol li a {
-      margin-left: 0.5em;
-      margin-right: 0.5em;
+      margin-left: 0.5rem;
+      margin-right: 0.5rem;
     }
 
     main .theIndex nav ol li:first-child a {
@@ -430,15 +430,15 @@ where
       padding-left: 0;
       display: flex;
       flex-wrap: wrap;
-      gap: 3em;
+      gap: 3rem;
     }
 
    main .theIndex .division > ol > li {
-      margin-bottom: 0.5em;
+      margin-bottom: 0.5rem;
     }
 
     main .theIndex .division ol ol {
-      padding-left: 1em;
+      padding-left: 1rem;
     }
 
     main .theIndex .division {

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -433,17 +433,17 @@ def highlightingStyle : String := "
   position: absolute;
   background-color: #e5e5e5;
   border: 1px solid black;
-  padding: 0.5em;
+  padding: 0.5rem;
   z-index: 300;
   font-size: inherit;
 }
 
 .hl.lean .hover-info.messages {
-  max-height: 10em;
+  max-height: 10rem;
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-gutter: stable;
-  padding: 0 0.5em 0 0;
+  padding: 0 0.5rem 0 0;
   display: block;
 }
 
@@ -452,7 +452,7 @@ def highlightingStyle : String := "
 }
 
 .hl.lean .hover-info.messages > code {
-  padding: 0.5em;
+  padding: 0.5rem;
   display: block;
   width: fit-content;
 }
@@ -462,11 +462,11 @@ def highlightingStyle : String := "
 }
 
 .hl.lean .hover-info.messages > code {
-  margin: 0.1em;
+  margin: 0.1rem;
 }
 
 .hl.lean .hover-info.messages > code:not(:first-child) {
-  margin-top: 0em;
+  margin-top: 0rem;
 }
 
 /*
@@ -477,7 +477,7 @@ def highlightingStyle : String := "
   .hl.lean .tactic:has(> .tactic-toggle:checked) .token:hover > .hover-container > .hover-info:not(.has-info *) {
     display: inline-block;
     position: absolute;
-    top: 1em;
+    top: 1rem;
     font-weight: normal;
     font-style: normal;
     width: min-content;
@@ -518,7 +518,7 @@ def highlightingStyle : String := "
   position: absolute;
   transform: translate(0.25rem, 0.3rem);
   border: 1px solid black;
-  padding: 0.5em;
+  padding: 0.5rem;
   z-index: 400;
   text-align: left;
 }
@@ -535,7 +535,7 @@ def highlightingStyle : String := "
 
 .hl.lean .hover-info.messages > code.error {
   background-color: #e5e5e5;
-  border-left: 0.2em solid #ffb3b3;
+  border-left: 0.2rem solid #ffb3b3;
 }
 
 .tippy-box[data-theme~='error'] .hl.lean .hover-info.messages > code.error {
@@ -563,7 +563,7 @@ def highlightingStyle : String := "
 
 .hl.lean .hover-info.messages > code.error {
   background-color: #e5e5e5;
-  border-left: 0.2em solid #efd871;
+  border-left: 0.2rem solid #efd871;
 }
 
 .tippy-box[data-theme~='warning'] .hl.lean .hover-info.messages > code.warning {
@@ -585,7 +585,7 @@ def highlightingStyle : String := "
 
 .hl.lean .hover-info.messages > code.info {
   background-color: #e5e5e5;
-  border-left: 0.2em solid #4777ff;
+  border-left: 0.2rem solid #4777ff;
 }
 
 .tippy-box[data-theme~='info'] .hl.lean .hover-info.messages > code.info {
@@ -596,7 +596,7 @@ def highlightingStyle : String := "
 .hl.lean div.docstring {
   font-family: sans-serif;
   white-space: normal;
-  max-width: 40em;
+  max-width: 40rem;
   width: max-content;
 }
 
@@ -607,10 +607,10 @@ def highlightingStyle : String := "
 .hl.lean .hover-info .sep {
   display: block;
   width: auto;
-  margin-left: 1em;
-  margin-right: 1em;
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
   padding: 0;
   height: 1px;
   border-top: 1px solid #ccc;
@@ -623,11 +623,11 @@ def highlightingStyle : String := "
 .hl.lean .tactic-state {
   display: none;
   position: relative;
-  left: 2em;
+  left: 2rem;
   width: fit-content;
   border: 1px solid #888888;
-  border-radius: 0.1em;
-  padding: 0.5em;
+  border-radius: 0.1rem;
+  padding: 0.5rem;
   font-family: sans-serif;
   background-color: #ffffff;
   z-index: 200;
@@ -638,7 +638,7 @@ def highlightingStyle : String := "
   display: block;
   width: auto;
   border: none;
-  padding: 0.5em;
+  padding: 0.5rem;
   font-family: sans-serif;
   background-color: #ffffff;
 }
@@ -688,12 +688,12 @@ def highlightingStyle : String := "
 .hl.lean .tactic > label::after {
   content: \"\";
   border: 1px solid #bbbbbb;
-  border-radius: 1em;
-  height: 0.25em;
+  border-radius: 1rem;
+  height: 0.25rem;
   vertical-align: middle;
-  width: 0.6em;
-  margin-left: 0.1em;
-  margin-right: 0.1em;
+  width: 0.6rem;
+  margin-left: 0.1rem;
+  margin-right: 0.1rem;
   display: inline-block;
   transition: all 0.5s;
 }
@@ -715,15 +715,15 @@ def highlightingStyle : String := "
 }
 
 .hl.lean .tactic-state .goal + .goal {
-  margin-top: 1.5em;
+  margin-top: 1.5rem;
 }
 
 .hl.lean .tactic-state summary {
-  margin-left: -0.5em;
+  margin-left: -0.5rem;
 }
 
 .hl.lean .tactic-state details {
-  padding-left: 0.5em;
+  padding-left: 0.5rem;
 }
 
 .hl.lean .case-label {
@@ -742,16 +742,16 @@ def highlightingStyle : String := "
 }
 
 .hl.lean .case-label:has(input[type=\"checkbox\"])::before {
-  width: 1em;
-  height: 1em;
+  width: 1rem;
+  height: 1rem;
   display: inline-block;
   background-color: black;
   content: ' ';
   transition: ease 0.2s;
-  margin-right: 0.7em;
+  margin-right: 0.7rem;
   clip-path: polygon(100% 0, 0 0, 50% 100%);
-  width: 0.6em;
-  height: 0.6em;
+  width: 0.6rem;
+  height: 0.6rem;
 }
 
 .hl.lean .case-label:has(input[type=\"checkbox\"]:not(:checked))::before {
@@ -772,8 +772,8 @@ def highlightingStyle : String := "
   display: block;
   overflow: hidden;
   transition: max-height 0.1s ease-in;
-  margin-left: 0.5em;
-  margin-top: 0.1em;
+  margin-left: 0.5rem;
+  margin-top: 0.1rem;
 }
 
 .hl.lean .labeled-case:has(.case-label input[type=\"checkbox\"]:checked) > :not(:first-child) {
@@ -806,7 +806,7 @@ def highlightingStyle : String := "
 
 .hl.lean .tactic-state .hypotheses .colon {
   text-align: center;
-  min-width: 1em;
+  min-width: 1rem;
 }
 
 .hl.lean .tactic-state .hypotheses .name {

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -491,7 +491,7 @@ def highlightingStyle : String := "
 
 .hl.lean.inline {
   display: inline;
-  white-space: pre-wrap;
+  white-space: pre-line;
 }
 
 .hl.lean .token {


### PR DESCRIPTION
 * Switch to rems universally
 * Include the magic "I know what I'm doing" meta tag

Based on advice in https://github.com/leanprover/reference-manual/issues/140 and https://github.com/leanprover/reference-manual/issues/137. It won't solve all the issues, and it requires a bit more testing, but a quick check was positive.