### PR TITLE
fix: unbreak canonical links broken by #557

### DIFF
--- a/static-web/find.js
+++ b/static-web/find.js
@@ -13,7 +13,7 @@ if(paramName) {
             if (xref.hasOwnProperty(domain)) {
                 console.log('Found domain ' + domain);
                 let opts = xref[domain];
-                if (opts['contents'].hasOwnProperty(name)) {
+                if (opts['contents'].hasOwnProperty(paramName)) {
                     options = opts['contents'][paramName].map(x => Object.assign(x, {'domain': domain}));
                 }
             }


### PR DESCRIPTION
I did an "innocent" variable renaming (triggered by a VSCode-suggested deprecation warning that was honestly spurious in the first place) that wasn't tested sufficiently and broke search, mea culpa