### PR TITLE
fix: show accurate progress bar during incremental elaboration

### DIFF
--- a/src/verso/Verso/Doc/Elab/Incremental.lean
+++ b/src/verso/Verso/Doc/Elab/Incremental.lean
@@ -154,7 +154,8 @@ def incrementallyElabCommand
           «syntax» := cmd
         }
         initAct
-        for b in steps do
+        for h : i in [0:steps.size] do
+          let b := steps[i]
           let mut reuseState := false
           if let some oldSnap := oldSnap? then
             if let some next := oldSnap.next then
@@ -180,7 +181,7 @@ def incrementallyElabCommand
           nextPromise.resolve {
             underlying := (← freshSnapshot),
             dynData := (.mk <| mkSnap <| updatedState.result?),
-            next := (some {stx? := some b, task := nextNextPromise.result?})
+            next := (some {stx? := some (mkNullNode <| steps.extract i steps.size), task := nextNextPromise.result?})
             «syntax» := b
           }
 


### PR DESCRIPTION
With the advent of parallelism, the progress bar now shows the union of the child nodes' spans. This is a quick fix to have the next child be the rest of the file; once Verso gets proper parallel elaboration, this will no longer suffice.