### PR TITLE
feat: allow manual parts to be marked as draft-only

### DIFF
--- a/examples/custom-genre/SimplePage.lean
+++ b/examples/custom-genre/SimplePage.lean
@@ -178,7 +178,7 @@ instance : Traverse SimplePage TraverseM where
     | .inr ⟨dest, some t⟩, _ => do
       modify fun st =>
         {st with
-          refTargets := st.refTargets.insert dest (st.refTargets.getD dest .empty |>.insert t)}
+          refTargets := st.refTargets.insert dest (st.refTargets.getD dest {} |>.insert t)}
       pure none
 
 /-! # Producing Output -/

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2025-03-12
+leanprover/lean4:nightly-2025-03-18

--- a/src/verso-blog/VersoBlog/Basic.lean
+++ b/src/verso-blog/VersoBlog/Basic.lean
@@ -72,7 +72,7 @@ deriving BEq
 
 structure ArchivesMeta where
   /-- The categories used by posts in these archives -/
-  categories : HashMap Post.Category (HashSet Name) := .empty
+  categories : HashMap Post.Category (HashSet Name) := {}
 deriving Repr
 
 instance [BEq α] [Hashable α] : BEq (HashSet α) where

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -204,13 +204,17 @@ instance : ToString Numbering where
 structure PartMetadata where
   authors : List String := []
   date : Option String := none
+  /-- The main tag for the part, used for cross-references. -/
   tag : Option Tag := none
   /-- If this part ends up as the root of a file, use this name for it -/
   file : Option String := none
+  /-- The internal unique ID, assigned during traversal. -/
   id : Option InternalId := none
   /-- Should this section be numbered? If `false`, then it's like `\section*` in LaTeX -/
   number : Bool := true
-  /-- Which number has been assigned? -/
+  /-- If `true`, the part is only rendered in draft mode. -/
+  draft : Bool := false
+  /-- Which number has been assigned? This field is set during traversal. -/
   assignedNumber : Option Numbering := none
   htmlSplit : HtmlSplitMode := .default
 deriving BEq, Hashable, Repr

--- a/src/verso/Verso/Doc/Lsp.lean
+++ b/src/verso/Verso/Doc/Lsp.lean
@@ -520,7 +520,7 @@ where
 
   go (text : FileMap) (stx : Syntax) : Array SemanticTokenEntry := Id.run do
     match stx with
-    | `(inline|$s:str) =>
+    | `(inline|$_s:str) =>
       mkTok text .string stx
     | `(inline|_[%$s $inlines* ]%$e) | `(inline|*[%$s $inlines* ]%$e) =>
       mkTok text .keyword s ++ go text (mkNullNode inlines) ++ mkTok text .keyword e
@@ -630,13 +630,13 @@ where
     -- In the next three cases, no token is returned. This is to allow Lean's to shine through, if
     -- there are any. It would be nice to add a priority mechanism to fall back to these defaults if
     -- Lean didn't provide any.
-    | `(arg_val| $v:num) =>
+    | `(arg_val| $_v:num) =>
       --mkTok text .number v
       #[]
-    | `(arg_val| $v:ident) =>
+    | `(arg_val| $_v:ident) =>
       -- mkTok text .variable v
       #[]
-    | `(arg_val| $v:str) =>
+    | `(arg_val| $_v:str) =>
       -- mkTok text .string v
       #[]
     | _ =>


### PR DESCRIPTION
This suppresses them in non-draft output.