### PR TITLE
chore: replace bv_decide with grind in Z85 impl

### DIFF
--- a/src/verso-util/VersoUtil/BinFiles/Z85.lean
+++ b/src/verso-util/VersoUtil/BinFiles/Z85.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Std.Tactic.BVDecide
-
 set_option guard_msgs.diff true
 set_option linter.missingDocs true
 
@@ -37,7 +35,7 @@ Finds the index of the given character in the alphabet.
 
 Used during decoding.
 -/
-private def alphabetChar (i : UInt32) (h : i < 85 := by bv_decide) : Char :=
+private def alphabetChar (i : UInt32) (h : i < 85 := by grind) : Char :=
   alphabet[i.toNat]
 
 


### PR DESCRIPTION
Now that grind is powerful enough for this proof, it simplifies the setup of the file.

Additionally, a user is experiencing permissions issues related to running bv_decide here, so this will hopefully work around it for now.