### PR TITLE
feat: several style changes for verso manuals

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -458,9 +458,16 @@ def docstringStyle := r#"
 }
 
 .namedocs .text {
+  /* Causes margins on child elements to collapse inside the element, such
+     that the margins don't extend into parent with the background color.
+     The effect is that weird borders in the definition box don't happen anymore. */
+  display: flow-root;
   background-color: white;
-  padding: 1.5rem;
-  margin-top: 0.5rem;
+  /* If there is no text, still show a white box. */
+  min-height: 3rem;
+  /* Add a padding. this is the same as the margin applied to the first and last child.
+     The effect is that the padding looks the same size on all sides. */
+  padding: 0 1.5rem;
 }
 
 .namedocs .text > pre {
@@ -526,6 +533,13 @@ def docstringStyle := r#"
   padding-left: 1rem;
 }
 
+/* These margins work together with the padding on .text */
+.namedocs .text > :first-child {
+  margin-top: 1.5rem;
+}
+.namedocs .text > :last-child {
+  margin-bottom: 1.5rem;
+}
 
 .namedocs .methods td, .namedocs .fields td {
   vertical-align: top;

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -476,7 +476,6 @@ def docstringStyle := r#"
 
 .namedocs .signature {
   font-family: var(--verso-code-font-family);
-  font-size: larger;
   margin-top: 0 !important;
   margin-left: 1.5rem !important;
   margin-right: 1.5rem;

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -557,7 +557,7 @@ def page
         <div class="with-toc">
           <div class="toc-backdrop" onclick="document.getElementById('toggle-toc-click')?.click()"></div>
           <nav id="toc">
-            <input type="checkbox" id="toggle-toc" checked="checked"/>
+            <input type="checkbox" id="toggle-toc" />
             <div class="first">
               {{if showNavButtons then toc.navButtons path else .empty}}
               {{toc.localHtml path localItems}}

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -540,6 +540,15 @@ def page
         {{extraHead}}
       </head>
       <body>
+        <header>
+          {{if let some url := logo then
+              let logoHtml := {{<img src={{url}}/>}}
+              let logoDest :=
+                if let some root := logoLink then root
+                else "/"
+              {{<a href={{logoDest}} id="logo">{{logoHtml}}</a>}}
+            else .empty }}
+        </header>
         <label for="toggle-toc" id="toggle-toc-click">
           <span class="line line1"/>
           <span class="line line2"/>
@@ -550,13 +559,6 @@ def page
           <nav id="toc">
             <input type="checkbox" id="toggle-toc" checked="checked"/>
             <div class="first">
-              {{if let some url := logo then
-                  let logoHtml := {{<img src={{url}}/>}}
-                  let logoDest :=
-                    if let some root := logoLink then root
-                    else "/"
-                  {{<a href={{logoDest}} id="logo">{{logoHtml}}</a>}}
-                else .empty }}
               {{if showNavButtons then toc.navButtons path else .empty}}
               {{toc.localHtml path localItems}}
             </div>

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -134,6 +134,12 @@ header {
     margin-top: var(--verso-header-height);
 }
 
+main [id] {
+  /* When jumping to something, display it below the header. We also add a little
+     whitespace, so it's easier to see that you are indeed viewing the whole item. */
+  scroll-margin-top: calc(var(--verso-header-height) + 1rem);
+}
+
 .with-toc #toc {
     position: fixed;
     z-index: 10;

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -24,6 +24,11 @@ def pageStyle : String := r####"
     /* Mobile font size */
     --verso-mobile-font-size: 16px;
 
+    /** Header appearance */
+    --verso-header-height: 3rem;
+    /* Height of the displayed logo */
+    --verso-logo-height: var(--verso-header-height);
+
     /** Table of Contents appearance **/
     --verso-toc-background-color: #fafafa;
     --verso-toc-text-color: black;
@@ -109,6 +114,25 @@ pre, code {
 }
 
 /******** Page Layout ********/
+
+header {
+	position: fixed;
+	top: 0;
+	z-index: 99;
+	left: 0;
+	right: 0;
+	background: white;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	height: var(--verso-header-height);
+	box-shadow: 0 0px 6px lightgray;
+    padding: 0 .5rem;
+}
+
+.with-toc {
+    margin-top: var(--verso-header-height);
+}
 
 .with-toc #toc {
     position: fixed;
@@ -389,19 +413,13 @@ pre, code {
 }
 
 #logo {
-  max-width: min(80%, calc(100% - calc(var(--verso-burger-width) + 1rem)));
-  max-height: 4rem;
+  max-height: 100%;
   display: block;
-  margin-left: auto;
-  margin-right: 0.5rem;
-  transition: height var(--verso-toc-transition-time) ease-in-out;
 }
 
 #logo img {
   object-fit: contain;
-  max-width: 100%;
-  max-height: 4rem;
-  margin-left: auto;
+  max-height: var(--verso-logo-height);
   display: block;
 }
 

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -130,6 +130,10 @@ header {
     padding: 0 .5rem;
 }
 
