### PR TITLE
fix: error recovery for directives

### DIFF
--- a/src/verso/Verso/Parser/Lean.lean
+++ b/src/verso/Verso/Parser/Lean.lean
@@ -141,12 +141,12 @@ def docMkIdResult (startPos : String.Pos) (val : Name) : ParserFn := fun c s =>
   let atom            := mkIdent info rawVal val
   s.pushSyntax atom
 
-partial def docIdentFn : ParserFn :=
+partial def docIdentFn (reportAs : String := "identifier") : ParserFn :=
   let rec parse (startPos : String.Pos) (r : Name) : ParserFn:= fun c s =>
     let input := c.input
     let i     := s.pos
     if h : input.atEnd i then
-      s.mkEOIError ["identifier"]
+      s.mkEOIError [reportAs]
     else
       let curr := input.get' i h
       if isIdBeginEscape curr then
@@ -174,7 +174,7 @@ partial def docIdentFn : ParserFn :=
         else
           docMkIdResult startPos r c s
       else
-        s.mkErrorAt "identifier" startPos
+        s.mkErrorAt reportAs startPos
   fun c s =>
     let startPos := s.pos
     parse startPos .anonymous c s

--- a/src/verso/Verso/SyntaxUtils.lean
+++ b/src/verso/Verso/SyntaxUtils.lean
@@ -43,11 +43,11 @@ defmethod ParserFn.test (p : ParserFn) (input : String) : IO String := do
   if s'.allErrors.isEmpty then
     return s!"Success! Final stack:\n{stk.pretty 50}\n{remaining}"
   else if let #[(p, _, err)] := s'.allErrors then
-    return s!"Failure: {err}\nFinal stack:\n{stk.pretty 50}\nRemaining: {repr $ input.extract p input.endPos}"
+    return s!"Failure @{p} ({ictx.fileMap.toPosition p}): {toString err}\nFinal stack:\n{stk.pretty 50}\nRemaining: {repr $ input.extract p input.endPos}"
   else
     let mut errors := ""
-    for (p, _, e) in s'.allErrors do
-      errors := errors ++ s!"  @{p}: {toString e}\n    {repr <| input.extract p input.endPos}\n"
+    for (p, _, e) in s'.allErrors.qsort (fun x y => x.1 < y.1 || x.1 == y.1 && toString x.2.2 < toString y.2.2)  do
+      errors := errors ++ s!"  @{p} ({ictx.fileMap.toPosition p}): {toString e}\n    {repr <| input.extract p input.endPos}\n"
     return s!"{s'.allErrors.size} failures:\n{errors}\nFinal stack:\n{stk.pretty 50}"
 
 defmethod ParserFn.test! (p : ParserFn) (input : String) : IO Unit :=


### PR DESCRIPTION
Now errors are shown on the directives in the source file, rather than at the end of the file, making it much easier to diagnose parser errors.