### PR TITLE
fix: avoid construction of redundant forward-slashes in search results

### DIFF
--- a/static-web/find.js
+++ b/static-web/find.js
@@ -1,9 +1,9 @@
 let params = new URLSearchParams(document.location.search);
 let domains = params.getAll("domain");
-let name = params.get("name");
+let paramName = params.get("name");
 console.log("Domains: " + domains);
-console.log("name: " + name);
-if(name) {
+console.log("name: " + paramName);
+if(paramName) {
     let siteRoot = typeof __versoSiteRoot !== 'undefined' ? __versoSiteRoot : "";
     let options = [];
     if (domains && domains.length > 0) {
@@ -14,14 +14,14 @@ if(name) {
                 console.log('Found domain ' + domain);
                 let opts = xref[domain];
                 if (opts['contents'].hasOwnProperty(name)) {
-                    options = opts['contents'][name].map(x => Object.assign(x, {'domain': domain}));
+                    options = opts['contents'][paramName].map(x => Object.assign(x, {'domain': domain}));
                 }
             }
         }
     } else {
         for (const [dom, opts] of Object.entries(xref)) {
-            if (opts['contents'].hasOwnProperty(name)) {
-                for (const i of opts['contents'][name]) {
+            if (opts['contents'].hasOwnProperty(paramName)) {
+                for (const i of opts['contents'][paramName]) {
                     options.push(Object.assign(i, {'domain': dom}));
                 }
             }
@@ -30,8 +30,8 @@ if(name) {
 
     if (options.length == 0) {
         addEventListener('DOMContentLoaded', event => {
-            document.title = "Not found: '" + name + "'";
-            document.querySelector("#title").innerHTML = "Not found: name '" + name + "'";
+            document.title = "Not found: '" + paramName + "'";
+            document.querySelector("#title").innerHTML = "Not found: name '" + paramName + "'";
             let allDomains = [];
             for (const d in xref) {
                 allDomains.push(d);
@@ -42,12 +42,13 @@ if(name) {
             document.querySelector("#message").innerHTML = "<p>Searched domains:</p>" + "<ul>" + domains.map(x => "<li><code>" + x + "</code>: " + xref[x]['title'] + "</li>\n").join('') + "</ul>";
         });
     } else if (options.length == 1) {
-        let addr = siteRoot + options[0]['address'] + "#" + options[0]['id'];
+        const addr = new URL(options[0]['address'], siteRoot);
+        addr.hash = options[0]['id'];
         window.location.replace(addr);
     } else {
         addEventListener('DOMContentLoaded', event => {
-            document.title = "Ambiguous: '" + name + "'";
-            document.querySelector("#title").innerHTML = "Ambiguous: name '" + name + "'";
+            document.title = "Ambiguous: '" + paramName + "'";
+            document.querySelector("#title").innerHTML = "Ambiguous: name '" + paramName + "'";
             document.querySelector("#message").innerHTML = "<p>Options:</p><ul>" +
                 options.map((x, idx) => '<li><p><a href="' + siteRoot + x['address'] + '#' + x['id'] + '">From ' + xref[x['domain']]['title'] + '</a></p></li>').join('\n') +
                 "</ul>";


### PR DESCRIPTION
Uses the new URL constructor to create addresses; avoids the redundant-forward-slash problem. Closes #555