### PR TITLE
chore: bump to new nightly

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,2 +1,2 @@
-leanprover/lean4:v4.17.0-rc1
+leanprover/lean4:nightly-2025-02-06
 

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1229,7 +1229,7 @@ def blockFromMarkdownWithLean (names : List Name) (b : MD4Lean.Block) : DocElabM
                 (elabBlockCode := tryElabBlockCode)
             synthesizeSyntheticMVarsUsingDefault
 
-            discard <| addAutoBoundImplicits #[]
+            discard <| addAutoBoundImplicits #[] (inlayHintPos? := none)
 
             return res
           catch e =>

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -488,7 +488,7 @@ unsafe def partCommandsForUnsafe (x : Name) : PartElabM (Array PartCommand) := d
 opaque partCommandsFor (x : Name) : PartElabM (Array PartCommand)
 
 
-abbrev RoleExpander := Array Arg → Array Syntax → DocElabM (Array (TSyntax `term))
+abbrev RoleExpander := Array Arg → TSyntaxArray `inline → DocElabM (Array (TSyntax `term))
 
 initialize roleExpanderAttr : KeyedDeclsAttribute RoleExpander ←
   mkDocExpanderAttribute `role_expander ``RoleExpander "Indicates that this function is used to implement a given role" `roleExpanderAttr
@@ -515,7 +515,7 @@ opaque codeBlockExpandersFor (x : Name) : DocElabM (Array CodeBlockExpander)
 
 
 
-abbrev DirectiveExpander := Array Arg → Array Syntax → DocElabM (Array (TSyntax `term))
+abbrev DirectiveExpander := Array Arg → TSyntaxArray `block → DocElabM (Array (TSyntax `term))
 
 initialize directiveExpanderAttr : KeyedDeclsAttribute DirectiveExpander ←
   mkDocExpanderAttribute `directive_expander ``DirectiveExpander "Indicates that this function is used to implement a given directive" `directiveExpanderAttr

--- a/src/verso/Verso/Syntax.lean
+++ b/src/verso/Verso/Syntax.lean
@@ -99,11 +99,6 @@ syntax (name:=inline_math) "\\math" code : inline
 /-- Display-mode mathematical notation -/
 syntax (name:=display_math) "\\displaymath" code : inline
 
-/-- Items from both ordered and unordered lists -/
-declare_syntax_cat list_item
-/-- List item -/
-syntax (name:=li) "*" inline* : list_item
-
 /--
 Block-level elements, such as paragraphs, headers, and lists.
 
@@ -120,6 +115,11 @@ Conventions:
    newline-separated for directives and code)
 -/
 declare_syntax_cat block
+
+/-- Items from both ordered and unordered lists -/
+declare_syntax_cat list_item
+/-- List item -/
+syntax (name:=li) "*" block* : list_item
 
 /-- A description of an item -/
 declare_syntax_cat desc_item


### PR DESCRIPTION
This fixes compatibility with upstream changes to LSP internals. In the process, the refactoring of the syntax representation was propagated to the semantic token highlighter, greatly improving it.