### PR TITLE
fix: represent parsed arguments as Lean syntax expects

### DIFF
--- a/src/verso/Verso/Doc/Elab.lean
+++ b/src/verso/Verso/Doc/Elab.lean
@@ -71,9 +71,9 @@ def _root_.Verso.Syntax.bold.expand : InlineExpander
 
 def parseArgVal (val : TSyntax `arg_val) : DocElabM ArgVal := do
   match val with
-  | `($s:str) => pure <| .str s
-  | `($x:ident) => pure <| .name x
-  | `($n:num) => pure <| .num n
+  | `(arg_val|$s:str) => pure <| .str s
+  | `(arg_val|$x:ident) => pure <| .name x
+  | `(arg_val|$n:num) => pure <| .num n
   | other => throwErrorAt other "Can't decode argument value '{repr other}'"
 
 def parseArgs (argStx : TSyntaxArray `argument) : DocElabM (Array Arg) := do


### PR DESCRIPTION
This allows Verso metaprograms to use quasiquotes correctly.