### PR TITLE
fix: prev-next buttons always take up exactly half the screen

### DIFF
--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -334,10 +334,10 @@ def Toc.navButtons (path : Path) (toc : Toc) : Html :=
     <nav class="prev-next-buttons">
       {{if let some somePrev := prev
           then button prev {{<span class="arrow">"←"</span><span class="where">{{getTitle somePrev |>.getD ""}}</span>}} "prev"
-          else .empty}}
+          else {{<div></div>}}}}
       {{if let some someNext := next
           then button next {{<span class="where">{{getTitle someNext |>.getD "Next"}}</span><span class="arrow">"→"</span>}} "next"
-          else .empty}}
+          else {{<div></div>}}}}
     </nav>
   }}
 

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -418,7 +418,7 @@ main [id] {
 
 .prev-next-buttons > * {
     display: flex;
-    flex-grow: 1;
+    flex: 1;
     justify-content: center;
     align-items: center;
     color: black;


### PR DESCRIPTION
This fixes two issues:

- The first and last pages of the book, the next/previous button would take up the full width, which was too much.
- On mobile, when flipping through the pages, sometimes the "next" button would move to below the "previous" button, which meant that I accidentally went back a page instead of forwards. Now, their location is consistent.

The drawback is that there will now, on mobile, be more pages where the next/prev buttons span multiple lines. But I think the tradeoff is worth it.