### PR TITLE
chore: prepare VersoManual.Docstring for module system

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -3,6 +3,11 @@ Copyright (c) 2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+import Lean.PrettyPrinter.Delaborator.Builtins
+import Lean.Elab.Term
+import Lean.DocString
+import Lean.Widget.TaggedText
+import Lean.Meta.Reduce
 
 import Std.Data.HashSet
 
@@ -10,17 +15,26 @@ import VersoManual.Basic
 import VersoManual.HighlightedCode
 import VersoManual.Index
 import VersoManual.Markdown
+import VersoManual.Docstring.Basic
 import VersoManual.Docstring.Config
+import VersoManual.Docstring.DocName
+import VersoManual.Docstring.PrettyPrint
 import VersoManual.Docstring.Progress
+
+import Verso.Instances
 import Verso.Code
+import Verso.Doc.Elab.Block
 import Verso.Doc.Elab.Monad
 import Verso.Doc.ArgParse
+import Verso.Doc.DocName
 import Verso.Doc.PointOfInterest
+import Verso.Doc.Suggestion.Basic
 
 
 import SubVerso.Highlighting
 
 import MD4Lean
+
 
 open Lean
 open Std (HashSet)
@@ -32,6 +46,8 @@ open Verso.Code.Highlighted.WebAssets
 open Lean.Doc.Syntax
 
 open SubVerso.Highlighting
+
+public section
 
 namespace Verso.ArgParse
 
@@ -67,123 +83,7 @@ def ValDesc.documentableName : ValDesc m (Ident × Name) where
 
 end Verso.ArgParse
 
