### PR TITLE
fix: don't asynchronously elaborate literate files

### DIFF
--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -4,7 +4,7 @@
  [{"url": "https://github.com/leanprover/subverso.git",
    "type": "git",
    "subDir": null,
-   "rev": "b9a93c9937192f69ba2707c3c2c452ca074692cd",
+   "rev": "2a494136ab009808a042bef0410d6e269ccb6653",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/examples/website-literate/lake-manifest.json
+++ b/examples/website-literate/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "b9a93c9937192f69ba2707c3c2c452ca074692cd",
+   "rev": "2a494136ab009808a042bef0410d6e269ccb6653",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "b9a93c9937192f69ba2707c3c2c452ca074692cd",
+   "rev": "2a494136ab009808a042bef0410d6e269ccb6653",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -289,6 +289,8 @@ def PartElabM.run (st : DocElabM.State) (st' : PartElabM.State) (act : PartElabM
   let ((res, st), st') ← act st st'
   pure (res, st, st')
 
+instance : Alternative PartElabM := inferInstanceAs <| Alternative (StateT DocElabM.State (StateT PartElabM.State TermElabM))
+
 instance : MonadRef PartElabM := inferInstanceAs <| MonadRef (StateT DocElabM.State (StateT PartElabM.State TermElabM))
 
 instance : MonadAlwaysExcept Exception PartElabM := inferInstanceAs <| MonadAlwaysExcept Exception (StateT DocElabM.State (StateT PartElabM.State TermElabM))
@@ -336,6 +338,8 @@ instance : MonadLift TermElabM DocElabM where
 
 instance : MonadLift IO DocElabM where
   monadLift act := fun _ st' => do return (← act, st')
+
+instance : Alternative DocElabM := inferInstanceAs <| Alternative (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
 
 instance : MonadRef DocElabM := inferInstanceAs <| MonadRef (ReaderT PartElabM.State (StateT DocElabM.State TermElabM))
 


### PR DESCRIPTION
The underlying process isn't safe to use this way.