### PR TITLE
fix: don't emit spurious newlines in markdown docstrings

### DIFF
--- a/src/tests/Tests/TexUnit.lean
+++ b/src/tests/Tests/TexUnit.lean
@@ -11,10 +11,7 @@ Unit tests covering TeX output given given concrete Verso structures.
 
 open Verso Genre.Manual
 
-/--
-info: before\Verb|verb|
-after
--/
+/-- info: before\Verb|verb|after -/
 #guard_msgs in
 #eval do
   let b : Doc.Block Genre.Manual := .concat #[

--- a/src/tests/integration/sample-doc/expected/tex/main.tex
+++ b/src/tests/integration/sample-doc/expected/tex/main.tex
@@ -51,9 +51,7 @@
 \mainmatter
 
 \chapter*{Introduction}
-This is a docstring.Here's some more text with a \Verb|code inline|
- in it.
+This is a docstring.Here's some more text with a \Verb|code inline| in it.
 Here's when a \Verb|code inline|
-
 occurs right before a line break.And then here's a paragraph break.
 \end{document}

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -896,10 +896,7 @@ def Block.leanFromMarkdown (hls : Highlighted) : Block where
 @[inline_extension leanFromMarkdown]
 def leanFromMarkdown.inlinedescr : InlineDescr := withHighlighting {
   traverse _id _data _ := pure none
-  toTeX :=
-    some <| fun go _ _ content => do
-      pure <| .seq <| ← content.mapM fun b => do
-        pure <| .seq #[← go b, .raw "\n"]
+  toTeX := some <| fun go _ _ content => content.mapM go
   toHtml :=
     open Verso.Output Html in
     open Verso.Doc.Html in


### PR DESCRIPTION
Fix one default `toTex` implementation that is not behaving as desired. Change unit tests to reflect desired behavior as opposed to empirically occurring but undesired formed behavior.

Further scrutiny of other cases and more unit tests to come. Resolves #513.