+:root:has(header:empty) {
+    --verso-header-height: 0px;
+}
+
 .with-toc {
     margin-top: var(--verso-header-height);
 }

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -12,9 +12,9 @@ def pageStyle : String := r####"
 :root {
     /** Typography **/
     /* The font family used for headers, ToC entries, etc */
-    --verso-structure-font-family: "Helvetica Neue","Segoe UI",Arial,sans-serif;
+    --verso-structure-font-family: "Helvetica Neue","Segoe UI", "Roboto", Arial,sans-serif;
     /* The font family used for body text */
-    --verso-text-font-family: Georgia, Times, "Times New Roman", serif;
+    --verso-text-font-family: "Helvetica Neue","Segoe UI", "Roboto", Arial,sans-serif;
     /* The font family used for code */
     --verso-code-font-family: monospace;
     /* What's the maximum line width, for legibility? */

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -680,31 +680,3 @@ main .section-toc a:hover {
 }
 
 "####
-
-def pageStyleJs : String := r####"
-function saveCheckboxesInit() {
-  for (checkbox of document.querySelectorAll('#toc input[type="checkbox"]')) {
-    const value = localStorage.getItem(checkbox.id);
-
-    // Treat the ToC toggle specially, because it should always default to
-    // closed on mobile-width screens but respect user preference on desktop-width.
-    if (checkbox.id === "toggle-toc" && window.matchMedia("(max-width: 700px)").matches) {
-        checkbox.checked = false;
-    } else if (value === "true") {
-        checkbox.checked = true;
-    } else if (value === "false") {
-        checkbox.checked = false;
-    } // if not found, do nothing
-
-    checkbox.addEventListener("change", persistCheckbox);
-  }
-}
-
-function persistCheckbox() {
-  const value = this.checked; // in a handler, 'this' is the element with the handler on it
-  const id = this.id;
-  localStorage.setItem(this.id, value ? "true" : "false");
-}
-
-window.addEventListener("DOMContentLoaded", saveCheckboxesInit);
-"####

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -199,6 +199,7 @@ main [id] {
     #toc {
         /* Push the toc off the page on mobile */
         right: 100%;
+        transition: transform var(--verso-toc-transition-time) ease;
     }
 
     #toc:has(#toggle-toc:checked) {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -169,7 +169,10 @@ header {
         display: block;
     }
     body:has(#toggle-toc:checked) .toc-backdrop {
-        position: fixed; inset: 0; background-color: #aaa8; z-index: 9;
+        position: fixed;
+        inset: 0;
+        background-color: #aaa8;
+        z-index: 9;
     }
     html:has(#toggle-toc:checked) {
         overflow: hidden;
@@ -408,14 +411,14 @@ header {
 }
 
 #logo {
-  max-height: 100%;
-  display: block;
+    max-height: 100%;
+    display: block;
 }
 
 #logo img {
-  object-fit: contain;
-  max-height: var(--verso-logo-height);
-  display: block;
+    object-fit: contain;
+    max-height: var(--verso-logo-height);
+    display: block;
 }
 
 /******** Headerline ********/

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -186,26 +186,14 @@ header {
     width: var(--verso-toc-width);
 }
 
-
-#toc {
-    /* Here, the width transition is delayed until after the translation has pushed
-       the ToC off the screen. */
-    transition: transform var(--verso-toc-transition-time) ease, width 0.1s linear var(--verso-toc-transition-time);
-    transform: translateX(-20rem);
-}
-
-#toc:has(#toggle-toc:checked) {
-    /* Here, the width transition must happen first, before the translation animation,
-       so the translation is delayed.
-     */
-    transition: transform var(--verso-toc-transition-time) ease 0.1s, width 0.1s linear;
-    transform: translateX(0);
-}
-
-/* Disable ToC transition on mobile */
 @media screen and (max-width: 700px) {
-    #toc, #toc:has(#toggle-toc:checked) {
-        transition: none;
+    #toc {
+        /* Push the toc off the page on mobile */
+        right: 100%;
+    }
+
+    #toc:has(#toggle-toc:checked) {
+        transform: translateX(var(--verso-toc-width));
     }
 }
 
@@ -360,13 +348,20 @@ header {
 }
 
 #local-buttons {
-    margin-top: 2.5rem;
+    margin-top: 1rem;
     font-weight: bold;
     font-family: var(--verso-structure-font-family);
     display: flex;
     justify-content: space-between;
     margin-left: 0.5rem;
     margin-right: 0.5rem
+}
+
+@media screen and (max-width: 700px) {
+    /* Make room for the toggle button on mobile */
+    #local-buttons {
+        margin-top: 2.5rem;
+    }
 }
 
 #local-buttons > * {
