### PR TITLE
fix: allow page names to be ordinary references as well as docnames

### DIFF
--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -102,8 +102,7 @@ def ref : RoleExpander
 def page_link : RoleExpander
   | #[.anon (.name page)], stxs => do
     let args ← stxs.mapM elabInline
-    let pageName := mkIdentFrom page <| docName page.getId
-    let val ← ``(Inline.other (Blog.InlineExt.pageref $(quote pageName.getId)) #[ $[ $args ],* ])
+    let val ← ``(Inline.other (Blog.InlineExt.pageref $(quote page.getId)) #[ $[ $args ],* ])
     pure #[val]
   | _, _ => throwUnsupportedSyntax
 

--- a/src/verso-blog/VersoBlog/Template.lean
+++ b/src/verso-blog/VersoBlog/Template.lean
@@ -85,7 +85,7 @@ def inlineHtml (g : Genre) [MonadConfig (HtmlT g IO)] [MonadPath (HtmlT g IO)]
       go <| .link contents addr
   | .pageref x, contents => do
     let st ← stateEq ▸ state
-    match st.pageIds.find? x with
+    match st.pageIds.find? x <|> st.pageIds.find? (docName x) with
     | none =>
       HtmlT.logError s!"Can't find target {x} - options are {st.pageIds.toList.map (·.fst)}"
       pure {{<strong class="internal-error">s!"Can't find target {x}"</strong>}}


### PR DESCRIPTION
This is needed when they come from sources other than modules