### PR TITLE
fix: better defaults for manualMain

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Building the user's guide as TeX and HTML"
-lake exe usersguide --depth 2
+lake exe usersguide --with-html-multi --with-html-single --with-tex
 
 echo "Building the user's guide as PDF"
 mkdir -p _out/tex

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -116,9 +116,9 @@ def paragraph : DirectiveExpander
 structure Config where
   destination : System.FilePath := "_out"
   maxTraversals : Nat := 20
-  htmlDepth := 0
-  emitTeX : Bool := true
-  emitHtmlSingle : Bool := true
+  htmlDepth := 2
+  emitTeX : Bool := false
+  emitHtmlSingle : Bool := false
   emitHtmlMulti : Bool := true
   wordCount : Option System.FilePath := none
   extraFiles : List (System.FilePath × String) := []


### PR DESCRIPTION
The HTML splitting depth now defaults to 2, and single-page and TeX output need to be explicitly enabled.

Closes #350 