### PR TITLE
fix: generate placeholder text for missing `toTex` implementations

### DIFF
--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -1271,7 +1271,8 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getBlock? b.name
       | panic! s!"Unknown block {b.name} while rendering.\n\nKnown blocks: {(← readThe ExtensionImpls).blockDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Block {b.name}" ]
+      | TeX.logError s!"Block {b.name} doesn't support TeX"
+        return \TeX{\textcolor{"red"}{s!"Missing toTeX for Block {b.name}"}}
     impl goI goB id b.data content
   inline go i content := do
     let some id := i.id
@@ -1279,7 +1280,8 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getInline? i.name
       | panic! s!"Unknown inline {i.name} while rendering.\n\nKnown inlines: {(← readThe ExtensionImpls).inlineDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Inline {i.name}" ]
+      | TeX.logError s!"Inline {i.name} doesn't support TeX"
+        return \TeX{\textcolor{"red"}{s!"Missing toTeX for Inline {i.name}"}}
     impl go id i.data content
 
 

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -1271,8 +1271,9 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getBlock? b.name
       | panic! s!"Unknown block {b.name} while rendering.\n\nKnown blocks: {(← readThe ExtensionImpls).blockDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | TeX.logError s!"Block {b.name} doesn't support TeX"
-        return .empty
+      | --TeX.logError s!"Block {b.name} doesn't support TeX"
+        --return .empty
+        return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Block {b.name}" ]
     impl goI goB id b.data content
   inline go i content := do
     let some id := i.id
@@ -1280,8 +1281,10 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getInline? i.name
       | panic! s!"Unknown inline {i.name} while rendering.\n\nKnown inlines: {(← readThe ExtensionImpls).inlineDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | TeX.logError s!"Inline {i.name} doesn't support TeX"
-        return .empty
+      | --TeX.logError s!"Inline {i.name} doesn't support TeX"
+        -- return .empty
+        -- "\color{red}{Missing toTeX for Manual.keywordOf}".
+        return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Inline {i.name}" ]
     impl go id i.data content
 
 

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -1271,9 +1271,7 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getBlock? b.name
       | panic! s!"Unknown block {b.name} while rendering.\n\nKnown blocks: {(← readThe ExtensionImpls).blockDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | --TeX.logError s!"Block {b.name} doesn't support TeX"
-        --return .empty
-        return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Block {b.name}" ]
+      | return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Block {b.name}" ]
     impl goI goB id b.data content
   inline go i content := do
     let some id := i.id
@@ -1281,10 +1279,7 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getInline? i.name
       | panic! s!"Unknown inline {i.name} while rendering.\n\nKnown inlines: {(← readThe ExtensionImpls).inlineDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | --TeX.logError s!"Inline {i.name} doesn't support TeX"
-        -- return .empty
-        -- "\color{red}{Missing toTeX for Manual.keywordOf}".
-        return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Inline {i.name}" ]
+      | return .command "textcolor" #[] #[ .raw "red", .raw s!"Missing toTeX for Inline {i.name}" ]
     impl go id i.data content
 
 

--- a/src/verso/Verso/Doc/TeX.lean
+++ b/src/verso/Verso/Doc/TeX.lean
@@ -41,7 +41,8 @@ def logError [Monad m] (message : String) : TeXT g m Unit := do
 def header [Monad m] (name : TeX) : TeXT g m TeX := do
   let opts ← options
   let some i := opts.headerLevel
-    | logError s!"No more header nesting available at {name.asString}"; return \TeX{\textbf{\Lean{name}}}
+    | --logError s!"No more header nesting available at {name.asString}";
+      return \TeX{\textbf{\Lean{name}}}
   let header := opts.headerLevels[i]
   pure <| .raw (s!"\\{header}" ++ "{") ++ name ++ .raw "}"
 

--- a/src/verso/Verso/Doc/TeX.lean
+++ b/src/verso/Verso/Doc/TeX.lean
@@ -41,7 +41,8 @@ def logError [Monad m] (message : String) : TeXT g m Unit := do
 def header [Monad m] (name : TeX) : TeXT g m TeX := do
   let opts ← options
   let some i := opts.headerLevel
-    | return \TeX{\textbf{\Lean{name}}}
+    | logError s!"No more header nesting available at {name.asString}"
+      return \TeX{\textcolor{"red"}{s!"Header nesting limit reached at {name.asString}"}}
   let header := opts.headerLevels[i]
   pure <| .raw (s!"\\{header}" ++ "{") ++ name ++ .raw "}"
 

--- a/src/verso/Verso/Doc/TeX.lean
+++ b/src/verso/Verso/Doc/TeX.lean
@@ -41,8 +41,7 @@ def logError [Monad m] (message : String) : TeXT g m Unit := do
 def header [Monad m] (name : TeX) : TeXT g m TeX := do
   let opts ← options
   let some i := opts.headerLevel
-    | --logError s!"No more header nesting available at {name.asString}";
-      return \TeX{\textbf{\Lean{name}}}
+    | return \TeX{\textbf{\Lean{name}}}
   let header := opts.headerLevels[i]
   pure <| .raw (s!"\\{header}" ++ "{") ++ name ++ .raw "}"
 


### PR DESCRIPTION
Generate placeholder text for missing `toTex` implementations instead failing.