### PR TITLE
chore: Add an integration test for TeX output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _out
 *.olean
 /.verso/
 /src/tests/parser/**/*.output
+/src/tests/integration/**/output

--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -4,4 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 import Tests.Golden
+import Tests.Integration
+import Tests.Integration.SampleDoc
 import Tests.ParserRegression

--- a/src/tests/Tests/Integration.lean
+++ b/src/tests/Tests/Integration.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jason Reed
+-/
+import Lean.Util.Diff
+
+namespace Verso.Integration
+
+/-- Configuration for the test runner -/
+structure Config where
+  /-- Where are expected files located? We expect a subdirectory
+  `expected` and `runTest` should produce files into a subdirectory
+  `output`. -/
+  testDir : System.FilePath
+  /-- Should the expected output be replaced with the actual output? -/
+  updateExpected : Bool := false
+  /-- How to run the test -/
+  runTest : IO Unit
+
+/--
+Returns all non-directory filepaths that are children of `root`, which
+must be a directory. Returns these as paths relative to `root`.
+
+This differs from `System.FilePath.walkRoot`, in that the latter returns
+absolute paths, and includes subdirectories.
+-/
+partial def filesBelow (root : System.FilePath) :
+    IO (Array System.FilePath) := Prod.snd <$> StateT.run (go ".") #[]
+where
+  go (p : System.FilePath) := do
+    for d in (← (root / p).readDir) do
+      if ← d.path.isDir then
+        go (p / d.fileName)
+      else
+        modify (·.push (p / d.fileName))
+
+/-- Main test runner -/
+def runTests (config : Config) : IO Unit := do
+  unless ← System.FilePath.pathExists config.testDir do
+    throw <| .userError s!"Test directory not found: {config.testDir}"
+
+  let expectedRoot := config.testDir / "expected"
+  let outputRoot := config.testDir / "output"
+
+  unless ← System.FilePath.pathExists expectedRoot do
+    throw <| .userError s!"Expected output directory not found: {expectedRoot}"
+
+  if config.updateExpected then
+    IO.println s!"Updating expected outputs in {config.testDir}..."
+    IO.FS.removeDirAll expectedRoot
+    IO.println s!"TODO: cp -r {outputRoot} {expectedRoot}"
+  else
+    IO.println s!"Running test in {config.testDir}..."
+    if ← outputRoot.pathExists then
+      IO.FS.removeDirAll outputRoot
+    config.runTest
+
+    let expectedFiles := (← filesBelow expectedRoot)
+    let outputFiles := (← filesBelow outputRoot)
+
+    if expectedFiles != outputFiles then
+      IO.println s!"✗ Expected files differ from actual files"
+      IO.println s!"Expected files in {expectedRoot}:\n  {expectedFiles}"
+      IO.println s!"Actual files in {outputRoot}:\n  {outputFiles}"
+      throw <| .userError s!"Test in {config.testDir} failed"
+
+    for file in expectedFiles do
+      let expected ← IO.FS.readFile (expectedRoot / file)
+      let actual ← IO.FS.readFile (outputRoot / file)
+      if expected != actual then
+        let d := Lean.Diff.diff (expected.split (· == '\n') |>.toArray) (actual.split (· == '\n') |>.toArray)
+        IO.println s!"✗ In test {config.testDir}, output file {file}"
+        IO.println s!"  Expected output differs from actual output"
+        IO.println (Lean.Diff.linesToString d)
+        throw <| .userError s!"Test in {config.testDir} failed"
+
+  return

--- a/src/tests/Tests/Integration/SampleDoc.lean
+++ b/src/tests/Tests/Integration/SampleDoc.lean
@@ -1,0 +1,37 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jason Reed
+-/
+import Verso
+import VersoManual
+
+namespace Verso.Integration.SampleDoc
+
+open Verso Genre Manual
+
+--------------------
+
+/-- This is a docstring.
+
+Here's some more text with a `code inline` in it.
+Here's when a `code inline`
+occurs right before a line break.
+
+And then here's a paragraph break.
+-/
+def sample_constant := Unit
+
+#docs (Manual) doc "Title of the Doc" :=
+:::::::
+
+%%%
+shortTitle := "ShortTitle"
+authors := ["Harry Q. Bovik"]
+%%%
+
+{docstring sample_constant}
+
+:::::::
+
+end Verso.Integration.SampleDoc

--- a/src/tests/integration/sample-doc/expected/tex/main.tex
+++ b/src/tests/integration/sample-doc/expected/tex/main.tex
@@ -1,0 +1,59 @@
+
+\documentclass{memoir}
+
+\usepackage{sourcecodepro}
+\usepackage{sourcesanspro}
+\usepackage{sourceserifpro}
+
+\usepackage{fancyvrb}
+\usepackage{fvextra}
+
+
+\makechapterstyle{lean}{%
+\renewcommand*{\chaptitlefont}{\sffamily\HUGE}
+\renewcommand*{\chapnumfont}{\chaptitlefont}
+% allow for 99 chapters!
+\settowidth{\chapindent}{\chapnumfont 999}
+\renewcommand*{\printchaptername}{}
+\renewcommand*{\chapternamenum}{}
+\renewcommand*{\chapnumfont}{\chaptitlefont}
+\renewcommand*{\printchapternum}{%
+\noindent\llap{\makebox[\chapindent][l]{%
+\chapnumfont \thechapter}}}
+\renewcommand*{\afterchapternum}{}
+}
+
+\chapterstyle{lean}
+
+\setsecheadstyle{\sffamily\bfseries\Large}
+\setsubsecheadstyle{\sffamily\bfseries\large}
+\setsubsubsecheadstyle{\sffamily\bfseries}
+
+\renewcommand{\cftchapterfont}{\normalfont\sffamily}
+\renewcommand{\cftsectionfont}{\normalfont\sffamily}
+\renewcommand{\cftchapterpagefont}{\normalfont\sffamily}
+\renewcommand{\cftsectionpagefont}{\normalfont\sffamily}
+
+\title{\sffamily Title of the Doc}
+\author{\sffamily Harry Q. Bovik}
+\date{\sffamily }
+
+\begin{document}
+
+\frontmatter
+
+\begin{titlingpage}
+\maketitle
+\end{titlingpage}
+
+\tableofcontents
+
+\mainmatter
+
+\chapter*{Introduction}
+This is a docstring.Here's some more text with a \Verb|code inline|
+ in it.
+Here's when a \Verb|code inline|
+
+occurs right before a line break.And then here's a paragraph break.
+\end{document}


### PR DESCRIPTION
Not yet as happy as I could be with this. It might be ok to land as incremental forward progress.

Flaws:
- The currently passing test actually encodes undesired behavior; the spurious newline from https://github.com/leanprover/verso/issues/513 shows up. Ideally I'd rather not check in a red test, nor a test that's green but semantically failing.
- WriterT seem to exist in mathlib not the standard prelude, so I'm using StateT
- Doesn't yet support the golden-test pattern as I'd like, because I still need to figure out how to get a string elaborated.
- Maybe TeX generation could be more of a pure function? Need to investigate more. It might be that it's too intertwined with config and IO-monadic logging to conveniently untangle, in which case I might not bother.