### PR TITLE
feat: add part generation and info-string checking in Markdown elab

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1248,25 +1248,12 @@ private def attempt (str : String) (xs : List (String → DocElabM α)) : DocEla
 
 
 open Lean Elab Term in
-def tryElabInlineCode (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
+def tryElabInlineCodeUsing (elabs : List (String → DocElabM Term))
     (priorWord : Option String) (str : String) : DocElabM Term := do
   -- Don't try to show Lake commands as terms
   if "lake ".isPrefixOf str then return (← ``(Verso.Doc.Inline.code $(quote str)))
   try
-    attempt str <| wordElab priorWord ++ [
-      tryElabInlineCodeName,
-      -- When identifiers have the same name as tactics, prefer the identifiers
-      tryElabInlineCodeTerm (identOnly := true),
-      tryParseInlineCodeTactic,
-      tryParseInlineCodeAttribute (validate := true),
-      tryInlineOption,
-      tryElabInlineCodeTerm,
-      tryElabInlineCodeMetavarTerm,
-      tryTacticName allTactics,
-      withTheReader Term.Context (fun ctx => {ctx with autoBoundImplicit := true}) ∘ tryElabInlineCodeTerm,
-      tryElabInlineCodeTerm (ignoreElabErrors := true),
-      tryHighlightKeywords extraKeywords
-    ]
+    attempt str <| wordElab priorWord ++ elabs
   catch
     | .error ref e =>
       logWarningAt ref e
@@ -1282,6 +1269,45 @@ where
     | some "attribute" => [tryParseInlineCodeAttribute (validate := false)]
     | some "tactic" => [tryParseInlineCodeTactic]
     | _ => []
+
+open Elab in
+def tryElabInlineCode (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
+    (priorWord : Option String) (str : String) : DocElabM Term :=
+  tryElabInlineCodeUsing [
+    tryElabInlineCodeName,
+    -- When identifiers have the same name as tactics, prefer the identifiers
+    tryElabInlineCodeTerm (identOnly := true),
+    tryParseInlineCodeTactic,
+    tryParseInlineCodeAttribute (validate := true),
+    tryInlineOption,
+    tryElabInlineCodeTerm,
+    tryElabInlineCodeMetavarTerm,
+    tryTacticName allTactics,
+    withTheReader Term.Context (fun ctx => {ctx with autoBoundImplicit := true}) ∘ tryElabInlineCodeTerm,
+    tryElabInlineCodeTerm (ignoreElabErrors := true),
+    tryHighlightKeywords extraKeywords
+  ] priorWord str
+
+open Elab in
+/--
+Like `tryElabInlineCode`, but prefers producing un-highlighted code blocks to
+displaying metavariable-typed terms (e.g., through auto-bound implicits or
+elaboration failures).
+-/
+def tryElabInlineCodeStrict (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
+    (priorWord : Option String) (str : String) : DocElabM Term :=
+  tryElabInlineCodeUsing [
+    tryElabInlineCodeName,
+    -- When identifiers have the same name as tactics, prefer the identifiers
+    tryElabInlineCodeTerm (identOnly := true),
+    tryParseInlineCodeTactic,
+    tryParseInlineCodeAttribute (validate := true),
+    tryInlineOption,
+    tryElabInlineCodeTerm,
+    tryElabInlineCodeMetavarTerm,
+    tryTacticName allTactics,
+    tryHighlightKeywords extraKeywords
+  ] priorWord str
 
 open Lean Elab Term in
 def tryElabBlockCode (_ _ : Option String) (str : String) : DocElabM Term := do

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1284,7 +1284,7 @@ where
     | _ => []
 
 open Lean Elab Term in
-def tryElabBlockCode (str : String) : DocElabM Term := do
+def tryElabBlockCode (_ _ : Option String) (str : String) : DocElabM Term := do
   try
     attempt str [
       tryElabBlockCodeCommand,

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1310,7 +1310,7 @@ def tryElabInlineCodeStrict (allTactics : Array Tactic.Doc.TacticDoc) (extraKeyw
   ] priorWord str
 
 open Lean Elab Term in
-def tryElabBlockCode (_ _ : Option String) (str : String) : DocElabM Term := do
+def tryElabBlockCode (_info? _lang? : Option String) (str : String) : DocElabM Term := do
   try
     attempt str [
       tryElabBlockCodeCommand,

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -283,8 +283,9 @@ private partial def partFromMarkdownAux {m} [Monad m]
 /--
 Adds blocks from Markdown, treating top-level headers as new parts.
 
-Note that `handleHeaders` is still used for elaborating headers that appear
-nested within blocks (e.g., blockquotes).
+`handleHeaders` provides a means of elaborating headers that appear
+nested within blocks (e.g., blockquotes), with one element for each supported
+level of nesting.
 
 `currentHeaderLevels` gives a list of headers within which elaboration is
 occurring and which can be terminated by the current elaboration. Typically,

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -259,7 +259,7 @@ private partial def closeSections {m} [Monad m]
     else
       modifyThe MDState ({· with inHeaders := (level, nesting + 1) :: hdrs})
 
-private partial def partFromMarkdownAux {m} [Monad m]
+private partial def addPartFromMarkdownAux {m} [Monad m]
     [MonadLiftT PartElabM m] [MonadStateOf PartElabM.State m]
     [MonadQuotation m] [AddMessageContext m] [MonadError m]
     : MD4Lean.Block → MDT m Term Term Unit
@@ -289,8 +289,10 @@ level of nesting.
 
 `currentHeaderLevels` gives a list of headers within which elaboration is
 occurring and which can be terminated by the current elaboration. Typically,
-these are taken from a previous iteration of `partFromMarkdown`, but they can
-also be specified manually as `(headerLevel, nestingLevel)` pairs.
+these are taken from a previous execution of `addPartFromMarkdown`, but they can
+also be specified manually as `(headerLevel, nestingLevel)` pairs, where
+`headerLevel` is the Markdown header level and `nestingLevel` the corresponding
+Verso nesting level of a preceding header.
 -/
 def addPartFromMarkdown {m} [Monad m]
     [MonadLiftT PartElabM m] [MonadStateOf PartElabM.State m]
@@ -301,5 +303,5 @@ def addPartFromMarkdown {m} [Monad m]
     (elabInlineCode : Option (Option String → String → m Term) := none)
     (elabBlockCode : Option (Option String → Option String → String → m Term) := none) : m (List (Nat × Nat)) := do
   let ctxt := {headerHandlers := ⟨handleHeaders⟩, elabInlineCode, elabBlockCode}
-  let (_, { inHeaders }) ← (partFromMarkdownAux md |>.run ctxt |>.run {inHeaders := currentHeaderLevels})
+  let (_, { inHeaders }) ← (addPartFromMarkdownAux md |>.run ctxt |>.run {inHeaders := currentHeaderLevels})
   return inHeaders

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -220,22 +220,22 @@ def strongEmphHeaders' : List (Array (Doc.Inline g) → Except String (Doc.Block
   fun inls => pure <| .para #[.emph inls]
 ]
 
-private partial def stringFromMarkdownText : Text → Except String String
+partial def stringFromMarkdownText : Text → Except String String
   | .normal str | .br str | .softbr str => pure str
   | .nullchar => .error "Unepxected null character in parsed Markdown"
   | .del _ => .error "Unexpected strikethrough in parsed Markdown"
-  | .em txt => arrToStr <| txt.mapM stringFromMarkdownText
-  | .strong txt => arrToStr <| txt.mapM stringFromMarkdownText
-  | .a _ _ _ txt => arrToStr <| txt.mapM stringFromMarkdownText
+  | .em txt => joinArrM <| txt.mapM stringFromMarkdownText
+  | .strong txt => joinArrM <| txt.mapM stringFromMarkdownText
+  | .a _ _ _ txt => joinArrM <| txt.mapM stringFromMarkdownText
   | .latexMath m => pure <| String.join m.toList
   | .latexMathDisplay m =>  pure <| String.join m.toList
   | .u txt => .error s!"Unexpected underline around {repr txt} in parsed Markdown:"
-  | .code str => pure <| String.join str.toList
+  | .code strs => pure <| String.join strs.toList
   | .entity ent => .error s!"Unsupported entity {ent} in parsed Markdown"
   | .img .. => .error s!"Unexpected image in parsed Markdown"
   | .wikiLink .. => .error s!"Unexpected wiki-style link in parsed Markdown"
 where
-  arrToStr (x : Except String (Array String)) : Except String String :=
+  joinArrM (x : Except String (Array String)) : Except String String :=
     return String.join (← x).toList
 
 open Verso.Doc.Elab

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -30,7 +30,7 @@ private structure HeaderHandlers (m : Type u → Type w) (block : Type u) (inlin
 structure MDContext (m : Type u → Type w) (block : Type u) (inline : Type u) : Type (max u w) where
   headerHandlers : HeaderHandlers m block inline
   elabInlineCode : Option (Option String → String → m inline)
-  elabBlockCode : Option (Option String → Option String → String → m block)
+  elabBlockCode : Option ((info? lang? : Option String) → String → m block)
 
 def attrText : AttrText → Except String String
   | .normal str => pure str

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -251,7 +251,7 @@ private partial def closeSections {m} [Monad m]
   | [] => modifyThe MDState ({· with inHeaders := [(level, 0)]})
   | (docLevel, nesting) :: more =>
     if level ≤ docLevel then
-      if let some ctxt' := (← getThe PartElabM.State).partContext.close default then -- TODO: source position!
+      if let some ctxt' := (← getThe PartElabM.State).partContext.close default then -- Markdown parser provides no source position
         modifyThe PartElabM.State fun st => {st with partContext := ctxt'}
         closeSections level
       if level < docLevel then

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -99,7 +99,7 @@ partial def inlineFromMarkdown [Monad m] [MonadQuotation m] [AddMessageContext m
 
 partial def inlineFromMarkdown' : Text → Except String (Doc.Inline g)
   | .normal str | .br str | .softbr str => pure <| .text str
-  | .nullchar => .error "Unepxected null character in parsed Markdown"
+  | .nullchar => .error "Unexpected null character in parsed Markdown"
   | .del _ => .error "Unexpected strikethrough in parsed Markdown"
   | .em txt => .emph <$> txt.mapM inlineFromMarkdown'
   | .strong txt => .bold <$> txt.mapM inlineFromMarkdown'
@@ -222,7 +222,7 @@ def strongEmphHeaders' : List (Array (Doc.Inline g) → Except String (Doc.Block
 
 partial def stringFromMarkdownText : Text → Except String String
   | .normal str | .br str | .softbr str => pure str
-  | .nullchar => .error "Unepxected null character in parsed Markdown"
+  | .nullchar => .error "Unexpected null character in parsed Markdown"
   | .del _ => .error "Unexpected strikethrough in parsed Markdown"
   | .em txt => joinArrM <| txt.mapM stringFromMarkdownText
   | .strong txt => joinArrM <| txt.mapM stringFromMarkdownText

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -177,7 +177,7 @@ def blockFromMarkdown [Monad m] [MonadQuotation m] [MonadError m] [AddMessageCon
     (md : MD4Lean.Block)
     (handleHeaders : List (Array Term → m Term) := [])
     (elabInlineCode : Option (Option String → String → m Term) := none)
-    (elabBlockCode : Option (Option String → Option String → String → m Term) := none) : m Term :=
+    (elabBlockCode : Option ((info? lang? : Option String) → String → m Term) := none) : m Term :=
   let ctxt := {headerHandlers := ⟨handleHeaders⟩, elabInlineCode, elabBlockCode}
   (·.fst) <$> blockFromMarkdownAux md ctxt {}
 

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -268,7 +268,7 @@ private partial def addPartFromMarkdownAux {m} [Monad m]
     let txtStxs ← txt.mapM inlineFromMarkdown |>.run' none
     let titleTexts ← match txt.mapM stringFromMarkdownText with
       | .ok t => pure t
-      | .error e => throwError m!"Invalid Markdown in header:\n{e}"
+      | .error e => throwError m!"Unsupported Markdown in header:\n{e}"
     let titleText := titleTexts.foldl (· ++ ·) ""
     PartElabM.push {
       titleSyntax := quote (k := `str) titleText

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -601,6 +601,7 @@ def highlightingStyle : String := "
   text-decoration-style: wavy;
   text-decoration-line: underline;
   text-decoration-thickness: from-font;
+  text-decoration-skip-ink: none;
 }
 
 .hl.lean .has-info .hover-info {


### PR DESCRIPTION
This PR adds the Markdown elaboration features required for error explanations, namely the ability to create `Part`s from Markdown headers, the ability to access infostrings in code-block elaborators, and a "strict" inline code elaboration mode.