### PR TITLE
Small UI fixes

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -463,8 +463,6 @@ def docstringStyle := r#"
      The effect is that weird borders in the definition box don't happen anymore. */
   display: flow-root;
   background-color: white;
-  /* If there is no text, still show a white box. */
-  min-height: 3rem;
   /* Add a padding. this is the same as the margin applied to the first and last child.
      The effect is that the padding looks the same size on all sides. */
   padding: 0 1.5rem;

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -537,7 +537,7 @@ where
       padding-left: 0;
       display: flex;
       flex-direction: column;
-      gap: 1rem;
+      gap: .5rem;
       overflow-wrap: break-word;
     }
 


### PR DESCRIPTION
This fixes two minor UI things. It makes the distance between index elements smaller, and removes the white box in empty definition boxes.

Before:

<img width="343" alt="Screenshot 2025-03-08 at 08 34 20" src="https://github.com/user-attachments/assets/400831ba-b5ce-4010-944e-e3157708922e" />

After:

<img width="330" alt="Screenshot 2025-03-08 at 08 34 26" src="https://github.com/user-attachments/assets/c23c2f11-77f7-4f2e-93d8-eca2d5e3209d" />

And the definition boxes. Before:

<img width="750" alt="Screenshot 2025-03-08 at 08 35 22" src="https://github.com/user-attachments/assets/35be9a37-d808-48a0-a39e-9465c86abdb5" />

After:

<img width="779" alt="Screenshot 2025-03-08 at 08 35 35" src="https://github.com/user-attachments/assets/b6be5339-598b-4735-98ab-38186fce8960" />
