### PR TITLE
feat: allow parts to disable showing inline HTML ToC

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -53,6 +53,9 @@ namespace Manual
 defmethod Part.htmlSplit (part : Part Manual) : HtmlSplitMode :=
   part.metadata.map (·.htmlSplit) |>.getD .default
 
+defmethod Part.htmlToc (part : Part Manual) : Bool :=
+  part.metadata.map (·.htmlToc) |>.getD true
+
 
 def Inline.ref : Inline where
   name := `Verso.Genre.Manual.Inline.ref
@@ -552,7 +555,7 @@ where
         {{<section>{{Html.titlePage titleHtml authors introHtml ++ contents}} {{subTocHtml}}</section>}}
       else
         let subTocHtml :=
-          if (depth > 0 && part.htmlSplit != .never) && subToc.size > 0 then
+          if (depth > 0 && part.htmlSplit != .never) && subToc.size > 0 && part.htmlToc then
             {{<ol class="section-toc">{{subToc.map (·.html config.sectionTocDepth)}}</ol>}}
           else .empty
         {{<section><h1>{{titleHtml}}</h1> {{introHtml}} {{contents}} {{subTocHtml}}</section>}}

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -227,6 +227,8 @@ structure PartMetadata where
   draft : Bool := false
   /-- Which number has been assigned? This field is set during traversal. -/
   assignedNumber : Option Numbering := none
+  /-- If `true`, this part will display a list of subparts that are separate HTML pages. -/
+  htmlToc := true
   htmlSplit : HtmlSplitMode := .default
 deriving BEq, Hashable, Repr
 


### PR DESCRIPTION
This PR adds the ability for a `Part` to disable showing an inline table of contents on a rendered HTML page with an `htmlToc` option. This is necessary for error explanations, since we will render a custom table of explanations with additional metadata rather than using Verso's built-in table of contents.