### PR TITLE
fix: add new TeX packages to all of CI

### DIFF
--- a/.github/workflows/merge-main-nightly.yml
+++ b/.github/workflows/merge-main-nightly.yml
@@ -95,6 +95,14 @@ jobs:
             upquote
             lineno
             float
+            tcolorbox
+            tikzfill
+            pdfcol
+            listings
+            epstopdf-pkg
+            pgf
+            environ
+            etoolbox
 
       - name: Check `tlmgr` version
         run: tlmgr --version

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -152,6 +152,15 @@ jobs:
           upquote
           lineno
           float
+          tcolorbox
+          tikzfill
+          pdfcol
+          listings
+          epstopdf-pkg
+          pgf
+          environ
+          etoolbox
+
 
     - name: Check `tlmgr` version
       run: tlmgr --version


### PR DESCRIPTION
#607 added some further TeX dependencies, but didn't add them to the nightly-testing update infrastructure.