### PR TITLE
refactor: reduce output C size with redundancy elimination and serialization

### DIFF
--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -169,9 +169,10 @@ def reportMessages {m} [Monad m] [MonadLog m] [MonadError m]
       throwErrorAt blame "No error expected in code block, one occurred"
 
 /--
-Within the DocElabM monad, `← quoteHighlightViaSerialization hls` should result in a Term with the
-same denotation as `quote hls`, but that often produces smaller code because it quotes a compressed
-version of the highlight.
+Produces, within the DocElabM, a Syntax expression that denotes the `hsl` value. Specifically,
+within the DocElabM monad, `← quoteHighlightViaSerialization hls` will result in a syntax term that
+represents the same highlight as `quote hls`, but will hopefully produce smaller code because of
+quoting a compressed version of the highlight.
 -/
 private def quoteHighlightViaSerialization (hls : Highlighted) : DocElabM Term := do
   let repr := hlToExport hls

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -19,6 +19,33 @@ open Std (HashMap)
 
 namespace SubVerso.Highlighting
 
+
+/--
+Serialize `Highlighted` code as a string.
+
+Nothing should be assumed about the `String` output except that it can be passed to `hlFromExport`
+to recover the original input.
+-/
+def hlToExport (hl: SubVerso.Highlighting.Highlighted) : String :=
+  hl.exportCode |>.toJson |>.compress
+
+/--
+Recover the `Highlighted` data from its serialization.
+
+Can only be expected to work on the output of `hlToExport`.
+-/
+def hlFromExport (exportLit : String) : SubVerso.Highlighting.Highlighted :=
+  match Lean.Json.parse exportLit with
+  | .error e => panic! s!"Failed to parse Highlighted export data as JSON: {e}"
+  | .ok v =>
+    match SubVerso.Highlighting.ExportCode.fromJson? v with
+    | .error e => panic! s!"Failed to deserialize Highlighted export data from parsed JSON: {e}"
+    | .ok v' =>
+      match v'.toHighlighted with
+      | .error e => panic! s!"Failed to deserialize highlighted code from export data: {e}"
+      | .ok hl => hl
+
+
 /--
 Removes n levels of indentation from highlighted code.
 -/

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -42,7 +42,7 @@ def hlFromExport (exportLit : String) : SubVerso.Highlighting.Highlighted :=
     | .error e => panic! s!"Failed to deserialize Highlighted export data from parsed JSON: {e}"
     | .ok v' =>
       match v'.toHighlighted with
-      | .error e => panic! s!"Failed to deserialize highlighted code from export data: {e}"
+      | .error e => panic! s!"Failed to deserialize Highlighted data from export data: {e}"
       | .ok hl => hl
 
 


### PR DESCRIPTION
`Highlighted` objects contain highly redundant information, and the result is that the C code we output at present redundantly represents this redundant information.

This PR steals a trick that @david-christiansen introduced in teorth/analysis#352 of exporting `Highlighted` to the existing `ExportCode` format, serializing the resulting data to JSON, and producing syntax that transforms that resulting string back to Highlighted. (Aggressive compiler optimizations could undo this work, but that does not seem to be an issue at present.)

Leads to a 11% reduction in the output size of C code for the reference manual (as reported by `find .lake/build/ir -name "*.c" | xargs du -c | tail -n 1`) — 1049888 to 936912. 