### PR TITLE
refactor: pattern-match destructuring to projection for DocElabContext

### DIFF
--- a/src/verso/Verso/Doc/Elab.lean
+++ b/src/verso/Verso/Doc/Elab.lean
@@ -147,7 +147,7 @@ open Lean.Parser.Term in
 def _root_.Lean.Doc.Syntax.role.expand : InlineExpander
   | inline@`(inline| role{$name $args*} [$subjects*]) => do
       withRef inline <| withFreshMacroScope <| withIncRecDepth <| do
-        let ⟨genre, _⟩ ← readThe DocElabContext
+        let genre := (← readThe DocElabContext).genreSyntax
         let resolvedName ← realizeGlobalConstNoOverloadWithInfo name
         let exp ← roleExpandersFor resolvedName
         let argVals ← parseArgs args
@@ -398,7 +398,7 @@ def _root_.Lean.Doc.Syntax.command.expand : BlockExpander := fun block =>
   | `(block|command{$name $args*}) => do
     withTraceNode `Elab.Verso.block (fun _ => pure m!"Block role {name}") <|
     withRef block <| withFreshMacroScope <| withIncRecDepth <| do
-      let ⟨genre, _⟩ ← readThe DocElabContext
+      let genre := (← readThe DocElabContext).genreSyntax
       let resolvedName ← realizeGlobalConstNoOverloadWithInfo name
       let exp ← blockCommandExpandersFor resolvedName
       let argVals ← parseArgs args
@@ -420,7 +420,7 @@ def _root_.Lean.Doc.Syntax.command.expand : BlockExpander := fun block =>
 @[block_expander Lean.Doc.Syntax.para]
 partial def _root_.Lean.Doc.Syntax.para.expand : BlockExpander
   | `(block| para[ $args:inline* ]) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     ``(Block.para (genre := $(⟨genre⟩)) #[$[$(← args.mapM elabInline)],*])
   | _ =>
     throwUnsupportedSyntax
@@ -430,7 +430,7 @@ def elabLi (block : Syntax) : DocElabM (Syntax × TSyntax `term) :=
   withRef block <|
   match block with
   | `(list_item|*%$dot $contents:block*) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let item ← ``(ListItem.mk (α := Block $(⟨genre⟩)) #[$[$(← contents.mapM elabBlock)],*])
     pure (dot, item)
   | _ =>
@@ -439,7 +439,7 @@ def elabLi (block : Syntax) : DocElabM (Syntax × TSyntax `term) :=
 @[block_expander Lean.Doc.Syntax.ul]
 def _root_.Lean.Doc.Syntax.ul.expand : BlockExpander
   | `(block|ul{$itemStxs*}) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let mut bullets : Array Syntax := #[]
     let mut items : Array (TSyntax `term) := #[]
     for i in itemStxs do
@@ -456,7 +456,7 @@ def _root_.Lean.Doc.Syntax.ul.expand : BlockExpander
 @[block_expander Lean.Doc.Syntax.ol]
 def _root_.Lean.Doc.Syntax.ol.expand : BlockExpander
   | `(block|ol($start:num){$itemStxs*}) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let mut bullets : Array Syntax := #[]
     let mut items : Array (TSyntax `term) := #[]
     for i in itemStxs do
@@ -474,7 +474,7 @@ def elabDesc (block : Syntax) : DocElabM (Syntax × TSyntax `term) :=
   withRef block <|
   match block with
   | `(desc_item|:%$colon $dts* => $dds*) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let item ← ``(DescItem.mk (α := Inline $(⟨genre⟩)) (β := Block $(⟨genre⟩))  #[$[$(← dts.mapM elabInline)],*] #[$[$(← dds.mapM elabBlock)],*])
     pure (colon, item)
   | _ =>
@@ -483,7 +483,7 @@ def elabDesc (block : Syntax) : DocElabM (Syntax × TSyntax `term) :=
 @[block_expander Lean.Doc.Syntax.dl]
 def _root_.Lean.Doc.Syntax.dl.expand : BlockExpander
   | `(block|dl{$itemStxs*}) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let mut colons : Array Syntax := #[]
     let mut items : Array (TSyntax `term) := #[]
     for i in itemStxs do
@@ -508,7 +508,7 @@ def _root_.Lean.Doc.Syntax.blockquote.expand : BlockExpander
 @[block_expander Lean.Doc.Syntax.codeblock]
 def _root_.Lean.Doc.Syntax.codeblock.expand : BlockExpander
   | `(block|``` $nameStx:ident $argsStx* | $contents:str ```) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let name ← realizeGlobalConstNoOverloadWithInfo nameStx
     let exp ← codeBlockExpandersFor name
     -- TODO typed syntax here
@@ -532,7 +532,7 @@ def _root_.Lean.Doc.Syntax.codeblock.expand : BlockExpander
 @[block_expander Lean.Doc.Syntax.directive]
 def _root_.Lean.Doc.Syntax.directive.expand : BlockExpander
   | `(block| ::: $nameStx:ident $argsStx* { $contents:block* } ) => do
-    let ⟨genre, _⟩ ← readThe DocElabContext
+    let genre := (← readThe DocElabContext).genreSyntax
     let name ← realizeGlobalConstNoOverloadWithInfo nameStx
     let exp ← directiveExpandersFor name
     let args ← parseArgs argsStx

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -428,7 +428,7 @@ def findLinksAndNotes : Expr → MetaM (Array (Expr × Expr))
 
 open Lean Meta Elab Term in
 def PartElabM.addBlock (block : TSyntax `term) : PartElabM Unit := withRef block <| do
-  let ⟨_, g⟩ ← readThe DocElabContext
+  let g := (← readThe DocElabContext).genre
 
   let n ← mkFreshUserName `block
 
@@ -505,7 +505,7 @@ def DocElabM.addLinkRef (refName : TSyntax `str) : DocElabM (TSyntax `term) := d
 def PartElabM.addFootnoteDef (refName : TSyntax `str) (content : Array (TSyntax `term)) : PartElabM Unit := do
   let strName := refName.getString
   let docName ← currentDocName
-  let ⟨_, genre⟩ ← readThe DocElabContext
+  let genre := (← readThe DocElabContext).genre
   match (← getThe State).footnoteDefs[strName]? with
   | none =>
     let t := mkApp3 (.const ``HasNote []) (toExpr strName) (toExpr docName) genre
@@ -528,7 +528,7 @@ def PartElabM.addFootnoteDef (refName : TSyntax `str) (content : Array (TSyntax 
 
 def DocElabM.addFootnoteRef (refName : TSyntax `str) : DocElabM (TSyntax `term) := do
   let strName := refName.getString
-  let ⟨genre, _⟩ ← readThe DocElabContext
+  let genre := (← readThe DocElabContext).genreSyntax
   match (← getThe State).footnoteRefs[strName]? with
   | none =>
     modifyThe State fun st => {st with footnoteRefs := st.footnoteRefs.insert strName ⟨#[refName]⟩}


### PR DESCRIPTION
Modify pattern match destructuring to field projection where that's an obvious move. 

This is intended to make it less of a big diff elsewhere where I want to explore adding fields to DocElabContext. I'm also curious if stylistically there's a preferred version — I certainly would be inclined to use the (existing) pattern-destructuring notation if I had less than 3 or so fields and the fields were very stable.