### PR TITLE
feat: allow parts in manuals to specify short titles

### DIFF
--- a/doc/UsersGuide/Basic.lean
+++ b/doc/UsersGuide/Basic.lean
@@ -8,6 +8,7 @@ set_option pp.rawOnError true
 #doc (Manual) "Writing Documentation in Lean with Verso" =>
 
 %%%
+shortTitle := "Documentation with Verso"
 authors := ["David Thrane Christiansen"]
 %%%
 
@@ -57,6 +58,9 @@ results in
 {docstring List.forM}
 
 ## More Docstring Examples
+%%%
+shortTitle := "More Docstrings"
+%%%
 
 Here are some docstrings as rendered by Verso.
 They include heuristic elaboration of code items in their Markdown that attempts to guess what was meant.
@@ -91,6 +95,10 @@ They include heuristic elaboration of code items in their Markdown that attempts
 {docstring Thunk}
 
 # Technical Terminology
+%%%
+shortTitle := "Glossary"
+tag := "tech-terms"
+%%%
 
 The `deftech` role can be used to annotate the definition of a {tech}[technical term].
 Elsewhere in the document, `tech` can be used to annotate a use site of a technical term.

--- a/src/verso/Verso/Output/Html.lean
+++ b/src/verso/Verso/Output/Html.lean
@@ -33,6 +33,8 @@ where
 
 def Html.empty : Html := .seq #[]
 
+def Html.ofString : String → Html := .text true
+
 def Html.append : Html → Html → Html
   | .seq xs, .seq ys => .seq (xs ++ ys)
   | .seq xs, other => .seq (xs.push other)


### PR DESCRIPTION
These short titles are used in the following circumstances where space may be constrained:
 1. Left-side table of contents (main body ToCs use the full title)

 2. For the root part, the short title is shown on page headers instead of the full title. The full title is still shown on the title page.

Closes #363