-namespace Verso.Genre.Manual
-
-def getDocString?
-    [Monad m] [MonadLiftT IO m] [MonadOptions m] [MonadLog m] [AddMessageContext m]
-    (env : Environment) (declName : Name) :
-    m (Option String) := do
-  let docs? ← findDocString? env declName
-  if docs?.isNone then
-    if !(← Verso.Genre.Manual.Docstring.getAllowMissing) then
-      Lean.logError m!"'{declName}' is not documented.\n\nSet option 'verso.docstring.allowMissing' to 'true' to allow missing docstrings."
-    else
-      Lean.logWarning m!"'{declName}' is not documented.\n\nSet option 'verso.docstring.allowMissing' to 'false' to disallow missing docstrings."
-  return docs?
-
-
-structure Signature where
-  /-- The signature formatted for wider screens, such as desktop displays -/
-  wide : Highlighted
-  /-- The signature formatted for narrower screens, such as mobile displays -/
-  narrow : Highlighted
-deriving ToJson, FromJson, Quote
-
-namespace Block
-
-namespace Docstring
-
-
-
-private def nameString (x : Name) (showNamespace : Bool) :=
-  if showNamespace then x.toString
-  else
-    match x with
-    | .str _ s => s
-    | _ => x.toString
-
-open Lean.PrettyPrinter Delaborator in
-def ppName (c : Name) (showUniverses := true) (showNamespace : Bool := true) (openDecls : List OpenDecl := []) : MetaM FormatWithInfos :=
-  MonadWithReaderOf.withReader (fun (ρ : Core.Context) => {ρ with openDecls := ρ.openDecls ++ openDecls}) <|do
-  let decl ← getConstInfo c
-  let e := .const c (decl.levelParams.map mkLevelParam)
-  let (stx, infos) ← withOptions (pp.universes.set · true |> (pp.fullNames.set · true)) <|
-    delabCore e (delab := delabConst)
-  -- The special-casing here is to allow the `showNamespace` setting to work. This is perhaps too
-  -- big of a hammer...
-  match stx with
-    | `($x:ident.{$uni,*}) =>
-      let unis : Format ← do
-        if showUniverses then
-          let us ← uni.getElems.toList.mapM (ppCategory `level ·.raw)
-          pure <| ".{" ++ Format.joinSep us ", " ++ "}"
-        else
-          pure .nil
-
-      return ⟨Std.Format.tag SubExpr.Pos.root (.text (nameString x.getId showNamespace)) ++ unis, infos⟩
-    | `($x:ident) =>
-      return ⟨Std.Format.tag SubExpr.Pos.root (Std.Format.text (nameString x.getId showNamespace)), infos⟩
-    | _ =>
-      return ⟨← ppTerm stx, infos⟩
-
-def stripNS : Syntax → Syntax
-  | .ident info substr x pre => .ident info substr x.getString!.toName pre
-  | .node info kind args => .node info kind (args.map stripNS)
-  | other => other
-
-def stripInfo : Syntax → Syntax
-  | .ident _ substr x pre => .ident .none substr x pre
-  | .node _ kind args => .node .none kind (args.map stripInfo)
-  | .atom _ x => .atom .none x
-  | .missing => .missing
-
-
-/--
-Strip an explicit `_root_` from each identifier, to work around configuration problems in the pretty
-printer
--/
-def stripRootPrefix (stx : Syntax) : Syntax :=
-  stx.rewriteBottomUp fun
-  | .ident info substr x pre => .ident info substr (x.replacePrefix `_root_ .anonymous) pre
-  | s => s
-
-open Lean.PrettyPrinter Delaborator in
-/--
-Postprocess Lean's own `ppSignature` to remove the namespace (used for constructors) and any
-`_root_` prefixes that have snuck in. The latter is not strictly correctness preserving, but it's an
-expedient hack. It also removes the info from the constant's name if requested, to avoid unwanted
-linking from a definition site to itself.
--/
-def ppSignature (c : Name) (showNamespace : Bool := true) (openDecls : List OpenDecl := []) (constantInfo : Bool := true) : MetaM FormatWithInfos :=
-  withTheReader Core.Context (fun ρ => {ρ with openDecls := ρ.openDecls ++ openDecls}) <| do
-  let decl ← getConstInfo c
-  let e := .const c (decl.levelParams.map mkLevelParam)
-  let (stx, infos) ← delabCore e (delab := delabConstWithSignature)
-  let stx : Syntax ←
-    stripRootPrefix <$>
-    if showNamespace then pure stx.raw
-    else
-      match stx with
-      | `(declSigWithId|$nameUniv $argsRet:declSig ) => do
-        `(declSigWithId|$(⟨stripNS nameUniv⟩) $argsRet) <&> (·.raw)
-      | _ => pure stx.raw
-  let stx : Syntax ←
-    if constantInfo then pure stx
-    else
-      match stx with
-      | `(declSigWithId|$nameUniv $argsRet:declSig ) => do
-        `(declSigWithId|$(⟨stripInfo nameUniv⟩) $argsRet) <&> (·.raw)
-      | _ => pure stx
-
-  return ⟨← ppTerm ⟨stx⟩, infos⟩  -- HACK: not a term
-
-
-structure DocName where
-  name : Name
-  hlName : Highlighted
-  signature : Highlighted
-  docstring? : Option String
-deriving ToJson, FromJson, Repr, Quote
+namespace Verso.Genre.Manual.Block.Docstring
 
 inductive Visibility where
   | «public» | «private» | «protected»
@@ -253,39 +153,6 @@ def DeclType.label : DeclType → String
   | .recursor _ => "recursor"
   | .other => ""
 
