### PR TITLE
feat: automatic signature docstrings for Verso elements

### DIFF
--- a/examples/website/DemoSite/Blog/Conditionals.lean
+++ b/examples/website/DemoSite/Blog/Conditionals.lean
@@ -26,9 +26,11 @@ categories := [examples, other]
 %%%
 
 
+:::htmlDiv (class := "some-other-class")
 Finally started blogging!
-This post describes the syntax and semantics of conditional expressions in Lean.
+This post {htmlSpan (class := "some-class")}[describes] the syntax and semantics of conditional expressions in Lean.
 Here are some examples:
+:::
 
 ```leanInit demo
 -- This block initializes a Lean context


### PR DESCRIPTION
Adds automatically-generated hovers for Verso elements, and makes them easier to define.

TODO:
 * [ ] Use the new style in all the code
 * [ ] Better formatting of signatures
 * [ ] Show docstrings for expanders in hovers