### PR TITLE
test: move Examples.lean tests out of the Verso compilation path

### DIFF
--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -3,6 +3,8 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+import Tests.Basic
+import Tests.GenericCode
 import Tests.Golden
 import Tests.Integration
 import Tests.Integration.SampleDoc

--- a/src/tests/Tests/Basic.lean
+++ b/src/tests/Tests/Basic.lean
@@ -3,31 +3,30 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso.Doc.Concrete
-
+import Verso
+namespace Verso.BasicTest
 set_option guard_msgs.diff true
-
-namespace Verso.Examples
-
 set_option pp.rawOnError true
+
+
+/- ----- -/
 
 #docs (.none) noDoc "Nothing" :=
 :::::::
 :::::::
-
 /-- info: Verso.Doc.Part.mk #[Verso.Doc.Inline.text "Nothing"] "Nothing" none #[] #[] -/
 #guard_msgs in
   #eval noDoc
 
-#docs (.none) a "My title here" :=
+
+/- ----- -/
+
+#docs (.none) littleParagraph "My title here" :=
 :::::::
 
 Hello, I'm a paragraph. Yes I am!
 
 :::::::
-
-
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "My title here"]
@@ -37,15 +36,17 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval a
+  #eval littleParagraph
 
-#docs (.none) a' "My title here" :=
+
+/- ----- -/
+
+#docs (.none) listOneItem "My title here" :=
 :::::::
 
 * Just a list with one item
 
 :::::::
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "My title here"]
@@ -55,19 +56,19 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval a'
+  #eval listOneItem
 
 
-#docs (.none) b "My title here" :=
+/- ----- -/
+
+#docs (.none) sectionAndPara "My title here" :=
 :::::::
 
 # Section 1
 
 a paragraph
 
-
 :::::::
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "My title here"]
@@ -82,9 +83,12 @@ info: Verso.Doc.Part.mk
       #[]]
 -/
 #guard_msgs in
-  #eval b
+  #eval sectionAndPara
 
-#docs (.none) c "My title here" :=
+
+/- ----- -/
+
+#docs (.none) nestedDoc1 "My title here" :=
 :::::::
 
 # Section 1
@@ -99,10 +103,7 @@ More text:
 * with two
  * and nested
 
-
-
 :::::::
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "My title here"]
@@ -127,9 +128,12 @@ info: Verso.Doc.Part.mk
           #[]]]
 -/
 #guard_msgs in
-  #eval c
+  #eval nestedDoc1
 
-#docs (.none) c' "My title here" :=
+
+/- ----- -/
+
+#docs (.none) nestedDoc2 "My title here" :=
 :::::::
 
 # Section 1
@@ -144,10 +148,7 @@ More text:
 2. with two
  * and nested
 
-
-
 :::::::
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "My title here"]
@@ -172,9 +173,12 @@ info: Verso.Doc.Part.mk
           #[]]]
 -/
 #guard_msgs in
-  #eval c'
+  #eval nestedDoc2
 
-#docs (.none) c'' "My title here" :=
+
+/- ----- -/
+
+#docs (.none) nestedDoc3 "My title here" :=
 :::::::
 
 # Section 1
@@ -193,9 +197,7 @@ More text:
 
  * and nested
 
-
 :::::::
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "My title here"]
@@ -221,10 +223,12 @@ info: Verso.Doc.Part.mk
           #[]]]
 -/
 #guard_msgs in
-  #eval c''
+  #eval nestedDoc3
 
 
-#docs (.none) d "More writing" :=
+/- ----- -/
+
+#docs (.none) nestedDoc4 "More writing" :=
 :::::::
 
 # Section 1
@@ -237,7 +241,6 @@ Here's a quote;
 Also, 2 > 3.
 
 :::::::
-
 /--
 info: Verso.Doc.Part.mk
   #[Verso.Doc.Inline.text "More writing"]
@@ -257,138 +260,10 @@ info: Verso.Doc.Part.mk
       #[]]
 -/
 #guard_msgs in
-  #eval d
+  #eval nestedDoc4
 
