### PR TITLE
feat: prev-next links on the pages

### DIFF
--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -329,13 +329,15 @@ partial def Toc.html (depth : Option Nat) : Toc → Html
 def Toc.navButtons (path : Path) (toc : Toc) : Html :=
   let z := Zipper.followPath toc.onlyPages path
   let prev := z.bind Zipper.prev |>.map (·.focus)
-  let parent := z.bind Zipper.up? |>.map (·.focus)
   let next := z.bind Zipper.next |>.map (·.focus)
   {{
-    <nav id="local-buttons">
-      {{button prev {{<span class="arrow">"←"</span><span class="where">"Prev"</span>}} "prev"}}
-      {{button parent {{<span class="arrow">"↑"</span><span class="where">"Up"</span>}} }}
-      {{button next {{<span class="where">"Next"</span><span class="arrow">"→"</span>}} "next"}}
+    <nav class="prev-next-buttons">
+      {{if let some somePrev := prev
+          then button prev {{<span class="arrow">"←"</span><span class="where">{{getTitle somePrev |>.getD ""}}</span>}} "prev"
+          else .empty}}
+      {{if let some someNext := next
+          then button next {{<span class="where">{{getTitle someNext |>.getD "Next"}}</span><span class="arrow">"→"</span>}} "next"
+          else .empty}}
     </nav>
   }}
 
@@ -558,7 +560,6 @@ def page
           <nav id="toc">
             <input type="checkbox" id="toggle-toc" />
             <div class="first">
-              {{if showNavButtons then toc.navButtons path else .empty}}
               {{toc.localHtml path localItems}}
             </div>
             <div class="last">
@@ -575,7 +576,11 @@ def page
             </div>
           </nav>
           <main>
-            {{contents}}
+            <div class="content-wrapper">
+              {{if showNavButtons then toc.navButtons path else .empty}}
+              {{contents}}
+              {{if showNavButtons then toc.navButtons path else .empty}}
+            </div>
           </main>
         </div>
       </body>

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -361,62 +361,40 @@ main [id] {
   padding-bottom: 0.5rem;
 }
 
-#local-buttons {
-    margin-top: 1rem;
+.prev-next-buttons {
     font-weight: bold;
     font-family: var(--verso-structure-font-family);
     display: flex;
     justify-content: space-between;
-    margin-left: 0.5rem;
-    margin-right: 0.5rem
+    flex-wrap: wrap;
+    max-width: var(--verso-content-max-width);
 }
 
-@media screen and (max-width: 700px) {
-    /* Make room for the toggle button on mobile */
-    #local-buttons {
-        margin-top: 2.5rem;
-    }
-}
-
-#local-buttons > * {
-    width: 4.5rem;
+.prev-next-buttons > * {
     display: flex;
+    flex-grow: 1;
     justify-content: center;
     align-items: center;
+    color: black;
+    text-decoration: none;
 }
 
-#local-buttons .local-button .where {
+.prev-next-buttons > [rel=prev] {
+    justify-content: start;
+}
+
+.prev-next-buttons > [rel=next] {
+    justify-content: end;
+}
+
+.prev-next-buttons .local-button .where {
     margin: 0 0.3rem;
+    /* Fix the position relative to the arrows. */
+    position: relative;
+    top: 0.1rem;
 }
 
-.local-button.active {
-    color: var(--verso-toc-text-color);
-    border: 1px solid var(--verso-toc-background-color);
-}
-
-.local-button.inactive {
-    color: color-mix(in srgb, var(--verso-toc-text-color), var(--verso-toc-background-color));
-    border: 1px solid var(--verso-toc-background-color);
-    cursor: default;
-}
-
-
-#local-buttons a.local-button.active {
-    text-decoration: none;
-}
-
-#local-buttons a.local-button.active:hover {
-    text-decoration: none;
-    background-color: color-mix(in srgb, white, var(--verso-toc-background-color));
-    border-color: color-mix(in srgb, var(--verso-toc-text-color) 30%, var(--verso-toc-background-color) 70%);
-}
-
-#local-buttons .local-button.inactive:hover {
-
-}
-
-
-#local-buttons .arrow {
+.prev-next-buttons .arrow {
     font-family: var(--verso-code-font-family);
     font-size: 150%;
 }
@@ -571,9 +549,14 @@ main .authors {
     text-align: center;
 }
 
+/******** Main content ********/
+
+.content-wrapper {
+    padding: var(--verso--content-padding-x);
+}
+
 main > section {
     position: relative;
-    padding: var(--verso--content-padding-x);
 }
 
 main section {


### PR DESCRIPTION
Moves next/previous buttons to the content part of the page. This provides for nicer ergonomics, because it feels more like turning pages in a book, and you can also see what the next chapter is directly.

Closes https://github.com/leanprover/reference-manual/issues/322.

<img width="1740" alt="Screenshot 2025-03-08 at 14 25 09" src="https://github.com/user-attachments/assets/aabf4970-a7e4-4c79-93d9-ad8152ad97fd" />
<img width="1740" alt="Screenshot 2025-03-08 at 14 25 17" src="https://github.com/user-attachments/assets/8e6d0e70-9cee-40d4-9f7d-eb3b9a8f48e2" />

![Screen Shot 2025-03-08 at 14 25 34](https://github.com/user-attachments/assets/dd3f7898-5ea1-46c3-883b-255a6343c322)
