### PR TITLE
chore: remove redundant error mods

### DIFF
--- a/examples/documented-package/lake-manifest.json
+++ b/examples/documented-package/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "c6eb80454dc41cd6bb862e97ee69a65758c7793e",
+      "rev": "38718c8c1ca0c1f1315de42e79516c87bb8efc2c",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -6,7 +6,7 @@
       "url": "https://github.com/leanprover/subverso",
       "type": "git",
       "subDir": null,
-      "rev": "c6eb80454dc41cd6bb862e97ee69a65758c7793e",
+      "rev": "38718c8c1ca0c1f1315de42e79516c87bb8efc2c",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/examples/website-literate/lake-manifest.json
+++ b/examples/website-literate/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "c6eb80454dc41cd6bb862e97ee69a65758c7793e",
+      "rev": "38718c8c1ca0c1f1315de42e79516c87bb8efc2c",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "c6eb80454dc41cd6bb862e97ee69a65758c7793e",
+   "rev": "38718c8c1ca0c1f1315de42e79516c87bb8efc2c",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
SubVerso now retains the fact that they were errors.