-#docs (.none) e "More writing" :=
-:::::::
 
-# Section 1
-
-Here's some code
-
-```
-(define (zero f z) z)
-(define (succ n) (lambda (f x) (f (n f z))))
-```
-
-:::::::
-
-/--
-info: Verso.Doc.Part.mk
-  #[Verso.Doc.Inline.text "More writing"]
-  "More writing"
-  none
-  #[]
-  #[Verso.Doc.Part.mk
-      #[Verso.Doc.Inline.text "Section 1"]
-      "Section 1"
-      none
-      #[Verso.Doc.Block.para #[Verso.Doc.Inline.text "Here's some code"],
-        Verso.Doc.Block.code "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n"]
-      #[]]
--/
-#guard_msgs in
-  #eval e
-
-#docs (.none) f "More code writing" :=
-:::::::
-
-# Section 1
-
-Here's some `code`!
-
-```
-(define (zero f z) z)
-(define (succ n) (lambda (f x) (f (n f z))))
-```
-
-:::::::
-
-/--
-info: Verso.Doc.Part.mk
-  #[Verso.Doc.Inline.text "More code writing"]
-  "More code writing"
-  none
-  #[]
-  #[Verso.Doc.Part.mk
-      #[Verso.Doc.Inline.text "Section 1"]
-      "Section 1"
-      none
-      #[Verso.Doc.Block.para
-          #[Verso.Doc.Inline.text "Here's some ", Verso.Doc.Inline.code "code", Verso.Doc.Inline.text "!"],
-        Verso.Doc.Block.code "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n"]
-      #[]]
--/
-#guard_msgs in
-  #eval f
-
-#docs (.none) g "Ref link before" :=
-:::::::
-
-# Section 1
-
-[to here]: http://example.com
-
-Here's [a link][to here][^note]!
-
-[^note]: The footnote text
-
-:::::::
-
-/--
-info: Verso.Doc.Part.mk
-  #[Verso.Doc.Inline.text "Ref link before"]
-  "Ref link before"
-  none
-  #[]
-  #[Verso.Doc.Part.mk
-      #[Verso.Doc.Inline.text "Section 1"]
-      "Section 1"
-      none
-      #[Verso.Doc.Block.para
-          #[Verso.Doc.Inline.text "Here's ",
-            Verso.Doc.Inline.link #[(Verso.Doc.Inline.text "a link")] "http://example.com",
-            Verso.Doc.Inline.footnote "note" #[(Verso.Doc.Inline.text "The footnote text")], Verso.Doc.Inline.text "!"]]
-      #[]]
--/
-#guard_msgs in
-  #eval g
-
-#docs (.none) g' "Ref link after" :=
-:::::::
-
-# Section 1
-
-[^note]: The footnote text
-
-Here's [a link][to here][^note]!
-
-[to here]: http://example.com
-
-:::::::
-
-/--
-info: Verso.Doc.Part.mk
-  #[Verso.Doc.Inline.text "Ref link after"]
-  "Ref link after"
-  none
-  #[]
-  #[Verso.Doc.Part.mk
-      #[Verso.Doc.Inline.text "Section 1"]
-      "Section 1"
-      none
-      #[Verso.Doc.Block.para
-          #[Verso.Doc.Inline.text "Here's ",
-            Verso.Doc.Inline.link #[(Verso.Doc.Inline.text "a link")] "http://example.com",
-            Verso.Doc.Inline.footnote "note" #[(Verso.Doc.Inline.text "The footnote text")], Verso.Doc.Inline.text "!"]]
-      #[]]
--/
-#guard_msgs in
-  #eval g'
-
-/-- info: true -/
-#guard_msgs in
-#eval toString (repr g) == (toString (repr g')).replace "after" "before"
+/- ----- -/
 
 -- https://github.com/leanprover/verso/pull/541
 /-- error: Wrong header nesting - got #### but expected at most ### -/

