### PR TITLE
feat: convert docComments in Literate Lean pages

### DIFF
--- a/examples/website/DemoSiteMain.lean
+++ b/examples/website/DemoSiteMain.lean
@@ -9,6 +9,8 @@ import DemoSite
 
 open Verso Genre Blog Site Syntax
 
+set_option verso.literateMarkdown.convertDoccomments true 
+
 open Output Html Template Theme in
 def theme : Theme := { Theme.default with
   primaryTemplate := do

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -402,8 +402,9 @@ partial def docFromMod (project : System.FilePath) (mod : String)
     -- Lemma is purposefully unchecked, such that it can be matched on when a project
     -- is dependent on mathlib
     | ``declaration | `lemma =>
-      match code with
-      | .seq s =>
+      -- Only convert doccomments if the option is turned on
+      match (← getConvertDoccomments), code with
+      | true, .seq s =>
         -- Find the index corresponding to the docComment
         let docCommentIdx := s.findIdx? (fun
           | (.token ⟨.docComment, _⟩) => True
@@ -421,7 +422,7 @@ partial def docFromMod (project : System.FilePath) (mod : String)
         | none =>
           -- No docComment attached to declaration, render definition as usual
           addBlock (← ``(Block.other (BlockExt.highlightedCode `name $(quote code)) Array.mkArray0))
-      | _ => addBlock (← ``(Block.other (BlockExt.highlightedCode `name $(quote code)) Array.mkArray0))
+      | _, _ => addBlock (← ``(Block.other (BlockExt.highlightedCode `name $(quote code)) Array.mkArray0))
     | ``eval | ``evalBang | ``reduceCmd | ``print | ``printAxioms | ``printEqns | ``«where» | ``version | ``synth | ``check =>
       addBlock (← ``(Block.other (BlockExt.highlightedCode `name $(quote code)) Array.mkArray0))
       if let some (k, msg) := getFirstMessage code then
@@ -613,6 +614,8 @@ directory that contains a toolchain file and a Lake configuration (`lakefile.tom
 
 Set the option `verso.literateMarkdown.logInlines` to `true` to see the error messages that
 prevented elaboration of inline elements.
+Set the option `verso.literateMarkdown.convertDoccomments` to `true` to convert doccomments in
+a similar way as the module docstrings, except without allowing headers.
 -/
 syntax "def_literate_post " ident optConfig " from " ident " in " str " as " str (" with " term)? (rewrites)? : command
 

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -407,7 +407,7 @@ partial def docFromMod (project : System.FilePath) (mod : String)
       | true, .seq s =>
         -- Find the index corresponding to the docComment
         let docCommentIdx := s.findIdx? (fun
-          | (.token ⟨.docComment, _⟩) => True
+          | (.token ⟨.docComment, _⟩) => true
           | _ => false)
         match docCommentIdx with
         | some i =>

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -399,7 +399,9 @@ partial def docFromMod (project : System.FilePath) (mod : String)
           }
         | other =>
           addBlock (← ofBlock helper other)
-    | ``declaration =>
+    -- Lemma is purposefully unchecked, such that it can be matched on when a project
+    -- is dependent on mathlib
+    | ``declaration | `lemma =>
       match code with
       | .seq s =>
         -- Find the index corresponding to the docComment

--- a/src/verso-blog/VersoBlog/LiterateLeanPage/Options.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage/Options.lean
@@ -13,7 +13,17 @@ register_option verso.literateMarkdown.logInlines : Bool := {
   descr := "Whether to log failures to elaborate inline code items in Markdown comments."
 }
 
+register_option verso.literateMarkdown.convertDoccomments : Bool := {
+  defValue := false
+  group := "doc"
+  descr := "Whether to convert doccomments on definitions to text ."
+}
+
+
 namespace Verso.Genre.Blog.Literate
 
 def getLogInlines [Monad m] [MonadOptions m] : m Bool := do
   return (← getOptions).get verso.literateMarkdown.logInlines.name verso.literateMarkdown.logInlines.defValue
+
+def getConvertDoccomments [Monad m] [MonadOptions m] : m Bool := do
+  return (← getOptions).get verso.literateMarkdown.convertDoccomments.name verso.literateMarkdown.convertDoccomments.defValue


### PR DESCRIPTION
This feature is controlled by the `verso.literateMarkdown.convertDoccomments` option, which defaults to false for backwards compatibility.