### PR TITLE
feat: multiple signature widths

### DIFF
--- a/doc/UsersGuide/Basic.lean
+++ b/doc/UsersGuide/Basic.lean
@@ -79,7 +79,9 @@ They include heuristic elaboration of code items in their Markdown that attempts
 
 {docstring Float (label := "type") (hideFields := true) (hideStructureConstructor := true)}
 
+{docstring Array.forM}
 
+{docstring Array.forRevM}
 
 :::tactic "induction"
 :::

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -480,6 +480,31 @@ main [id] {
     display: block;
 }
 
+/******** Width-dependent layout elements ********/
+
+.narrow-only {
+    display: none;
+}
+
+@media screen and (max-width: 500px) {
+    .wide-only {
+        display: none;
+    }
+    .narrow-only {
+        display: revert;
+    }
+}
+
+@media screen and (min-width: 700px) and (max-width: 920px){
+    .wide-only {
+        display: none;
+    }
+    .narrow-only {
+        display: revert;
+    }
+}
+
+
 /******** Headerline ********/
 
 #toggle-toc-click {


### PR DESCRIPTION
In the manual genre, renders signatures with multiple widths, so that media queries can select an appropriate one. This allows the design to be more responsive and waste less space.