--- a/src/tests/Tests/GenericCode.lean
+++ b/src/tests/Tests/GenericCode.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2023 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import Verso
+namespace Verso.GenericCodeTest
+set_option guard_msgs.diff true
+set_option pp.rawOnError true
+
+
+/- ----- -/
+
+#docs (.none) code1 "More writing" :=
+:::::::
+
+# Section 1
+
+Here's some code
+
+```
+(define (zero f z) z)
+(define (succ n) (lambda (f x) (f (n f z))))
+```
+
+:::::::
+/--
+info: Verso.Doc.Part.mk
+  #[Verso.Doc.Inline.text "More writing"]
+  "More writing"
+  none
+  #[]
+  #[Verso.Doc.Part.mk
+      #[Verso.Doc.Inline.text "Section 1"]
+      "Section 1"
+      none
+      #[Verso.Doc.Block.para #[Verso.Doc.Inline.text "Here's some code"],
+        Verso.Doc.Block.code "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n"]
+      #[]]
+-/
+#guard_msgs in
+  #eval code1
+/--
+info: Verso.Output.Html.tag
+  "section"
+  #[]
+  (Verso.Output.Html.seq
+    #[Verso.Output.Html.tag "h1" #[] (Verso.Output.Html.seq #[Verso.Output.Html.text true "More writing"]),
+      Verso.Output.Html.tag
+        "section"
+        #[]
+        (Verso.Output.Html.seq
+          #[Verso.Output.Html.tag "h2" #[] (Verso.Output.Html.seq #[Verso.Output.Html.text true "Section 1"]),
+            Verso.Output.Html.tag "p" #[] (Verso.Output.Html.seq #[Verso.Output.Html.text true "Here's some code"]),
+            Verso.Output.Html.tag
+              "pre"
+              #[]
+              (Verso.Output.Html.text true "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n")])])
+-/
+#guard_msgs in
+  #eval Doc.Genre.none.toHtml (m:=Id) {logError := fun _ => ()} () () {} {} {} code1 |>.run .empty |>.fst
+
+
+/- ----- -/
+
+#docs (.none) code2 "More code writing" :=
+:::::::
+
+# Section 1
+
+Here's some `code`!
+
+```
+(define (zero f z) z)
+(define (succ n) (lambda (f x) (f (n f z))))
+```
+
+:::::::
+/--
+info: Verso.Doc.Part.mk
+  #[Verso.Doc.Inline.text "More code writing"]
+  "More code writing"
+  none
+  #[]
+  #[Verso.Doc.Part.mk
+      #[Verso.Doc.Inline.text "Section 1"]
+      "Section 1"
+      none
+      #[Verso.Doc.Block.para
+          #[Verso.Doc.Inline.text "Here's some ", Verso.Doc.Inline.code "code", Verso.Doc.Inline.text "!"],
+        Verso.Doc.Block.code "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n"]
+      #[]]
+-/
+#guard_msgs in
+  #eval code2

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -5,6 +5,7 @@ Author: David Thrane Christiansen
 -/
 import SubVerso.Helper
 import SubVerso.Module
+import Verso.Doc.Concrete
 import VersoBlog.Basic
 import VersoBlog.LiterateLeanPage.Options
 import MD4Lean

--- a/src/verso-blog/VersoBlog/Site/Syntax.lean
+++ b/src/verso-blog/VersoBlog/Site/Syntax.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
+import Verso.Doc.Concrete
 import VersoBlog.Site
 
 open Lean Elab Macro Term

--- a/src/verso-manual/VersoManual/Docstring/Progress.lean
+++ b/src/verso-manual/VersoManual/Docstring/Progress.lean
@@ -8,6 +8,7 @@ import Lean.Environment
 import Lean.Meta
 import Lean.DocString.Syntax
 import VersoManual.Basic
+import Verso.Doc.Elab
 
 
 namespace Verso.Genre.Manual

--- a/src/verso-manual/VersoManual/Draft.lean
+++ b/src/verso-manual/VersoManual/Draft.lean
@@ -10,6 +10,7 @@ import Std.Data.HashMap
 import Std.Data.HashSet
 
 import Verso.Doc.ArgParse
