### PR TITLE
doc: small clarification on extraCss docstrings

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -174,9 +174,9 @@ structure Config where
   emitHtmlMulti : Bool := true
   wordCount : Option System.FilePath := none
   extraFiles : List (System.FilePath × String) := []
-  /-- Extra CSS to be included inline into every `<head>` -/
+  /-- Extra CSS files to be included inline into every `<head>` -/
   extraCss : List String := []
-  /-- Extra JS to be included inline into every `<head>` -/
+  /-- Extra JS files to be included inline into every `<head>` -/
   extraJs : List StaticJsFile := []
   /-- Extra CSS to be written to the filesystem in the Verso data directory and loaded by each `<head>` -/
   extraCssFiles : Array (String × String) := #[]

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -583,7 +583,7 @@ structure InlineDescr where
   -/
   toHtml : Option (InlineToHtml Manual (ReaderT ExtensionImpls IO))
   /--
-  Extra JavaScript to add to a `<script>` tag in the generated HTML's `<head>`
+  Extra JavaScript files to add to a `<script>` tag in the generated HTML's `<head>`
   -/
   extraJs : List String := []
   /--
@@ -591,7 +591,7 @@ structure InlineDescr where
   -/
   extraJsFiles : List JsFile := []
   /--
-  Extra CSS to add to a `<style>` tag in the generated HTML's `<head>`
+  Extra CSS files to add to a `<style>` tag in the generated HTML's `<head>`
   -/
   extraCss : List String := []
   /--


### PR DESCRIPTION
My reading of these docstrings was that they insert extra css as a string directly, rather than being intended to be file names, so this PR amends the docstrings to explicitly describe css files (in particular because extraCssFiles could also have been taking in file names!)

Please feel free to suggest alternate wording here!