### PR TITLE
fix: several small UI fixes

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -486,6 +486,7 @@ def docstringStyle := r#"
 }
 
 .namedocs .label {
+  display: block;
   font-size: smaller;
   font-family: var(--verso-structure-font-family);
   position: absolute;

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -620,7 +620,7 @@ where
   opacity: 0;
 }
 .namedocs:has(input[data-parent-idx=\"" ++ toString i ++ "\"]:checked) [data-inherited-from=\"" ++ toString i ++"\"] {
-  display: table-row;
+  display: block;
   transform: none;
   opacity: 1;
 }

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -55,6 +55,8 @@ def pageStyle : String := r####"
     --verso-mobile-burger-line-width: 0.3rem;
     --verso-mobile-burger-line-radius: 0.3rem;
 
+    /* Colors */
+    --verso-warning-color: #e7a71d; /* 2.11 contrast ratio for white, 9.94 for black */
 }
 
 /******** Global parameters not intended for customization by themes ********/

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -588,22 +588,22 @@ def highlightingStyle : String := "
 }
 
 .hl.lean .has-info.warning {
-  text-decoration-color: #efd871;
+  text-decoration-color: var(--verso-warning-color);
 }
 
 @media (hover: hover) {
   .hl.lean .has-info.warning:hover {
-    background-color: #efd871;
+    background-color:var(--verso-warning-color);
   }
 }
 
 .hl.lean .hover-info.messages > code.warning {
-  background-color: #efd871;
+  background-color: var(--verso-warning-color);
 }
 
 .hl.lean .hover-info.messages > code.error {
   background-color: #e5e5e5;
-  border-left: 0.2rem solid #efd871;
+  border-left: 0.2rem solid var(--verso-warning-color);
 }
 
 .tippy-box[data-theme~='warning'] .hl.lean .hover-info.messages > code.warning {
@@ -919,7 +919,7 @@ def highlightingStyle : String := "
 .tippy-box[data-theme~='warning'] {
   background-color: #e5e5e5;
   color: black;
-  border: 3px solid #efd871;
+  border: 3px solid var(--verso-warning-color);
 }
 
 .tippy-box[data-theme~='error'] {


### PR DESCRIPTION
fix: display the label consistently over namedocs headers

fix: overflowing code examples, LawfulMonad

I think this is only displayed in a few places, one of them being
`LawfulMonad.{u, v}`. Would it be possible to apply some formatting to
those examples too, so the scrolling becomes unnecessary?

fix: darker warning color (and centralize it)

I picked #E7A71D, as it has 2.11 contrast to white, which should be OK
for visual cues. The previous color was #efd871, which only has 1.42.
See https://webaim.org/resources/contrastchecker/?fcolor=EFD871&bcolor=FFFFFF.