### PR TITLE
chore: bump to 2025-03-30

### DIFF
--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "47d9bba3154aee70e7875c74acca8a8668c7389f",
+   "rev": "f8cecd1c0781d98ff7e783b9a63a072b1f857f7e",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "47d9bba3154aee70e7875c74acca8a8668c7389f",
+   "rev": "f8cecd1c0781d98ff7e783b9a63a072b1f857f7e",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -5,7 +5,7 @@ require subverso from git "https://github.com/leanprover/subverso.git"@"main"
 require MD4Lean from git "https://github.com/acmepjz/md4lean"@"main"
 
 package verso where
-  precompileModules := true
+  precompileModules := false -- temporarily disabled to work around an issue with nightly-2025-03-30
   -- add package configuration options here
 
 @[default_target]

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,2 @@
-leanprover/lean4:nightly-2025-03-21
+leanprover/lean4:nightly-2025-03-30
+


### PR DESCRIPTION
This temporarily disables precompiled modules, which slows down elaboration of big documents. Changes from lean4#7716 made compilation not work with it enabled.