### PR TITLE
fix: external code rebuilds and hints

### DIFF
--- a/examples/documented-package/lake-manifest.json
+++ b/examples/documented-package/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "5f3249b337736723c55d62ea0b58b19c7bc14e53",
+      "rev": "e0d11f0f3084c921c5a97d86837a42f11b8d0af6",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/examples/website-examples/lake-manifest.json
+++ b/examples/website-examples/lake-manifest.json
@@ -1,14 +1,19 @@
-{"version": 7,
- "packagesDir": ".lake/packages",
- "packages":
- [{"url": "https://github.com/leanprover/subverso",
-   "type": "git",
-   "subDir": null,
-   "rev": "5f3249b337736723c55d62ea0b58b19c7bc14e53",
-   "name": "subverso",
-   "manifestFile": "lake-manifest.json",
-   "inputRev": "main",
-   "inherited": false,
-   "configFile": "lakefile.lean"}],
- "name": "examples",
- "lakeDir": ".lake"}
+{
+  "version": 7,
+  "packagesDir": ".lake/packages",
+  "packages": [
+    {
+      "url": "https://github.com/leanprover/subverso",
+      "type": "git",
+      "subDir": null,
+      "rev": "e0d11f0f3084c921c5a97d86837a42f11b8d0af6",
+      "name": "subverso",
+      "manifestFile": "lake-manifest.json",
+      "inputRev": "main",
+      "inherited": false,
+      "configFile": "lakefile.lean"
+    }
+  ],
+  "name": "examples",
+  "lakeDir": ".lake"
+}

--- a/examples/website-literate/lake-manifest.json
+++ b/examples/website-literate/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "5f3249b337736723c55d62ea0b58b19c7bc14e53",
+      "rev": "e0d11f0f3084c921c5a97d86837a42f11b8d0af6",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "5f3249b337736723c55d62ea0b58b19c7bc14e53",
+   "rev": "e0d11f0f3084c921c5a97d86837a42f11b8d0af6",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2025-05-19
+leanprover/lean4:nightly-2025-05-23

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -48,6 +48,7 @@ def loadModuleContent
   let lakeVars :=
     #["LAKE", "LAKE_HOME", "LAKE_PKG_URL_MAP",
       "LEAN_SYSROOT", "LEAN_AR", "LEAN_PATH", "LEAN_SRC_PATH",
+      "LEAN_GITHASH",
       "ELAN_TOOLCHAIN", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"]
 
 
@@ -133,6 +134,7 @@ def Helper.fromModule
   let lakeVars :=
     #["LAKE", "LAKE_HOME", "LAKE_PKG_URL_MAP",
       "LEAN_SYSROOT", "LEAN_AR", "LEAN_PATH", "LEAN_SRC_PATH",
+      "LEAN_GITHASH",
       "ELAN_TOOLCHAIN", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"]
 
   let cmd := "elan"

--- a/src/verso/Verso/Code/External/Files.lean
+++ b/src/verso/Verso/Code/External/Files.lean
@@ -64,6 +64,7 @@ def loadModuleContent' (projectDir : String) (mod : String) (suppressNamespaces 
   let lakeVars :=
     #["LAKE", "LAKE_HOME", "LAKE_PKG_URL_MAP",
       "LEAN_SYSROOT", "LEAN_AR", "LEAN_PATH", "LEAN_SRC_PATH",
+      "LEAN", "ELAN", "ELAN_HOME", "LEAN_GITHASH",
       "ELAN_TOOLCHAIN", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"]
 
 


### PR DESCRIPTION
Prevents spurious rebuilds from subprocesses and repairs broken hint formatting.

