### PR TITLE
feat: structure docstring control

### DIFF
--- a/doc/UsersGuide/Basic.lean
+++ b/doc/UsersGuide/Basic.lean
@@ -73,6 +73,8 @@ They include heuristic elaboration of code items in their Markdown that attempts
 
 {docstring Monad}
 
+{docstring Float (label := "type") (hideFields := true) (hideStructureConstructor := true)}
+
 
 
 :::tactic "induction"


### PR DESCRIPTION
Adds the following:
 * Suppression of structure constructors
 * Custom labels

Bugfix:
 * When there's no fields, the header was shown. It's now shown only when there are fields.