### PR TITLE
feat: add linters for extra markup

### DIFF
--- a/examples/package-manual/PackageManual.lean
+++ b/examples/package-manual/PackageManual.lean
@@ -175,11 +175,11 @@ tag := "sec-ref"
 Sections with tags can be cross-referenced.
 They additionally gain permalink indicators that can be used to link to them even if the document is reorganized.
 Tags are added in section metadata, e.g.
-````
+```
 %%%
 tag := "my-tag"
 %%%
-````
+```
 They can be linked to using {lean}`ref`.
 Here's one to {ref "sec-ref"}[this section].
 

--- a/examples/package-manual/PackageManual/DocFeatures.lean
+++ b/examples/package-manual/PackageManual/DocFeatures.lean
@@ -41,28 +41,28 @@ When there is no default set, or to override it, the example code features all a
 # Example Modules
 
 To include a module, use the `module`{index}[`module`] code block:
-`````
+````
 ```module (module := M)
 ...
 ```
-`````
+````
 The contents of the code block specifies the expected code.
 This ensures that documentation doesn't get out of sync with examples and makes it easier to read the documentation source code.
 While it's an error if they don't match, a code action can fix the problem.
 
 :::paragraph
 To show output from the module, use the `moduleInfo`{index}[`moduleInfo`], `moduleWarning`{index}[`moduleWarning`], or `moduleError`{index}[`moduleError`] code blocks:
-`````
+````
 ```moduleInfo (module := M)
 ...
 ```
-`````
+````
 The code block serves two purposes: it selects one of the messages with the appropriate severity, and it ensures that the documentation stays in sync with the code.
 However, metavariable renumbering does not affect whether the message is considered to match.
 :::
 
 For inline contexts, the `moduleName`{index}[`moduleName`] and `moduleTerm`{index}[`moduleTerm`] roles expect a single code element as their parameter and respectively select the first name or token sequence in the indicated module that matches it.
-For example, ``` {moduleName}`x` ``` indicates the first occurrence of `x` in the module, and ``` {moduleTerm}`3 + y` ``` indicates the first term that matches `3 + y`.
+For example, `` {moduleName}`x` `` indicates the first occurrence of `x` in the module, and `` {moduleTerm}`3 + y` `` indicates the first term that matches `3 + y`.
 These are included with information such as bindings intact, so correct highlighting depends on using more specific {tech}[anchors] to indicate the appropriate region of the file.
 
 
@@ -72,12 +72,12 @@ These are included with information such as bindings intact, so correct highligh
 An {deftech}_anchor_ is a named region of a module.
 Anchors can be included by name, rather than by line number.
 An anchor is delimited by special comments:
-``````
+```
 -- ANCHOR: anAnchor
 def f : Nat → Nat := id
 #eval f 2
 -- ANCHOR_END: anAnchor
-``````
+```
 The comments themselves are removed, and there is no requirement that anchors be well-nested.
 :::
 
@@ -95,5 +95,5 @@ is equivalent to
 ...
 ```
 ````
-and ``` {anchorName anAnchor}`x` ``` is equivalent to ``` {moduleName (anchor := anAnchor)}`x` ```.
+and `` {anchorName anAnchor}`x` `` is equivalent to `` {moduleName (anchor := anAnchor)}`x` ``.
 :::

--- a/examples/textbook/DemoTextbook.lean
+++ b/examples/textbook/DemoTextbook.lean
@@ -111,11 +111,11 @@ tag := "sec-ref"
 Sections with tags can be cross-referenced.
 They additionally gain permalink indicators that can be used to link to them even if the document is reorganized.
 Tags are added in section metadata, e.g.
-````
+```
 %%%
 tag := "my-tag"
 %%%
-````
+```
 They can be linked to using {lean}`ref`.
 Here's one to {ref "sec-ref"}[this section].
 


### PR DESCRIPTION
In particular, this will help users not get caught on the fact that `*` is different from Markdown.