### PR TITLE
chore: update lychee dependency in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           lake exe simplepage
 
       - name: Check internal links on the example website
-        uses: lycheeverse/lychee-action@v1.9.0
+        uses: lycheeverse/lychee-action@v2
         with:
           format: markdown
           jobSummary: true


### PR DESCRIPTION
There's a probably-not-important-for-us dependabot update on our lychee version, but the [breaking changes](https://github.com/lycheeverse/lychee-action/releases/tag/v2.0.0) for v2 all seemed to be about sensible changes to the defaults, so it doesn't seem like anything would hold us back from just updating to a v2 dependency