### PR TITLE
chore: bump SubVerso dependency

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,2 +1,1 @@
 leanprover/lean4:v4.19.0-rc1
-


### PR DESCRIPTION
This fixes a bug with scope-altering commands