### PR TITLE
fix: correctly handle extraJs/Css in manual genre (closes #529)

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -177,7 +177,7 @@ structure Config where
   /-- Extra CSS to be included inline into every `<head>` -/
   extraCss : List String := []
   /-- Extra JS to be included inline into every `<head>` -/
-  extraJs : List StaticJsFile := []
+  extraJs : List String := []
   /-- Extra CSS to be written to the filesystem in the Verso data directory and loaded by each `<head>` -/
   extraCssFiles : Array (String × String) := #[]
   /-- Extra JS to be written to the filesystem in the Verso data directory and loaded by each `<head>` -/
@@ -265,6 +265,8 @@ def traverse (logError : String → IO Unit) (text : Part Manual) (config : Conf
   let remoteContent ← updateRemotes false config.remoteConfigFile (if config.verbose then IO.println else fun _ => pure ())
   let mut state : Manual.TraverseState := {
     licenseInfo := .ofList config.licenseInfo,
+    extraCss := Std.HashSet.emptyWithCapacity |>.insertMany config.extraCss
+    extraJs := Std.HashSet.emptyWithCapacity |>.insertMany config.extraJs
     extraCssFiles := config.extraCssFiles,
     extraJsFiles := config.extraJsFiles,
     remoteContent
@@ -410,7 +412,6 @@ def page (toc : List Html.Toc)
   }
   let extraJsFiles :=
     sortJs <|
-      config.extraJs.toArray.map (true, ·) ++
       state.extraJsFiles.map (false, ·.toStaticJsFile)
   let extraJsFiles := extraJsFiles.map fun
     | (true, f) => (f.filename, f.defer)
@@ -423,9 +424,9 @@ def page (toc : List Html.Toc)
     (repoLink := config.sourceLink)
     (issueLink := config.issueLink)
     (localItems := localItems)
-    -- The extra CSS and JS in the config is not take here because it's used to initialize the
+    -- The extraCss and extraJs in the config is not take here because it's used to initialize the
     -- traverse state and is thus already present.
-    (extraStylesheets := config.extraCss ++ state.extraCssFiles.toList.map ("/-verso-data/" ++ ·.1))
+    (extraStylesheets := state.extraCssFiles.toList.map ("/-verso-data/" ++ ·.1))
     (extraJsFiles := extraJsFiles)
     (extraHead := config.extraHead)
     (extraContents := config.extraContents)


### PR DESCRIPTION
- make extraJs a string
- correctly initialize the traverse state with the config
- don't add extraCss to the file list