### PR TITLE
fix: code block was overflowing

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -524,6 +524,7 @@ def docstringStyle := r#"
   padding-left: 0.5rem;
   float: left;
   margin-top: 0;
+  max-width: calc(100% - 1rem);
 }
 .namedocs > .text .constructor .docs {
   clear: both;


### PR DESCRIPTION
Before:

![Screen Shot 2025-03-16 at 13 33 10](https://github.com/user-attachments/assets/1c5457b5-bf39-4ef0-98e1-5d309c7094eb)

After:

![Screen Shot 2025-03-16 at 13 33 14](https://github.com/user-attachments/assets/26912f1b-e253-48b0-a0b5-389601c8673b)