### PR TITLE
fix: reduce the content padding on mobile

### DIFF
--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -62,7 +62,13 @@ def pageStyle : String := r####"
 :root {
     /* How much space to add on the sides of content for small screens and to place widgets. */
     --verso--content-padding-x: 1.5rem;
+}
 
+@media screen and (max-width: 700px) {
+  :root {
+    /* Reduce the standard padding on mobile */
+    --verso--content-padding-x: 1rem;
+  }
 }
 
 /******** Root font size - this is what rem is based on *********/


### PR DESCRIPTION
The content padding doesn't need to be as large on mobile as it has to on desktop, which gives us more valuable space for content.