### PR TITLE
fix: add '%%%' as a token when parsing metadata blocks

### DIFF
--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -4,3 +4,4 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 import Tests.Golden
+import Tests.ParserRegression

--- a/src/tests/Tests/ParserRegression.lean
+++ b/src/tests/Tests/ParserRegression.lean
@@ -1,0 +1,18 @@
+import Verso
+import VersoManual
+
+/-
+This is a test for https://github.com/leanprover/verso/issues/531
+-/
+
+open Verso Genre Manual
+
+#docs (Manual) sample_part "Title of the Doc" :=
+:::::::
+
+%%%
+shortTitle := "ShortTitle"
+authors := ["Harry Q. Bovik"]
+%%%
+
+:::::::

--- a/src/tests/Tests/ParserRegression.lean
+++ b/src/tests/Tests/ParserRegression.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jason Reed
+-/
 import Verso
 import VersoManual
 

--- a/src/verso/Verso/Parser.lean
+++ b/src/verso/Verso/Parser.lean
@@ -668,12 +668,16 @@ open Lean.Parser.Term in
 def metadataBlock : ParserFn :=
   nodeFn ``metadata_block <|
     opener >>
-    metadataContents.fn >>
+    (adaptUncacheableContextFn addTriplePercent metadataContents.fn) >>
     takeWhileFn (·.isWhitespace) >>
     closer
 where
   opener := atomicFn (bolThen (eatSpaces >> strFn "%%%") "%%% (at line beginning)") >> eatSpaces >> ignoreFn (chFn '\n')
   closer := bolThen (eatSpaces >> strFn "%%%") "%%% (at line beginning)" >> eatSpaces >> ignoreFn (chFn '\n' <|> eoiFn)
+
+  -- This is necessary in Lean v4.24.0-rc1. Check if it's still necessary in subsequent releases.
+  addTriplePercent c := { c with tokens := c.tokens.insert "%%%" "%%%" }
+
 
 structure InList where
   indentation : Nat


### PR DESCRIPTION
Fixes #531