+import Verso.Doc.Elab
 import VersoManual.Basic
 
 open Verso.ArgParse

--- a/src/verso-manual/VersoManual/Glossary.lean
+++ b/src/verso-manual/VersoManual/Glossary.lean
@@ -7,8 +7,9 @@ Author: David Thrane Christiansen
 import Lean.Data.Json
 import Lean.Data.Json.FromToJson
 
+import Verso.Doc.Elab
+import Verso.Doc.PointOfInterest
 import VersoManual.Basic
-import Verso.Doc.ArgParse
 
 open Verso Genre Manual ArgParse
 open Verso.Doc.Elab

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -9,6 +9,7 @@ import Lean.Data.Json.FromToJson
 import Std.Data.HashMap
 import Std.Data.HashSet
 
+import Verso.Doc.Elab
 import VersoManual.Basic
 import MultiVerso
 

--- a/src/verso-manual/VersoManual/Markdown.lean
+++ b/src/verso-manual/VersoManual/Markdown.lean
@@ -9,6 +9,7 @@ import MD4Lean
 import Lean.Exception
 
 import Verso.Doc
+import Verso.Doc.Elab
 
 import VersoManual.Basic
 

--- a/src/verso-manual/VersoManual/Table.lean
+++ b/src/verso-manual/VersoManual/Table.lean
@@ -6,6 +6,7 @@ Author: David Thrane Christiansen
 
 import VersoManual.Basic
 import Verso.Doc.ArgParse
+import Verso.Doc.Elab
 
 open Verso Doc Elab
 open Verso.Genre Manual

--- a/src/verso/Verso.lean
+++ b/src/verso/Verso.lean
@@ -19,7 +19,6 @@ import Verso.Doc.Html
 import Verso.Doc.Lsp
 import Verso.Doc.Suggestion
 import Verso.Doc.TeX
-import Verso.Examples
 import Verso.ExpectString
 import Verso.Hover
 import Verso.Instances

--- a/src/verso/Verso/Doc/Html.lean
+++ b/src/verso/Verso/Doc/Html.lean
@@ -5,7 +5,6 @@ Author: David Thrane Christiansen
 -/
 
 import Verso.Doc
-import Verso.Examples
 import Verso.Output.Html
 import Verso.Method
 import Verso.Code.Highlighted
@@ -213,28 +212,7 @@ defmethod Genre.toHtml (g : Genre) [ToHtml g m α]
     (x : α) : StateT (Verso.Code.Hover.State Html) m Html :=
   ToHtml.toHtml x ⟨options, context, state, definitionIds, linkTargets, codeOptions⟩
 
-open Verso.Examples
 
-/--
-info: Verso.Output.Html.tag
-  "section"
-  #[]
-  (Verso.Output.Html.seq
-    #[Verso.Output.Html.tag "h1" #[] (Verso.Output.Html.seq #[Verso.Output.Html.text true "More writing"]),
-      Verso.Output.Html.tag
-        "section"
-        #[]
-        (Verso.Output.Html.seq
-          #[Verso.Output.Html.tag "h2" #[] (Verso.Output.Html.seq #[Verso.Output.Html.text true "Section 1"]),
-            Verso.Output.Html.tag "p" #[] (Verso.Output.Html.seq #[Verso.Output.Html.text true "Here's some code"]),
-            Verso.Output.Html.tag
-              "pre"
-              #[]
-              (Verso.Output.Html.text true "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n")])])
--/
-#guard_msgs in
-  #eval Genre.none.toHtml (m:=Id) {logError := fun _ => ()} () () {} {} {} e |>.run .empty |>.fst
-end
 
 def embody (content : Html) : Html := {{
 <html>


### PR DESCRIPTION
I've been occasionally blocked by Examples.lean failing in a way that makes it difficult or impossible to test a separate piece of code; this PR moves the tests currently in the Examples directory into two files that gets run by lake test. This did weird things with unstable pre-module-system dependencies within the project, which resulted in most of the files that got touched in this PR.