### PR TITLE
fix: revert to font defaults for wavy underline thicknesses

### DIFF
--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -548,7 +548,7 @@ def highlightingStyle : String := "
 .hl.lean .has-info {
   text-decoration-style: wavy;
   text-decoration-line: underline;
-  text-decoration-thickness: 0.1rem;
+  text-decoration-thickness: from-font;
 }
 
 .hl.lean .has-info .hover-info {


### PR DESCRIPTION
This fixes issues with them getting cut off.