### PR TITLE
README: fix HTML directory for http.server

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ lake exe demotextbook --output _out/examples/demotextbook
 To view the output, a local server will be needed. One way to get such
 a server is to use the one from the Python standard library, e.g.
 ```
-python3 -m http.server 8880 --directory _out/examples/demotextbook/html-single &
+python3 -m http.server 8880 --directory _out/examples/demotextbook/html-multi &
 ```
 after which `http://localhost:8880/` will show the generated site.
 


### PR DESCRIPTION
I'm not sure if I did something wrong, but when I ran the previous command, I only got a `http-multi` sub-directory, I didn't get `http-single`.