### PR TITLE
fix: don't hide the header bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ To generate the Verso documentation for Verso itself, run `generate.sh`.
 
 ### Customization of Manual Genre HTML
 
-The title of the book being written in the manual genre is displayed either
-at the top of the screen or in the table of contents, depending on screen
-width. Books with very long titles may wish to change the threshold at which
-this occurs using the following CSS:
+The title of the book being written in the manual genre can be displayed
+either at the top of the screen or in the table of contents, depending on
+screen width. Books with long titles may wish to add a threshold at which
+the title moves to the table of contents using the following CSS:
 
 ```css
 /* Move the title from the header to the toc when there is not enough room. */
@@ -74,13 +74,6 @@ this occurs using the following CSS:
 
   .header-title {
     display: none;
-  }
-
-  @media screen and (min-width: 1200px) {
-    /* Hide the header bar if there is no logo, no "burger menu", the title is hidden, and no other elements have been added to it */
-    :root:has(header > .header-logo-wrapper:empty):has(header > .header-title-wrapper:last-child:nth-child(2)) {
-      --verso-header-height: 0px;
-    }
   }
 }
 ```

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -166,20 +166,6 @@ header {
     text-wrap: nowrap;
 }
 
-@media screen and (max-width: 1100px) {
-    /* Hide the title, but not the wrapper, on smaller screens. The wrapper is necessary to make the other elements in the header
-       appear in the right place. The 1100 px matches the one on the toc title. */
-    .header-title {
-        display: none;
-    }
-    @media screen and (min-width: 700px) {
-        /* Hide the header if there is no logo, no burger, the title is hidden, and no other elements have been added to it */
-        :root:has(header > .header-logo-wrapper:empty):has(header > .header-title-wrapper:last-child:nth-child(2)) {
-            --verso-header-height: 0px;
-        }
-    }
-}
-
 :root:has(header:empty) {
     --verso-header-height: 0px;
 }
@@ -276,20 +262,13 @@ main [id] {
 }
 
 .toc-title {
-    /* The ToC title is displayed when there is no room for the title in the header. */
+    /* The ToC title can be displayed when there is no room for the title in the header. */
     display: none;
     padding: 0 .5rem;
 }
 
 .toc-title h1 {
     margin-bottom: 0;
-}
-
-/* Display the ToC title on smaller screens. The 1100 matches the one on the header title. */
-@media screen and (max-width: 1100px) {
-    .toc-title {
-        display: block;
-    }
 }
 
 #toc .split-tocs {


### PR DESCRIPTION
These changes make it so that the title doesn't move from the header bar to the table of contents by default. This means that some books will have an overflowing header on small devices by default, but it will be easy to notice and it is easy to fix.

The header bar needs to always be displayed, because that's where the menu button lives. For books with long titles and no logo, who set the boundary higher than 700px, this will cause the header bar to be empty from 700px to the set width. I don't expect this to be a problem until we move the quick jump from the reference manual to Verso, but then the header bar also won't be empty anymore.