### PR TITLE
chore: update reference manual benchmark version

### DIFF
--- a/.reference_manual_revision
+++ b/.reference_manual_revision
@@ -1,3 +1,3 @@
 # This should be a version of https://github.com/leanprover/reference-manual
 # Used to benchmark the performance of verso on the reference manual
-0f57e73a88cdc16e1c98fa5b2f6315c2df8487b3
+5267d3840a6e3628063b9edef3347ad4aaf08564


### PR DESCRIPTION
New commit grabs relevant changes from leanprover/reference-manual#648 to sync with leanprover/verso#615