### PR TITLE
feat: show summary of current page in manual genre

### DIFF
--- a/doc/UsersGuide/Basic.lean
+++ b/doc/UsersGuide/Basic.lean
@@ -11,7 +11,9 @@ set_option pp.rawOnError true
 authors := ["David Thrane Christiansen"]
 %%%
 
+
 Documentation can take many forms:
+
 
  * References
  * Tutorials
@@ -23,6 +25,7 @@ Documentation can take many forms:
 %%%
 tag := "genres"
 %%%
+
 
 :::paragraph
 Documentation comes in many forms, and no one system is suitable for representing all of them.
@@ -70,11 +73,14 @@ They include heuristic elaboration of code items in their Markdown that attempts
 
 {docstring Monad}
 
+
+
 :::tactic "induction"
 :::
 
 :::tactic "simp"
 :::
+
 
 {docstring Nat}
 

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -565,11 +565,16 @@ structure BlockDescr where
   extraCss : List String := []
   extraCssFiles : List (String × String) := []
   licenseInfo : List LicenseInfo := []
+  /--
+  Should this block be an entry in the page-local ToC? If so, how should it be represented?
+  -/
+  localContentItem : InternalId → Json → Array (Doc.Block Manual) → Option Verso.Output.Html :=
+    fun _ _ _ => none
 
   toTeX : Option (BlockToTeX Manual (ReaderT ExtensionImpls IO))
 deriving TypeName
 
-instance : Inhabited BlockDescr := ⟨⟨id, default, default, default, default, default, default, default, default⟩⟩
+instance : Inhabited BlockDescr := ⟨⟨id, default, default, default, default, default, default, default, default, default⟩⟩
 
 open Lean in
 initialize inlineExtensionExt

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -545,6 +545,8 @@ def docstringStyle := r#"
   transition-behavior: allow-discrete;
   @starting-style { opacity: 0 !important; }
 }
+
+#this-page-items .tactic-name { font-weight: bold; }
 "# ++ Id.run do
   let mut str := ""
   for i in [0:50] do
@@ -751,6 +753,13 @@ def docstring.descr : BlockDescr := withHighlighting {
           </div>
         </div>
       }}
+
+  localContentItem := fun _id info _contents => open Verso.Output.Html in do
+    let .ok (name, _declType, _signature) := FromJson.fromJson? (α := Name × Block.Docstring.DeclType × Option Highlighted) info
+      | failure
+    pure #[{{<code>{{name.getString!}}</code>}}]
+
+
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
   extraCss := [docstringStyle]
 }
@@ -1461,6 +1470,10 @@ def optionDocs.descr : BlockDescr where
           </div>
         </div>
       }}
+  localContentItem := fun _id info _contents => open Verso.Output.Html in do
+    let .ok (name, _defaultValue) := FromJson.fromJson? (α := Name × Highlighted) info
+      | failure
+    pure #[{{<code>{{name.toString}}</code>}}]
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
   extraCss := [highlightingStyle, docstringStyle]
   extraJs := [highlightingJs]
@@ -1545,6 +1558,13 @@ def tactic : DirectiveExpander
     let userContents ← more.mapM elabBlock
     pure #[← ``(Verso.Doc.Block.other (Block.tactic $(quote tactic) $(quote opts.show)) #[$(contents ++ userContents),*])]
 
+
+
+def Inline.tactic : Inline where
+  name := `Verso.Genre.Manual.tacticInline
+
+
+
 open Verso.Genre.Manual.Markdown in
 open Lean Elab Term Parser Tactic Doc in
 @[block_extension tactic]
@@ -1586,12 +1606,14 @@ def tactic.descr : BlockDescr := withHighlighting {
           </div>
         </div>
       }}
+  localContentItem := fun _id info _contents => open Verso.Output.Html in do
+    let .ok (tactic, «show») := FromJson.fromJson? (α := TacticDoc × Option String) info
+      | failure
+    pure #[{{<code class="tactic-name">{{show.getD tactic.userName}}</code>}}]
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
   extraCss := [docstringStyle]
 }
 
-def Inline.tactic : Inline where
-  name := `Verso.Genre.Manual.tacticInline
 
 deriving instance Repr for NameSet
 deriving instance Repr for Lean.Elab.Tactic.Doc.TacticDoc
