### PR TITLE
Put the title in the header for manuals built on Verso

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,24 @@ try to make the system more extensible.
 
 To generate the Verso documentation for Verso itself, run `generate.sh`.
 
+### Customization of manuals built with Verso
+
+To change the point at which the title moves from the header bar to
+the ToC, add something like the following css to your theme file.
+
+```css
+/* Move the title from the header to the toc when there is not enough room. */
+@media screen and (max-width: 1200px) {
+  .toc-title {
+    display: block;
+  }
+
+  .header-title {
+    display: none;
+  }
+}
+```
+
 ## Highlighted Lean Code in Verso
 
 Because Lean's parser is extensible, regular-expression-based syntax

--- a/README.md
+++ b/README.md
@@ -58,10 +58,12 @@ try to make the system more extensible.
 
 To generate the Verso documentation for Verso itself, run `generate.sh`.
 
-### Customization of manuals built with Verso
+### Customization of Manual Genre HTML
 
-To change the point at which the title moves from the header bar to
-the ToC, add something like the following css to your theme file.
+The title of the book being written in the manual genre is displayed either
+at the top of the screen or in the table of contents, depending on screen
+width. Books with very long titles may wish to change the threshold at which
+this occurs using the following CSS:
 
 ```css
 /* Move the title from the header to the toc when there is not enough room. */
@@ -75,6 +77,10 @@ the ToC, add something like the following css to your theme file.
   }
 }
 ```
+
+Vary the value `1200px` until there's space for the title. This CSS should be
+saved in a served static file and added to the `extraCss` field in the `config`
+parameter to `manualMain`.
 
 ## Highlighted Lean Code in Verso
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ this occurs using the following CSS:
   .header-title {
     display: none;
   }
