### PR TITLE
refactor: prepare to serialize highlights

### DIFF
--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -172,7 +172,7 @@ def reportMessages {m} [Monad m] [MonadLog m] [MonadError m]
 De-indents and returns (syntax of) a Block representation containing highlighted Lean code.
 The argument `hls` must be a highlighting of the parsed string `str`.
 -/
-private def mkHighlightedLeanBlock (shouldShow : Bool) (hls : Highlighted) (str: StrLit) : DocElabM Term := do
+private def toHighlightedLeanBlock (shouldShow : Bool) (hls : Highlighted) (str: StrLit) : DocElabM Term := do
   if !shouldShow then
     return ← ``(Block.concat #[])
 
@@ -189,7 +189,7 @@ private def mkHighlightedLeanBlock (shouldShow : Bool) (hls : Highlighted) (str:
 Returns (syntax of) an Inline representation containing highlighted Lean code.
 The argument `hls` must be a highlighting of the parsed string `str`.
 -/
-private def mkHighlightedLeanInline (shouldShow : Bool) (hls : Highlighted) (str : StrLit) : DocElabM Term := do
+private def toHighlightedLeanInline (shouldShow : Bool) (hls : Highlighted) (str : StrLit) : DocElabM Term := do
   if !shouldShow then
     return ← ``(Inline.concat #[])
 
@@ -252,7 +252,7 @@ def lean : CodeBlockExpanderOf LeanBlockConfig
       for cmd in cmds do
         hls := hls ++ (← highlight cmd nonSilentMsgs cmdState.infoState.trees)
 
-      mkHighlightedLeanBlock config.show hls str
+      toHighlightedLeanBlock config.show hls str
     finally
       if !config.keep then
         setEnv origEnv
@@ -360,7 +360,7 @@ def leanTerm : CodeBlockExpanderOf LeanInlineConfig
           logMessage msg
 
       let hls := (← highlight stx #[] (PersistentArray.empty.push tree))
-      mkHighlightedLeanBlock config.show hls str
+      toHighlightedLeanBlock config.show hls str
 
 /--
 Elaborates the provided Lean term in the context of the current Verso module.
@@ -451,7 +451,7 @@ def leanInline : RoleExpanderOf LeanInlineConfig
 
       let hls := (← highlight stx #[] (PersistentArray.empty.push tree))
 
-      mkHighlightedLeanInline config.show hls term
+      toHighlightedLeanInline config.show hls term
 
 
 /--
@@ -503,7 +503,7 @@ def inst : RoleExpanderOf LeanBlockConfig
 
       let hls := (← highlight stx #[] (PersistentArray.empty.push tree))
 
-      mkHighlightedLeanInline config.show hls term
+      toHighlightedLeanInline config.show hls term
 
 /--
 Elaborates the contained document in a new section.


### PR DESCRIPTION
1. Pulls out common code from the two inline generating functions and the two block generating functions, towards the goal of minimizing cut and paste when we switch from just `$(quote hlt)` to a more complicated serialization procedure for including highlighted material in files.
2. Eliminates some dead code.
3. Fixes a small bug that meant that `-show` didn't work on `lean` or `inst` roles in VersoManual. This is broken on the current release candidate, but I don't think the code path was ever exercised and noone noticed:

   ```lean
   import VersoManual
   open Verso.Genre.Manual.InlineLean
   #doc (Verso.Genre.Manual) "Bonk" =>
   {lean -show}`43 + 2`
   ```

Stress checked that this did not change the sha1sum of the HTML files generated by compiling the reference manual.

Replaces #549