@@ -1719,6 +1741,11 @@ def conv.descr : BlockDescr := withHighlighting {
           </div>
         </div>
       }}
+  localContentItem := fun _id info _contents => open Verso.Output.Html in do
+    let .ok (_name, «show», _docs?) := FromJson.fromJson? (α := Name × String × Option String) info
+      | failure
+    pure #[{{<code class="tactic-name">{{«show»}}</code>}}]
+
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
   extraCss := [docstringStyle]
 }

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -237,6 +237,7 @@ pre, code {
     z-index: -10;
 }
 
+
 :root {
     --verso-toc-triangle-width: 0.6rem;
     --verso-toc-triangle-height: 0.6rem;
@@ -297,6 +298,26 @@ pre, code {
 #toc .split-toc td {
     vertical-align: top;
     font-size: 90%;
+}
+
+#toc .split-toc > ol {
+    border-left: 1px dotted;
+    list-style-type: none;
+    padding-left: 0.5rem;
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+}
+
+#toc .split-toc > ol > li {
+    text-indent: -1.5rem;
+    padding-left: 2.5rem;
+}
+
+#toc .split-toc > ol > li:has(.header) {
+    padding-left: 2rem;
 }
 
 #toc .split-toc .current td:not(.num), #toc .split-toc .title .current {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/

