### PR TITLE
feat: finer-grained control over missing docstring errors/warnings

### DIFF
--- a/src/verso-manual/VersoManual/Docstring/Config.lean
+++ b/src/verso-manual/VersoManual/Docstring/Config.lean
@@ -19,6 +19,12 @@ register_option verso.docstring.allowDeprecated : Bool := {
   descr := "Whether to accept documentation for deprecated names"
 }
 
+register_option verso.docstring.allowMissing : Bool := {
+  defValue := false
+  group := "doc"
+  descr := "Whether to accept missing documentation. If false, missing docstrings are errors rather than warnings."
+}
+
 namespace Verso.Genre.Manual.Docstring
 
 def getElabMarkdown [Monad m] [MonadOptions m] : m Bool := do
@@ -26,3 +32,6 @@ def getElabMarkdown [Monad m] [MonadOptions m] : m Bool := do
 
 def getAllowDeprecated [Monad m] [MonadOptions m] : m Bool := do
   return (← getOptions).get verso.docstring.allowDeprecated.name verso.docstring.allowDeprecated.defValue
+
+def getAllowMissing [Monad m] [MonadOptions m] : m Bool := do
+  return (← getOptions).get verso.docstring.allowMissing.name verso.docstring.allowMissing.defValue


### PR DESCRIPTION
This makes it much easier to track progress to a fully-documented manual without empty boxes.