+
+  /* Hide the header bar if there is no logo, the title is hidden, and no other elements have been added to it */
+  :root:has(header > .header-logo-wrapper:empty):has(header > .header-title-wrapper:last-child:nth-child(2)) {
+    --verso-header-height: 0px;
+  }
 }
 ```
 

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -293,7 +293,7 @@ def page (toc : List Html.Toc)
   let toc := {
     title := htmlBookTitle, path := #[], id := "" , sectionNum := some #[], children := toc
   }
-  Html.page toc path textTitle htmlTitle contents
+  Html.page toc path textTitle htmlTitle htmlBookTitle contents
     state.extraCss (state.extraJs.insertMany extraJs)
     (showNavButtons := showNavButtons)
     (base := config.baseURL)

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -501,7 +501,10 @@ r#"(function(){
 
 def page
     (toc : Toc) (path : Path)
-    (textTitle : String) (htmlTitle : Html) (contents : Html)
+    (textTitle : String)
+    (htmlTitle : Html)
+    (bookTitle : Html)
+    (contents : Html)
     (extraCss : HashSet String)
     (extraJs : HashSet String)
     (localItems : Array Html)
@@ -550,8 +553,7 @@ def page
               else .empty }}
           </div>
           <div class="header-title-wrapper">
-            -- TODO should be checked by someone better at lean. At least the title should be 'the title of the book', but I don't know where to find that.
-            <a href={{if let some dest := logoLink then dest else "/"}} class="header-title"><h1>"The Lean Language Reference"</h1></a>
+            <a href={{if let some dest := logoLink then dest else "/"}} class="header-title"><h1>{{bookTitle}}</h1></a>
           </div>
         </header>
         <label for="toggle-toc" id="toggle-toc-click">
@@ -563,9 +565,8 @@ def page
           <div class="toc-backdrop" onclick="document.getElementById('toggle-toc-click')?.click()"></div>
           <nav id="toc">
             <input type="checkbox" id="toggle-toc" />
-            -- TODO same as above
-            <a href={{if let some dest := logoLink then dest else "/"}} class="toc-title"><h1>"The Lean Language Reference"</h1></a>
             <div class="first">
+              <a href={{if let some dest := logoLink then dest else "/"}} class="toc-title"><h1>{{bookTitle}}</h1></a>
               {{if showNavButtons then toc.navButtons path else .empty}}
               {{toc.localHtml path localItems}}
             </div>

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -416,7 +416,7 @@ where
           }}
           {{«section»}}
           <span class={{if thisPage && !isTop then "current" else ""}}>
-            {{title}}
+            {{if isTop then "Table of Contents" else title}}
           </span>
         </div>
         {{if let some children := children then children
@@ -540,13 +540,19 @@ def page
       </head>
       <body>
         <header>
-          {{if let some url := logo then
-              let logoHtml := {{<img src={{url}}/>}}
-              let logoDest :=
-                if let some root := logoLink then root
-                else "/"
-              {{<a href={{logoDest}} id="logo">{{logoHtml}}</a>}}
-            else .empty }}
+          <div class="header-logo-wrapper">
+            {{if let some url := logo then
+                let logoHtml := {{<img src={{url}}/>}}
+                let logoDest :=
+                  if let some root := logoLink then root
+                  else "/"
+                {{<a href={{logoDest}} id="logo">{{logoHtml}}</a>}}
+              else .empty }}
+          </div>
+          <div class="header-title-wrapper">
+            -- TODO should be checked by someone better at lean. At least the title should be 'the title of the book', but I don't know where to find that.
+            <a href={{if let some dest := logoLink then dest else "/"}} class="header-title"><h1>"The Lean Language Reference"</h1></a>
+          </div>
         </header>
         <label for="toggle-toc" id="toggle-toc-click">
           <span class="line line1"/>
@@ -557,6 +563,8 @@ def page
           <div class="toc-backdrop" onclick="document.getElementById('toggle-toc-click')?.click()"></div>
           <nav id="toc">
             <input type="checkbox" id="toggle-toc" />
+            -- TODO same as above
+            <a href={{if let some dest := logoLink then dest else "/"}} class="toc-title"><h1>"The Lean Language Reference"</h1></a>
             <div class="first">
               {{if showNavButtons then toc.navButtons path else .empty}}
               {{toc.localHtml path localItems}}

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -123,11 +123,55 @@ header {
 	right: 0;
 	background: white;
 	display: flex;
-	justify-content: space-between;
 	align-items: center;
 	height: var(--verso-header-height);
 	box-shadow: 0 0px 6px lightgray;
-    padding: 0 .5rem;
+    /* This padding is for the search bar. Should probably live with the search bar. */
+    padding-right: .5rem;
+}
+
+.header-logo-wrapper {
+    /* Make the logo always take up the same space as the toc */
+    flex-basis: var(--verso-toc-width);
+    /* Make padding be included in the width calculation */
+    box-sizing: border-box;
+    /* Add padding so it doesn't sit at the very edge of the screen. */
+    padding-left: .5rem;
+}
+
+@media screen and (max-width: 700px) {
+    .header-logo-wrapper {
+        display: none;
+    }
+}
+
+.header-title-wrapper {
+    /* The title wrapper grows to fill up the header */
+    flex: 1;
+    /* And adds the padding of the content */
+    padding-left: var(--verso--content-padding-x);
+}
+
+.header-title {
+    text-decoration: none;
+    color: black;
+    font-size: 2rem;
+    font-weight: bold;
+}
+
+.header-title h1 {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
+    text-wrap: nowrap;
+}
+
+@media screen and (max-width: 1100px) {
+    /* Hide the title, but not the wrapper, on smaller screens. The wrapper is necessary to make the other elements in the header
+       appear in the right place. The 1100 px matches the one on the toc title. */
+    .header-title {
+        display: none;
+    }
 }
 
 :root:has(header:empty) {
@@ -223,6 +267,23 @@ main [id] {
 #toc a:hover {
     text-decoration: underline;
     color: #000;
+}
+
+.toc-title {
+    /* The ToC title is displayed when there is no room for the title in the header. */
+    display: none;
+    padding: 0 .5rem;
+}
+
+.toc-title h1 {
+    margin-bottom: 0;
+}
+
+/* Display the ToC title on smaller screens. The 1100 matches the one on the header title. */
+@media screen and (max-width: 1100px) {
+    .toc-title {
+        display: block;
+    }
 }
 
 #toc .split-tocs {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -172,6 +172,11 @@ header {
     .header-title {
         display: none;
     }
+
+    /* Hide the header if there is no logo, the title is hidden, and no other elements have been added to it */
+    :root:has(header > .header-logo-wrapper:empty):has(header > .header-title-wrapper:last-child:nth-child(2)) {
+        --verso-header-height: 0px;
+    }
 }
 
 :root:has(header:empty) {

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -158,7 +158,7 @@ main [id] {
 /** Mobile **/
 @media screen and (max-width: 700px) {
     .with-toc > main {
-        padding-left: 1.5rem;
+        padding-left: 0;
     }
 }
 
@@ -371,13 +371,6 @@ main [id] {
     margin-right: 0.5rem
 }
 
-@media screen and (max-width: 700px) {
-    /* Make room for the toggle button on mobile */
-    #local-buttons {
-        margin-top: 2.5rem;
-    }
-}
-
 #local-buttons > * {
     width: 4.5rem;
     display: flex;
@@ -452,6 +445,8 @@ main [id] {
         padding: 0.5rem;
         position: fixed;
         z-index: 100; /* Show on top of ToC/content */
+        /* Calculation to make it sit in the middle of the header. The .5rem is the padding added to #toggle-toc-click. */
+        top: calc((var(--verso-header-height) - var(--verso-burger-height) - 2 * .5rem) / 2);
         filter: drop-shadow(1px 1px var(--verso-burger-toc-hidden-shadow-color)) drop-shadow(-1px -1px var(--verso-burger-toc-hidden-shadow-color));
         transition:
             height var(--verso-toc-transition-time) ease-in-out,
@@ -574,6 +569,13 @@ main .authors {
 main > section {
     position: relative;
     padding: var(--verso--content-padding-x);
+}
+
+@media screen and (max-width: 700px) {
+    /* Remove extra margin on mobile. */
+    main > section > :first-child {
+        margin-top: 0;
+    }
 }
 
 main section {


### PR DESCRIPTION
This PR is in draft, because it needs the title of the manual currently being worked on - right now it is hardcoded to "The Lean Language Reference". Other than that, it's ready to go.

The move to the ToC is implemented such that it is easy to overwrite for
dependents. They will need to add the following css to their theme
file:

```css
/* Move the title from the header to the toc when there is not enough room. */
@media screen and (max-width: 1200px) {
  .toc-title {
    display: block;
  }

  .header-title {
    display: none;
  }
}
```