--- a/src/verso-manual/VersoManual/LocalContents.lean
+++ b/src/verso-manual/VersoManual/LocalContents.lean
@@ -1,0 +1,150 @@
+import Lean
+import Verso
+import VersoManual.Basic
+
+open Lean
+
+namespace Verso.Genre.Manual
+
+open Doc
+
+abbrev LocalContentItemRecognizer :=
+  Manual.Block → Option (Array (Doc.Inline Manual) × Slug)
+
+def LocalContentItemRecognizer.failure : LocalContentItemRecognizer := fun _ => Option.none
+
+def LocalContentItemRecognizer.orElse (r1 r2 : LocalContentItemRecognizer) : LocalContentItemRecognizer := fun b => r1 b <|> r2 b
+
+initialize localContentAttr : TagAttribute ←
+  registerTagAttribute `local_content_list "Functions that recognize items for the page-local table of contents"
+
+private def localContentRecognizers [Monad m] [MonadLiftT MetaM m] [MonadOptions m] [MonadEnv m] [MonadError m] : m (Array Name) := do
+  let st := localContentAttr.ext.toEnvExtension.getState (← getEnv)
+  let st' := st.importedEntries.flatten ++ st.state.toArray
+
+  let mut out := #[]
+  for f in st' do
+    let t ← Meta.inferType (.const f [])
+    if (← Meta.isDefEq t (.const ``LocalContentItemRecognizer [])) then
+      out := out.push f
+    else
+      throwError m!"Recognizer '{f}' has type '{t}' (expected {``LocalContentItemRecognizer}')"
+  pure out
+
+open Lean Elab Term in
+scoped elab "local_content_recognizer_fun" : term => do
+  let mut stx ← ``(LocalContentItemRecognizer.failure)
+  let rs ← localContentRecognizers
+  for f in rs do
+    stx ← `($(mkIdent f) <|> $stx)
+  elabTerm stx none
+
+structure HeaderStatus where
+  level : Nat
+  numbering : Option String
+
+
+open Verso.Output in
+structure LocalContentItem where
+  header? : Option HeaderStatus
+  slug : Slug
+  linkText : Html
+
+partial def fromNone : Doc.Inline Genre.none → Doc.Inline Manual
+  | .text s => .text s
+  | .concat xs => .concat (xs.map fromNone)
+  | .image alt dest => .image alt dest
+  | .link xs dest => .link (xs.map fromNone) dest
+  | .linebreak s => .linebreak s
+  | .code s => .code s
+  | .emph xs => .emph (xs.map fromNone)
+  | .bold xs => .bold (xs.map fromNone)
+  | .math mode x => .math mode x
+  | .footnote x xs => .footnote x (xs.map fromNone)
+
+partial def toNone : Doc.Inline Manual → Doc.Inline Genre.none
+  | .other i is => .concat (is.map toNone)
+  | .text s => .text s
+  | .concat xs => .concat (xs.map toNone)
+  | .image alt dest => .image alt dest
+  | .link xs dest => .link (xs.map toNone) dest
+  | .linebreak s => .linebreak s
+  | .code s => .code s
+  | .emph xs => .emph (xs.map toNone)
+  | .bold xs => .bold (xs.map toNone)
+  | .math mode x => .math mode x
+  | .footnote x xs => .footnote x (xs.map toNone)
+
+open Verso.Output Html
+
+def LocalContentItem.toHtml (item : LocalContentItem) : Html :=
+  let txt := {{<a href=s!"#{item.slug.toString}">{{item.linkText}}</a>}}
+  if let some ⟨level, numbering⟩ := item.header? then
+    let numHtml := if let some l := numbering then {{<span class="level-num">{{l}}</span>" "}} else .empty
+    {{<span class=s!"header head-{level}">{{numHtml}}{{txt}}</span>}}
+  else
+    txt
+
+partial def blockItem? (impls : ExtensionImpls) (xref : TraverseState ) (blk : Block) (contents : Array (Doc.Block Manual)) : Option LocalContentItem := do
+  let impl ← impls.getBlock? blk.name
+  let id ← blk.id
+  let name ← impl.localContentItem id blk.data contents
+  let (_path, slug) ← xref.externalTags[id]? -- TODO validate path
+  return ⟨none, slug, name⟩
+
+partial def blockContents (impls : ExtensionImpls) (xref : TraverseState) (acc : Array LocalContentItem) (b : Doc.Block Manual) : Array LocalContentItem := Id.run do
+  match b with
+  | .para .. | .code .. => acc
+  | .concat xs | .blockquote xs =>
+    let mut acc := acc
+    for x in xs do
+      acc := blockContents impls xref acc x
+    acc
+  | .ul xs | .ol _ xs =>
+    let mut acc := acc
+    for x in xs do
+      for y in x.contents do
+        acc := blockContents impls xref acc y
+    acc
+  | .dl xs =>
+    let mut acc := acc
+    for x in xs do
+      for y in x.desc do
+        acc := blockContents impls xref acc y
+    acc
+  | .other blk bs =>
+    let mut acc := acc
+    if let some item := blockItem? impls xref blk bs then
+      acc := acc.push item
+    for b in bs do
+      acc := blockContents impls xref acc b
+    acc
+
+partial def localContents
+    (impls : ExtensionImpls) (opts : Html.Options Manual (ReaderT ExtensionImpls IO)) (ctxt : TraverseContext) (xref : TraverseState)
+    (p : Part Manual)
+    (sectionNumPrefix : Option String := none)
+    (includeTitle : Bool := true) (includeSubparts : Bool := true) (fromLevel : Nat := 0) : StateT (Code.Hover.State Html) (ReaderT ExtensionImpls IO) (Array (LocalContentItem)) := do
+  let sectionNumPrefix := sectionNumPrefix <|> sectionString ctxt
+  let mut out := #[]
+
+  if includeTitle then
+    let (html, _) ← p.title.mapM (Manual.toHtml opts ctxt xref {} {} {} ·) |>.run {} {}
+    let partDest : Option (LocalContentItem) := do
+      let m ← p.metadata
+      let id ← m.id
+      let (_, slug) ← xref.externalTags[id]?
+      let num := sectionString ctxt |>.map (withoutPrefix · sectionNumPrefix)
+
+      return ⟨some ⟨fromLevel, num⟩, slug, html⟩
+    out := out ++ partDest.toArray
+
+  for b in p.content do
+    out := blockContents impls xref out b
+  if includeSubparts then
+    for p' in p.subParts do
+      out := out ++ (← localContents impls opts (ctxt.inPart p') xref p' (sectionNumPrefix := sectionNumPrefix) (fromLevel := fromLevel + 1))
+  return out
+where
+  withoutPrefix (str : String) (prefix? : Option String) : String :=
+    prefix?.bind (str.dropPrefix? · |>.map Substring.toString) |>.getD str

--- a/src/verso-manual/VersoManual/LocalContents.lean
+++ b/src/verso-manual/VersoManual/LocalContents.lean
@@ -1,4 +1,8 @@
-import Lean
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
 import Verso
 import VersoManual.Basic
 


### PR DESCRIPTION
Adds things like docstrings to the ToC on the left in the manual genre. The set of things to be shown is extensible.

Closes #266.