### PR TITLE
chore: improve display/ergonomics for Grind manual page

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -703,7 +703,7 @@ def inheritance.descr : BlockDescr where
                 let filterId := s!"{parent.index}-{parent.name}-{name}"
                 pure {{
                   <li>
-                    <input type="checkbox" id={{filterId}} checked="checked" data-parent-idx={{toString parent.index}}/>
+                    <input type="checkbox" id={{filterId}} data-parent-idx={{toString parent.index}}/>
                     <label for={{filterId}}><code class="hl lean inline">{{← parent.parent.toHtml (g := Manual)}}</code></label>
                   </li>}}
               }}

--- a/src/verso/Verso/Doc/Elab.lean
+++ b/src/verso/Verso/Doc/Elab.lean
@@ -259,7 +259,13 @@ def partCommand (cmd : TSyntax `block) : PartElabM Unit :=
 where
   fallback : PartElabM Unit := do
     if (← getThe PartElabM.State).partContext.priorParts.size > 0 then
-      throwErrorAt cmd "Unexpected block"
+      let which := (← getThe PartElabM.State).partContext.priorParts.back?.map fun
+        | .mk _ _ titleString .. => s!" (namely “{titleString}”)"
+        | .included n => s!" (namely `{unDocName n.getId}`)"
+      let which := which.getD ""
+      let msg := m!"Block content found in a context where a header was expected."
+      let note := MessageData.note m!"A document part (section/chapter/etc) consists of a header, followed by zero or more blocks, followed by zero or more sub-parts. This block occurs after a sub-part{which}, but outside of the sub-parts."
+      throwErrorAt cmd "{msg}\n{note}"
     let blk ← liftDocElabM <| elabBlock cmd
     addBlock blk
 


### PR DESCRIPTION
This PR hides inherited fields by default and improves the error message that occurs when block content is in a context that expects a part.