@@ -426,28 +421,33 @@ header {
 /******** Headerline ********/
 
 #toggle-toc-click {
-    cursor: pointer;
-    /* This is the default, but it's needed to make the math work out so nice to be explicit: */
-    box-sizing: content-box;
-    width: var(--verso-burger-width);
-    height: var(--verso-burger-height);
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: space-between;
-    padding: 0.5rem;
-    position: fixed;
-    z-index: 100; /* Show on top of ToC/content */
-    filter: drop-shadow(1px 1px var(--verso-burger-toc-hidden-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-hidden-shadow-color));
-    transition:
-        height var(--verso-toc-transition-time) ease-in-out,
-        width var(--verso-toc-transition-time) ease-in-out;
-}
-
-body:has(#toggle-toc:checked) #toggle-toc-click {
-    filter: drop-shadow(1px 1px var(--verso-burger-toc-visible-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-visible-shadow-color));
+    /* Hidden on desktop */
+    display: none;
 }
 
 @media screen and (max-width: 700px) {
+    #toggle-toc-click {
+        display: inline-flex;
+        cursor: pointer;
+        /* This is the default, but it's needed to make the math work out so nice to be explicit: */
+        box-sizing: content-box;
+        width: var(--verso-burger-width);
+        height: var(--verso-burger-height);
+        flex-direction: column;
+        justify-content: space-between;
+        padding: 0.5rem;
+        position: fixed;
+        z-index: 100; /* Show on top of ToC/content */
+        filter: drop-shadow(1px 1px var(--verso-burger-toc-hidden-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-hidden-shadow-color));
+        transition:
+            height var(--verso-toc-transition-time) ease-in-out,
+            width var(--verso-toc-transition-time) ease-in-out;
+    }
+
+    body:has(#toggle-toc:checked) #toggle-toc-click {
+        filter: drop-shadow(1px 1px var(--verso-burger-toc-visible-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-visible-shadow-color));
+    }
+
     body {
         --verso-burger-width: var(--verso-mobile-burger-width);
         --verso-burger-height: var(--verso-mobile-burger-height);

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -185,7 +185,7 @@ header {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    height: 100dvh;
+    height: calc(100dvh - var(--verso-header-height));
     width: var(--verso-toc-width);
 }
 

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -470,10 +470,24 @@ where
       font-family: var(--verso-structure-font-family);
     }
 
+    main .theIndex [id] {
+      /* This needs the combined height of the index header and the page header. We
+         know the height of the page header, but the index header height varies, so
+         we use the maximum height it gets which also works well for readers with
+         wide screens */
+      scroll-margin-top: calc(var(--verso-header-height) + 7.5rem);
+    }
+
     @media screen and (max-width: 700px) {
       /* On mobile, the sticky index takes up half the screen. */
       main .theIndex nav {
         position: static;
+      }
+
+      main .theIndex [id] {
+        /* On mobile, the index header is not sticky, so we just need to
+        be below the page header. */
+        scroll-margin-top: var(--verso-header-height);
       }
     }
 

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -465,7 +465,7 @@ where
 
     main .theIndex nav {
       position: sticky;
-      top: 0;
+      top: var(--verso-header-height);
       background: white;
       font-family: var(--verso-structure-font-family);
     }

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -468,7 +468,6 @@ where
       top: 0;
       background: white;
       font-family: var(--verso-structure-font-family);
-      font-size: 1.25rem;
     }
 
     main .theIndex nav ol {

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -522,17 +522,9 @@ where
     main .theIndex .division > ol {
       padding-left: 0;
       display: flex;
-      flex-wrap: wrap;
-      gap: 2rem 3rem;
+      flex-direction: column;
+      gap: 1rem;
       overflow-wrap: break-word;
-    }
-
-    @media screen and (max-width: 700px) {
-      main .theindex .division > ol {
-        flex-direction: column;
-        flex-wrap: nowrap;
-        gap: 1rem;
-      }
     }
 
    main .theIndex .division > ol > li {

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -470,6 +470,13 @@ where
       font-family: var(--verso-structure-font-family);
     }
 
+    @media screen and (max-width: 700px) {
+      /* On mobile, the sticky index takes up half the screen. */
+      main .theIndex nav {
+        position: static;
+      }
+    }
+
     main .theIndex nav ol {
       padding: 0;
     }


### PR DESCRIPTION
This has a bunch of ideas related to issues https://github.com/leanprover/reference-manual/issues/316 , https://github.com/leanprover/reference-manual/issues/317 , https://github.com/leanprover/reference-manual/issues/318 , and https://github.com/leanprover/reference-manual/issues/319 .

It builds on top of the sans-serif pull request, so this is the combined changes.

Items addressed:

   - Add a fixed header
   - Reduce font size on desktop
   - Increase line height for body content
   - Make margins on all sides of definition boxes the same size.
   - Decrease the font size of the definition header text
   - Reduce index header font size
   - Make the index header not stick on mobile
   - Make the index always single-column
   - Disable toc hide/show on desktop

I'll add more tomorrow.