### PR TITLE
fix: make header mapping type abbreviation

### DIFF
--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -62,8 +62,7 @@ is understood as associating:
 We need to keep this state to appropriately repair non-consecutive
 Markdown header levels.
 -/
-public def HeaderMapping := List Nat
-deriving Inhabited
+public abbrev HeaderMapping := List Nat
 
 private structure MDState where
   inHeaders : HeaderMapping := []


### PR DESCRIPTION
Make the type `HeaderMapping` an abbreviation instead of a definition.

This change was intended as part of https://github.com/leanprover/verso/pull/539 and will make https://github.com/leanprover/reference-manual/pull/599 easier to land. There's still [one place remaining](https://github.com/leanprover/reference-manual/blob/main/Manual/Meta/ErrorExplanation.lean#L639-L640) in `Manual/Meta/ErrorExplanation.lean` which relies on the underlying implementation of `HeaderMapping`. It's convenient for now to make it an `abbrev`. Of course, we could also trivially implement `ForIn` for `HeaderMapping`, or expose a "close all sections for this `HeaderMapping` but I'd rather decouple that decision from [the present PR](https://github.com/leanprover/reference-manual/pull/599).
