### PR TITLE
fix: compile on macOS Tahoe 26.1

### DIFF
--- a/examples/documented-package/lean-toolchain
+++ b/examples/documented-package/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:4.14.0
+leanprover/lean4:v4.25.2

--- a/examples/website-examples/Examples.lean
+++ b/examples/website-examples/Examples.lean
@@ -44,7 +44,7 @@ def foo (n k : Nat) : Nat :=
   if n < k then
     1 + foo (n + 1) k
   else 0
-termination_by foo n k => k - n
+termination_by k - n
 %end
 
 %example version

--- a/examples/website-examples/lean-toolchain
+++ b/examples/website-examples/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.5.0
+leanprover/lean4:v4.25.2

--- a/examples/website-literate/lean-toolchain
+++ b/examples/website-literate/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.19.0-rc2
+leanprover/lean4:v4.25.2

--- a/examples/website/DemoSite/Blog/Subprojects.lean
+++ b/examples/website/DemoSite/Blog/Subprojects.lean
@@ -57,7 +57,7 @@ Version is:
 
 that is,
 ```leanOutput Examples.version (severity := information)
-"4.5.0"
+"4.25.2"
 ```
 
 Comparing output modulo whitespace differences, with exact:


### PR DESCRIPTION
The version of Lean being used in some of the examples was suffering from issue #5649 "macOS clang fails to link against dylib generated by Lean": https://github.com/leanprover/lean4/issues/5649

This PR bumps the versions so that they compile correctly on macOS.

(I'm investigating this project for the first time. I'm not sure if my proposed changes here harm `subverso` usage / testing, but `lake build` fails for me in the `main` branch without them.)