### PR TITLE
feat: reset heartbeat count for each top-level block

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -883,7 +883,7 @@ def tryElabCodeMetavarTermWith (mk : Highlighted → String → DocElabM α) (st
   | .error e => throw (.error (← getRef) e)
   | .ok stx => DocElabM.withFileMap (.ofString str) <| do
     if let `(doc_metavar|$pat:term : $ty:term) := stx then
-      let (newMsgs, tree, e') ← do
+      let (newMsgs, tree, e') ← show TermElabM _ from do
         let initMsgs ← Core.getMessageLog
         try
           Core.resetMessageLog
@@ -1167,7 +1167,7 @@ def tryElabInlineCode (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords :
       tryElabInlineCodeTerm,
       tryElabInlineCodeMetavarTerm,
       tryTacticName allTactics,
-      withReader (fun ctx => {ctx with autoBoundImplicit := true}) ∘ tryElabInlineCodeTerm,
+      withTheReader Term.Context (fun ctx => {ctx with autoBoundImplicit := true}) ∘ tryElabInlineCodeTerm,
       tryElabInlineCodeTerm (ignoreElabErrors := true),
       tryHighlightKeywords extraKeywords
     ]
@@ -1194,7 +1194,7 @@ def tryElabBlockCode (str : String) : DocElabM Term := do
       tryElabBlockCodeCommand,
       tryElabBlockCodeTerm,
       tryElabBlockCodeCommand (ignoreElabErrors := true),
-      withReader (fun ctx => {ctx with autoBoundImplicit := true}) ∘
+      withTheReader Term.Context (fun ctx => {ctx with autoBoundImplicit := true}) ∘
         tryElabBlockCodeTerm (ignoreElabErrors := true)
     ]
   catch
@@ -1245,7 +1245,7 @@ def blockFromMarkdownWithLean (names : List Name) (b : MD4Lean.Block) : DocElabM
             if let some n := isAutoBoundImplicitLocalException? e then
               s.restore (restoreInfo := true)
               Meta.withLocalDecl n .implicit (← Meta.mkFreshTypeMVar) fun x =>
-                withReader (fun ctx => { ctx with autoBoundImplicits := ctx.autoBoundImplicits.push x } ) do
+                withTheReader Term.Context (fun ctx => { ctx with autoBoundImplicits := ctx.autoBoundImplicits.push x } ) do
                   loop k (← (saveState : TermElabM _))
             else throw e
         | 0 => throwError "Ran out of local name attempts"

--- a/src/verso/Verso/Doc/Concrete.lean
+++ b/src/verso/Verso/Doc/Concrete.lean
@@ -223,7 +223,10 @@ elab (name := completeDoc) "#doc" "(" genre:term ")" title:inlineStr "=>" text:c
         let docName := mkIdentFrom title n
         let titleStr : TSyntax ``Lean.Parser.Command.docComment := quote titleString
         elabCommand (← `($titleStr:docComment def $docName : Part $genre := $(← finished.toSyntax' genre st'.linkDefs st'.footnoteDefs))))
-      (handleStep := (partCommand ⟨·⟩))
+      -- The heartbeat count is reset for each top-level Verso block because they are analogous to Lean commands.
+      (handleStep := fun block => do
+        let heartbeats ← IO.getNumHeartbeats
+        withTheReader Core.Context ({· with initHeartbeats := heartbeats}) (partCommand ⟨block⟩))
       (run := fun act => liftTermElabM <| Prod.fst <$> PartElabM.run {} initState act)
 
 /--

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -312,6 +312,10 @@ instance : MonadFinally PartElabM := inferInstanceAs <| MonadFinally (StateT Doc
 
 instance : MonadRef PartElabM := inferInstanceAs <| MonadRef (StateT DocElabM.State (StateT PartElabM.State TermElabM))
 
+instance : MonadWithReaderOf Core.Context PartElabM := inferInstanceAs <| MonadWithReaderOf Core.Context (StateT DocElabM.State (StateT PartElabM.State TermElabM))
+
+instance : MonadWithReaderOf Term.Context PartElabM := inferInstanceAs <| MonadWithReaderOf Term.Context (StateT DocElabM.State (StateT PartElabM.State TermElabM))
+
 def PartElabM.withFileMap (fileMap : FileMap) (act : PartElabM α) : PartElabM α :=
   fun ρ σ ctxt σ' mctxt rw cctxt => act ρ σ ctxt σ' mctxt rw {cctxt with fileMap := fileMap}
 
@@ -347,8 +351,6 @@ instance : MonadExceptOf Exception DocElabM := inferInstanceAs <| MonadExceptOf 
 
 instance : MonadAlwaysExcept Exception DocElabM := inferInstanceAs <| MonadAlwaysExcept Exception (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
 
-instance : MonadReader PartElabM.State DocElabM := inferInstanceAs <| MonadReader PartElabM.State (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
-
 instance : MonadReaderOf PartElabM.State DocElabM := inferInstanceAs <| MonadReaderOf PartElabM.State (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
 
 instance : MonadStateOf DocElabM.State DocElabM := inferInstanceAs <| MonadStateOf DocElabM.State (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
@@ -364,6 +366,12 @@ instance : MonadFileMap DocElabM := inferInstanceAs <| MonadFileMap (ReaderT Par
 instance : MonadOptions DocElabM := inferInstanceAs <| MonadOptions (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
 
 instance : MonadWithOptions DocElabM := inferInstanceAs <| MonadWithOptions (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
+
+instance : MonadWithReaderOf Core.Context DocElabM := inferInstanceAs <| MonadWithReaderOf Core.Context (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
+
+instance : MonadWithReaderOf Term.Context DocElabM := inferInstanceAs <| MonadWithReaderOf Term.Context (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
+
+instance : MonadReader PartElabM.State DocElabM := inferInstanceAs <| MonadReader PartElabM.State (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
 
 def DocElabM.withFileMap (fileMap : FileMap) (act : DocElabM α) : DocElabM α :=
   fun ρ σ ctxt σ' mctxt rw cctxt => act ρ σ ctxt σ' mctxt rw {cctxt with fileMap := fileMap}


### PR DESCRIPTION
This better reflects the fact that each Verso block is roughly equivalent to a Lean command. Asking the entire document to stay within heartbeat limits doesn't make so much sense.