### PR TITLE
feat: improve legibility

### DIFF
--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -90,6 +90,7 @@ h1, h2, h3, h4, h5, h6 {
 
 p, dt, dd {
     font-family: var(--verso-text-font-family);
+    line-height: 1.45;
 }
 
 dt {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -20,7 +20,7 @@ def pageStyle : String := r####"
     /* What's the maximum line width, for legibility? */
     --verso-content-max-width: 45rem;
     /* Desktop font size */
-    --verso-font-size: 18px;
+    --verso-font-size: 16px;
     /* Mobile font size */
     --verso-mobile-font-size: 16px;
 


### PR DESCRIPTION
The intention here is to improve legibility of the reference manual and other texts that will be generated from verso.

> feat: reduce font size on desktop
> 
> Since we use `rem` almost everywhere, the effect on the whole page is
> that it is slightly zoomed out. It doesn't increase the number of
> characters per line.
> 
> 16px is taken from MDN, the rust book, and stack overflow. It is the
> most common font size on the web.

> feat: increase line-height for body content
> 
> I investigated line heights from MDN and the rust book, and picked the
> lesser one out of caution. To me, it increases legibility.