### PR TITLE
fix: reset hearbeat count for each block

### DIFF
--- a/.reference_manual_revision
+++ b/.reference_manual_revision
@@ -1,3 +1,3 @@
 # This should be a version of https://github.com/leanprover/reference-manual
 # Used to benchmark the performance of verso on the reference manual
-2bfa3475e5e83b8e087622d43d93166bd071e55c
+0f57e73a88cdc16e1c98fa5b2f6315c2df8487b3


### PR DESCRIPTION
At the suggestion of @Kha , avoid the apparent need for bumping heartbeat counts that I had encountered and fixed in leanprover/reference-manual#644 by just resetting the heartbeat count upon each block installation task. Reverts the reference manual benchmarking version to a pre-heartbeat-bumping variant