-open Meta in
-def DocName.ofName (c : Name) (ppWidth : Nat := 40) (showUniverses := true) (showNamespace := true) (constantInfo := false) (openDecls : List OpenDecl := []) (checkDocstring : Bool := true) : MetaM DocName := do
-  let env ← getEnv
-  if let some _ := env.find? c then
-    let ctx := {
-      env           := (← getEnv)
-      mctx          := (← getMCtx)
-      options       := (← getOptions)
-      currNamespace := (← getCurrNamespace)
-      openDecls     := (← getOpenDecls)
-      fileMap       := default
-      ngen          := (← getNGen)
-    }
-
-    let ⟨fmt, infos⟩ ← withOptions (·.setBool `pp.tagAppFns true) <|
-      ppSignature c (showNamespace := showNamespace) (openDecls := openDecls) (constantInfo := constantInfo)
-
-    let ttSig := Lean.Widget.TaggedText.prettyTagged (w := ppWidth) fmt
-
-    let sig ← Lean.Widget.tagCodeInfos ctx infos ttSig
-
-    let ⟨fmt, infos⟩ ← withOptions (·.setBool `pp.tagAppFns true) <|
-      ppName c (showUniverses := showUniverses) (showNamespace := showNamespace) (openDecls := openDecls)
-    let ttName := Lean.Widget.TaggedText.prettyTagged (w := ppWidth) fmt
-    let name ← Lean.Widget.tagCodeInfos ctx infos ttName
-
-    let docstring? ← if checkDocstring then  getDocString? env c else Lean.findDocString? env c
-
-    let hlCtx : SubVerso.Highlighting.Context := ⟨{}, false, false, []⟩
-
-    pure { name := c, hlName := (← renderTagged none name hlCtx), signature := (← renderTagged none sig hlCtx), docstring? }
-  else
-    pure { name := c, hlName := .token ⟨.const c "" none false, c.toString⟩, signature := Highlighted.seq #[], docstring? := none }
 
 partial def getStructurePathToBaseStructureAux (env : Environment) (baseStructName : Name) (structName : Name) (path : List Name) : Option (List Name) :=
   if baseStructName == structName then
@@ -1614,7 +1481,7 @@ def highlightDataValue (v : DataValue) : Highlighted :=
     | .ofInt (v : Int) => ⟨.unknown, toString v⟩
     | .ofSyntax (v : Syntax) => ⟨.unknown, toString v⟩ -- TODO
 
-
+@[expose]
 def optionDocs.Args := Ident
 instance : FromArgs optionDocs.Args DocElabM := ⟨.positional `name .ident "The option name"⟩
 

--- a/src/verso-manual/VersoManual/Docstring/Basic.lean
+++ b/src/verso-manual/VersoManual/Docstring/Basic.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+module
+public import Lean.Data.Options
+public import Lean.DocString
+public import Lean.Log
+public import SubVerso.Highlighting.Highlighted
+public import VersoManual.Docstring.Config
+meta import Verso.Instances.Deriving
+
+open Lean
+open SubVerso.Highlighting
+
+namespace Verso.Genre.Manual
+
+public def getDocString?
+    [Monad m] [MonadLiftT IO m] [MonadOptions m] [MonadLog m] [AddMessageContext m]
+    (env : Environment) (declName : Name) :
+    m (Option String) := do
+  let docs? ← findDocString? env declName
+  if docs?.isNone then
+    if !(← Verso.Genre.Manual.Docstring.getAllowMissing) then
+      Lean.logError m!"'{declName}' is not documented.\n\nSet option 'verso.docstring.allowMissing' to 'true' to allow missing docstrings."
+    else
+      Lean.logWarning m!"'{declName}' is not documented.\n\nSet option 'verso.docstring.allowMissing' to 'false' to disallow missing docstrings."
+  return docs?
+
+
+public structure Signature where
+  /-- The signature formatted for wider screens, such as desktop displays -/
+  wide : Highlighted
+  /-- The signature formatted for narrower screens, such as mobile displays -/
+  narrow : Highlighted
+deriving ToJson, FromJson, Quote

--- a/src/verso-manual/VersoManual/Docstring/DocName.lean
+++ b/src/verso-manual/VersoManual/Docstring/DocName.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import SubVerso.Highlighting
+meta import Verso.Instances.Deriving
+import VersoManual.Docstring.Basic
+import VersoManual.Docstring.PrettyPrint
+import Lean.Data.Lsp.Internal
+import Lean.Meta
+import Lean.Widget.TaggedText
+import Lean.Widget.InteractiveCode
+
+open Lean
+open SubVerso.Highlighting
+
+namespace Verso.Genre.Manual.Block.Docstring
+
+
+public structure DocName where
+  name : Name
+  hlName : Highlighted
+  signature : Highlighted
+  docstring? : Option String
+deriving ToJson, FromJson, Repr, Quote
+
+
+open Meta in
+public def DocName.ofName (c : Name) (ppWidth : Nat := 40) (showUniverses := true) (showNamespace := true) (constantInfo := false) (openDecls : List OpenDecl := []) (checkDocstring : Bool := true) : MetaM DocName := do
+  let env ← getEnv
+  if let some _ := env.find? c then
+    let ctx := {
+      env           := (← getEnv)
+      mctx          := (← getMCtx)
+      options       := (← getOptions)
+      currNamespace := (← getCurrNamespace)
+      openDecls     := (← getOpenDecls)
+      fileMap       := default
+      ngen          := (← getNGen)
+    }
+
+    let ⟨fmt, infos⟩ ← withOptions (·.setBool `pp.tagAppFns true) <|
+      ppSignature c (showNamespace := showNamespace) (openDecls := openDecls) (constantInfo := constantInfo)
+
+    let ttSig := Lean.Widget.TaggedText.prettyTagged (w := ppWidth) fmt
+
+    let sig ← Lean.Widget.tagCodeInfos ctx infos ttSig
+
+    let ⟨fmt, infos⟩ ← withOptions (·.setBool `pp.tagAppFns true) <|
+      ppName c (showUniverses := showUniverses) (showNamespace := showNamespace) (openDecls := openDecls)
+    let ttName := Lean.Widget.TaggedText.prettyTagged (w := ppWidth) fmt
+    let name ← Lean.Widget.tagCodeInfos ctx infos ttName
+
+    let docstring? ← if checkDocstring then getDocString? env c else Lean.findDocString? env c
+
+    let hlCtx : SubVerso.Highlighting.Context := ⟨{}, false, false, []⟩
+
+    pure { name := c, hlName := (← renderTagged none name hlCtx), signature := (← renderTagged none sig hlCtx), docstring? }
+  else
+    pure { name := c, hlName := .token ⟨.const c "" none false, c.toString⟩, signature := Highlighted.seq #[], docstring? := none }

--- a/src/verso-manual/VersoManual/Docstring/PrettyPrint.lean
+++ b/src/verso-manual/VersoManual/Docstring/PrettyPrint.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+import Lean.Meta
+public import Lean.Meta.Basic
+import Lean.PrettyPrinter.Delaborator
+
+open Lean
+open Lean.PrettyPrinter Delaborator
+
+namespace Verso.Genre.Manual.Block.Docstring
+
+def stripNS : Syntax → Syntax
+  | .ident info substr x pre => .ident info substr x.getString!.toName pre
+  | .node info kind args => .node info kind (args.map stripNS)
+  | other => other
+
+def stripInfo : Syntax → Syntax
+  | .ident _ substr x pre => .ident .none substr x pre
+  | .node _ kind args => .node .none kind (args.map stripInfo)
+  | .atom _ x => .atom .none x
+  | .missing => .missing
+
+/--
+Strip an explicit `_root_` from each identifier, to work around configuration problems in the pretty
+printer
+-/
+def stripRootPrefix (stx : Syntax) : Syntax :=
+  stx.rewriteBottomUp fun
+  | .ident info substr x pre => .ident info substr (x.replacePrefix `_root_ .anonymous) pre
+  | s => s
+
+/--
+Postprocess Lean's own `ppSignature` to remove the namespace (used for constructors) and any
+`_root_` prefixes that have snuck in. The latter is not strictly correctness preserving, but it's an
+expedient hack. It also removes the info from the constant's name if requested, to avoid unwanted
+linking from a definition site to itself.
+-/
+public def ppSignature (c : Name) (showNamespace : Bool := true) (openDecls : List OpenDecl := []) (constantInfo : Bool := true) : MetaM FormatWithInfos :=
+  withTheReader Core.Context (fun ρ => {ρ with openDecls := ρ.openDecls ++ openDecls}) <| do
+  let decl ← getConstInfo c
+  let e := .const c (decl.levelParams.map mkLevelParam)
+  let (stx, infos) ← delabCore e (delab := delabConstWithSignature)
+  let stx : Syntax ←
+    stripRootPrefix <$>
+    if showNamespace then pure stx.raw
+    else
+      match stx with
+      | `(declSigWithId|$nameUniv $argsRet:declSig ) => do
+        `(declSigWithId|$(⟨stripNS nameUniv⟩) $argsRet) <&> (·.raw)
+      | _ => pure stx.raw
+  let stx : Syntax ←
+    if constantInfo then pure stx
+    else
+      match stx with
+      | `(declSigWithId|$nameUniv $argsRet:declSig ) => do
+        `(declSigWithId|$(⟨stripInfo nameUniv⟩) $argsRet) <&> (·.raw)
+      | _ => pure stx
+
+  return ⟨← ppTerm ⟨stx⟩, infos⟩  -- HACK: not a term
+
+def nameString (x : Name) (showNamespace : Bool) :=
+  if showNamespace then x.toString
+  else
+    match x with
+    | .str _ s => s
+    | _ => x.toString
+
+public def ppName (c : Name) (showUniverses := true) (showNamespace : Bool := true) (openDecls : List OpenDecl := []) : MetaM FormatWithInfos :=
+  MonadWithReaderOf.withReader (fun (ρ : Core.Context) => {ρ with openDecls := ρ.openDecls ++ openDecls}) <|do
+  let decl ← getConstInfo c
+  let e := .const c (decl.levelParams.map mkLevelParam)
+  let (stx, infos) ← withOptions (pp.universes.set · true |> (pp.fullNames.set · true)) <|
+    delabCore e (delab := delabConst)
+  -- The special-casing here is to allow the `showNamespace` setting to work. This is perhaps too
+  -- big of a hammer...
+  match stx with
+    | `($x:ident.{$uni,*}) =>
+      let unis : Format ← do
+        if showUniverses then
+          let us ← uni.getElems.toList.mapM (ppCategory `level ·.raw)
+          pure <| ".{" ++ Format.joinSep us ", " ++ "}"
+        else
+          pure .nil
+
+      return ⟨Std.Format.tag SubExpr.Pos.root (.text (nameString x.getId showNamespace)) ++ unis, infos⟩
+    | `($x:ident) =>
+      return ⟨Std.Format.tag SubExpr.Pos.root (Std.Format.text (nameString x.getId showNamespace)), infos⟩
+    | _ =>
+      return ⟨← ppTerm stx, infos⟩

--- a/src/verso/Verso/Doc/Suggestion.lean
+++ b/src/verso/Verso/Doc/Suggestion.lean
@@ -1,22 +1,15 @@
 /-
-Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 module
+public meta import Verso.Doc.Suggestion.Basic
 public meta import Lean.Server.CodeActions
 
 namespace Verso.Doc.Suggestion
 
 open Lean Elab Server RequestM
-
-meta structure Suggestion where
-  summary : String
-  replacement : String
-deriving TypeName
-
-public meta def saveSuggestion [Monad m] [MonadInfoTree m] (stx : Syntax) (summary replacement: String) : m Unit := do
-  pushInfoLeaf <| .ofCustomInfo {stx := stx, value := Dynamic.mk (Suggestion.mk summary replacement) }
 
 @[code_action_provider]
 public meta def provideSuggestions : CodeActionProvider := fun params snap => do

--- a/src/verso/Verso/Doc/Suggestion/Basic.lean
+++ b/src/verso/Verso/Doc/Suggestion/Basic.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import Lean.Elab.InfoTree.Types
+public import Lean.Elab.InfoTree.Main
+
+namespace Verso.Doc.Suggestion
+
+open Lean Elab
+
+public structure Suggestion where
+  summary : String
+  replacement : String
+deriving TypeName
+
+public def saveSuggestion [Monad m] [MonadInfoTree m] (stx : Syntax) (summary replacement: String) : m Unit := do
+  pushInfoLeaf <| .ofCustomInfo {stx := stx, value := Dynamic.mk (Suggestion.mk summary replacement) }


### PR DESCRIPTION
There's an issue to figure out before enabling it: we need to find a way to programmatically access docstrings (in the server olean) when building in batch mode. Once that's solved, we can enable the module system for the whole manual genre.