### PR TITLE
chore: improve CI parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 name: Continuous Integration
@@ -58,12 +60,6 @@ jobs:
           format: markdown
           jobSummary: true
           args: --base './_out/examples/demosite' --no-progress --offline './_out/examples/demosite/**/*.html'
-
-      - name: Check for consistent Subverso versions in all manifests
-        run: |
-          echo "Subverso versions:"
-          find . -name lake-manifest.json -print0 | xargs -0 jq '.packages[] | select(.name == "subverso") | {"file": input_filename, "subverso": .rev}'
-          find . -name lake-manifest.json -print0 | xargs -0 jq -e -s 'map(.packages[] | select(.name == "subverso").rev) | .[0] as $x | all(.[]; . == $x)'
 
       - name: Install PDF Dependencies
         uses: teatimeguest/setup-texlive-action@v3

--- a/.github/workflows/consistent-subverso-manifests.yml
+++ b/.github/workflows/consistent-subverso-manifests.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+name: Consistent Subverso dependencies
+
+jobs:
+  build:
+    name: consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for consistent Subverso versions in all manifests
+        run: |
+          echo "Subverso versions:"
+          find . -name lake-manifest.json -print0 | xargs -0 jq '.packages[] | select(.name == "subverso") | {"file": input_filename, "subverso": .rev}'
+          find . -name lake-manifest.json -print0 | xargs -0 jq -e -s 'map(.packages[] | select(.name == "subverso").rev) | .[0] as $x | all(.[]; . == $x)'


### PR DESCRIPTION
Moving the Subverso consistency check to its own job improves parallel processing and fails faster.

Also, there's no need to run on push and on pull request - it'd be nice to kick off builds when the push happens, but this results in double builds, which is not good.