### PR TITLE
chore: rule out CSS/JS confusion bugs

### DIFF
--- a/doc/UsersGuide/Manuals.lean
+++ b/doc/UsersGuide/Manuals.lean
@@ -42,6 +42,19 @@ The fields {name}`Block.name` and {name Manual.Inline.name}`Inline.name` are use
 
 Typically, the `inline_extension` and `block_extension` commands are used to simultaneously define an element and its descriptor, registering them for use by {name}`manualMain`.
 
+:::paragraph
+The type {name}`HtmlAssets` contains CSS and JavaScript code.
+{name}`Manual.TraverseState`, {name}`Manual.BlockDescr`, and {name}`Manual.InlineDescr` all inherit from this structure.
+During traversal, HTML assets are collected; they are all included in the final rendered document.
+
+{docstring Manual.HtmlAssets}
+
+Use {name}`HtmlAssets.combine` to combine multiple assets.
+
+{docstring Manual.HtmlAssets.combine}
+
+:::
+
 # Tags and References
 %%%
 tag := "manual-tags"
@@ -152,7 +165,7 @@ tag := "oss-licenses"
 %%%
 
 To facilitate providing appropriate credit to the authors of open-source JavaScript, CSS, and HTML libraries used to render a Verso document, inline and block elements can specify the licenses of components that they include in their rendered output.
-This is done using the {name}`BlockDescr.licenseInfo` and {name}`InlineDescr.licenseInfo` fields.
+This is done using the {name HtmlAssets.licenseInfo}`licenseInfo` field that {name}`BlockDescr` and {name}`InlineDescr` inherit from {name}`HtmlAssets`.
 These contain a {name}`LicenseInfo`:
 
 {docstring LicenseInfo}

--- a/src/tests/Tests/Serialization.lean
+++ b/src/tests/Tests/Serialization.lean
@@ -68,6 +68,12 @@ instance instShrinkableJsSourceMap : Shrinkable JsSourceMap where
     (shrink f.filename |>.map ({ f with filename := · })) ++
     (shrink f.contents |>.map ({ f with contents := · }))
 
+instance : Shrinkable JS where
+  shrink f := shrink f.js |>.map JS.mk
+
+instance : Shrinkable CSS where
+  shrink f := shrink f.css |>.map CSS.mk
+
 instance : Shrinkable JsFile where
   shrink f :=
     (shrink f.filename |>.map ({ f with filename := · })) ++
@@ -146,6 +152,12 @@ instance [Arbitrary α] [BEq α] [Hashable α] : Arbitrary (HashSet α) where
 instance : Arbitrary JsSourceMap where
   arbitrary := do
     return {filename := ← arbitrary, contents := ← arbitrary}
+
+instance : Arbitrary JS where
+  arbitrary := JS.mk <$> arbitrary
+
+instance : Arbitrary CSS where
+  arbitrary := CSS.mk <$> arbitrary
 
 instance : Arbitrary JsFile where
   arbitrary := do

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -379,7 +379,7 @@ def page (toc : List Html.Toc)
     (path : Path) (textTitle : String) (htmlBookTitle contents : Html)
     (state : TraverseState) (config : Config)
     (localItems : Array Html)
-    (showNavButtons : Bool := true) (extraJs : List String := []) : Html :=
+    (showNavButtons : Bool := true) (extraJs : List JS := []) : Html :=
   let toc := {
     title := htmlBookTitle, path := #[], id := "" , sectionNum := some #[], children := toc
   }
@@ -562,7 +562,7 @@ where
     for f in state.extraJsFiles do
       ensureDir (dir.join "-verso-data")
       (dir / "-verso-data" / f.filename).parent |>.forM fun d => ensureDir d
-      IO.FS.writeFile (dir / "-verso-data" / f.filename) f.contents
+      IO.FS.writeFile (dir / "-verso-data" / f.filename) f.contents.js
       if let some m := f.sourceMap? then
         IO.FS.writeFile (dir / "-verso-data" / m.filename) m.contents
     let titleToShow : Html :=

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -345,9 +345,9 @@ public instance : FromJson TraverseState where
     let domains <- v.getObjValAs? _ "domains"
     let ids <- v.getObjValAs? (Array InternalId) "ids"
     let ids := .ofArray ids
-    let extraCss <- v.getObjValAs? (Array String) "extraCss"
+    let extraCss <- v.getObjValAs? (Array CSS) "extraCss"
     let extraCss := .ofArray extraCss
-    let extraJs <- v.getObjValAs? (Array String) "extraJs"
+    let extraJs <- v.getObjValAs? (Array JS) "extraJs"
     let extraJs := .ofArray extraJs
     let extraJsFiles <- HashSet.ofArray <$> v.getObjValAs? (Array _) "extraJsFiles"
     let extraCssFiles <- HashSet.ofArray <$> v.getObjValAs? (Array _) "extraCssFiles"
@@ -392,26 +392,21 @@ local instance [BEq α] [Ord α] : BEq (TreeSet α) where
 local instance [BEq α] [Hashable α] [BEq β] : BEq (HashMap α β) where
   beq := private ptrEqThen fun xs ys => xs.size == ys.size && xs.all (ys[·]?.isEqSome ·)
 
+instance : BEq Contents where
+  beq := ptrEqThen fun c1 c2 =>
+    c1.contents.size == c2.contents.size &&
+    c1.contents.all (c2.contents[·.toName]?.isEqSome ·)
+
 instance : BEq TraverseState where
   beq := private ptrEqThen fun x y =>
+    x.toHtmlAssets == y.toHtmlAssets &&
     ptrEqThen' x.tags y.tags (fun t1 t2 =>
       t1.size == t2.size && t1.all (t2[·]?.isEqSome ·)) &&
-    x.externalTags.size == y.externalTags.size &&
-    (x.externalTags.all fun k v =>
-      match y.externalTags[k]? with
-      | none => false
-      | some v' => v == v') &&
+    x.externalTags == y.externalTags &&
     x.domains == y.domains &&
     x.ids == y.ids &&
-    x.extraCss == y.extraCss &&
-    x.extraJs == y.extraJs &&
-    x.extraJsFiles == y.extraJsFiles &&
-    x.extraCssFiles == y.extraCssFiles &&
     x.quickJump == y.quickJump &&
-    ptrEqThen' x.contents y.contents (fun c1 c2 =>
-      c1.contents.size == c2.contents.size &&
-      c1.contents.all (c2.contents[·.toName]? |>.isEqSome ·)) &&
-    x.licenseInfo == y.licenseInfo
+    x.contents == y.contents
 
 namespace TraverseState
 
@@ -692,9 +687,8 @@ def TraverseContext.inBlock (self : TraverseContext) (block : Lean.Doc.Block i M
 def TraverseContext.sectionNumber (self : TraverseContext) : Array (Option Numbering) :=
   self.headers.map (·.metadata |>.getD {} |>.assignedNumber)
 
-
 /-- Implementations of all the operations needed to use an inline element. -/
-structure InlineDescr where
+structure InlineDescr extends HtmlAssets where
   /-- All registered initializers are called in the state prior to the first traversal. -/
   init : TraverseState → TraverseState := id
 
@@ -713,26 +707,7 @@ structure InlineDescr where
   How to generate HTML. If `none`, generating HTML from a document that contains this inline will fail.
   -/
   toHtml : Option (InlineToHtml Manual (ReaderT ExtensionImpls IO))
-  /--
-  Extra JavaScript to add to a `<script>` tag in the generated HTML's `<head>`
-  -/
-  extraJs : List String := []
-  /--
-  Extra JavaScript to save to the static files directory and load in the generated HTMl's `<head>`
-  -/
-  extraJsFiles : List JsFile := []
-  /--
-  Extra CSS to add to a `<style>` tag in the generated HTML's `<head>`
-  -/
-  extraCss : List String := []
-  /--
-  Extra CSS to save to the static files directory and load in the generated HTMl's `<head>`
-  -/
-  extraCssFiles : List (String × String) := []
-  /--
-  Open-source licenses used by the inline, to be collected for display in the final document.
-  -/
-  licenseInfo : List LicenseInfo := []
+
   /--
   Should this inline be an entry in the page-local ToC? If so, how should it be represented?
 
@@ -755,12 +730,12 @@ structure InlineDescr where
 
 deriving TypeName
 
-instance : Inhabited InlineDescr := ⟨⟨id, default, default, default, default, default, default, default, default, default, default, default⟩⟩
+instance : Inhabited InlineDescr := ⟨⟨default, id, default, default, default, default, default, default⟩⟩
 
 /--
 Implementations of all the operations needed to use a block.
 -/
-structure BlockDescr where
+structure BlockDescr extends HtmlAssets where
   /-- All registered initializers are called in the state prior to the first traversal. -/
   init : TraverseState → TraverseState := id
 
@@ -771,26 +746,7 @@ structure BlockDescr where
   How to generate HTML. If `none`, generating HTML from a document that contains this block will fail.
   -/
   toHtml : Option (BlockToHtml Manual (ReaderT ExtensionImpls IO))
-  /--
-  Extra JavaScript to add to a `<script>` tag in the generated HTML's `<head>`
-  -/
-  extraJs : List String := []
-  /--
-  Extra JavaScript to save to the static files directory and load in the generated HTMl's `<head>`
-  -/
-  extraJsFiles : List JsFile := []
-  /--
-  Extra CSS to add to a `<style>` tag in the generated HTML's `<head>`
-  -/
-  extraCss : List String := []
-  /--
-  Extra CSS to save to the static files directory and load in the generated HTMl's `<head>`
-  -/
-  extraCssFiles : List (String × String) := []
-  /--
-  Open-source licenses used by the block, to be collected for display in the final document.
-  -/
-  licenseInfo : List LicenseInfo := []
+
   /--
   Should this block be an entry in the page-local ToC? If so, how should it be represented?
 
@@ -813,7 +769,7 @@ structure BlockDescr where
   preamble : List String := {}
 deriving TypeName
 
-instance : Inhabited BlockDescr := ⟨⟨id, default, default, default, default, default, default, default, default, default, default, default⟩⟩
+instance : Inhabited BlockDescr := ⟨⟨default, id, default, default, default, default, default, default⟩⟩
 
 syntax (name := inline_extension) "inline_extension" ident : attr
 syntax (name := block_extension) "block_extension" ident : attr
@@ -1400,18 +1356,7 @@ instance : Traverse Manual TraverseM where
     | ⟨name, id?, data, props⟩, content => do
       if let some id := id? then
         if let some impl := (← readThe ExtensionImpls).getBlock? name then
-          for js in impl.extraJs do
-            modify fun s => { s with extraJs := s.extraJs.insert js }
-          for css in impl.extraCss do
-            modify fun s => { s with extraCss := s.extraCss.insert css }
-          for f in impl.extraJsFiles do
-            unless (← get).extraJsFiles.any (·.filename == f.filename) do
-              modify fun s => { s with extraJsFiles := s.extraJsFiles.insert f }
-          for (name, css) in impl.extraCssFiles do
-            unless (← get).extraCssFiles.any (·.filename == name) do
-              modify fun s => { s with extraCssFiles := s.extraCssFiles.insert { filename := name, contents := css } }
-          for licenseInfo in impl.licenseInfo do
-            modify (·.addLicenseInfo licenseInfo)
+          modify fun s => { s with toHtmlAssets := s.toHtmlAssets.combine impl.toHtmlAssets }
 
           impl.traverse id data content
         else
@@ -1425,18 +1370,7 @@ instance : Traverse Manual TraverseM where
     | ⟨name, id?, data⟩, content => do
       if let some id := id? then
         if let some impl := (← readThe ExtensionImpls).getInline? name then
-          for js in impl.extraJs do
-            modify fun s => { s with extraJs := s.extraJs.insert js }
-          for css in impl.extraCss do
-            modify fun s => { s with extraCss := s.extraCss.insert css }
-          for f in impl.extraJsFiles do
-            unless (← get).extraJsFiles.any (·.filename == f.filename) do
-              modify fun s => { s with extraJsFiles := s.extraJsFiles.insert f }
-          for (name, css) in impl.extraCssFiles do
-            unless (← get).extraCssFiles.any (·.filename == name) do
-              modify fun s => { s with extraCssFiles := s.extraCssFiles.insert { filename := name, contents := css } }
-          for licenseInfo in impl.licenseInfo do
-            modify (·.addLicenseInfo licenseInfo)
+          modify fun s => { s with toHtmlAssets := s.toHtmlAssets.combine impl.toHtmlAssets }
 
           impl.traverse id data content
         else

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1501,7 +1501,7 @@ def optionDomainMapper : DomainMapper :=
 
 open Verso.Genre.Manual.Markdown in
 @[block_extension optionDocs]
-def optionDocs.descr : BlockDescr where
+def optionDocs.descr : BlockDescr := withHighlighting {
   init st := st
     |>.setDomainTitle optionDomain "Compiler options"
     |>.addQuickJumpMapper optionDomain optionDomainMapper
@@ -1547,9 +1547,8 @@ def optionDocs.descr : BlockDescr where
       (s!"{name.toString} (Option)", {{<code>{{name.toString}}</code>" (Option)"}})
     ]
   toTeX := some <| fun _goI goB _id _info contents => contents.mapM goB
-  extraCss := [highlightingStyle, docstringStyle]
-  extraJs := [highlightingJs]
-
+  extraCss := [docstringStyle]
+}
 
 def Block.tactic (name : Lean.Elab.Tactic.Doc.TacticDoc) («show» : Option String) : Block where
   name := `Verso.Genre.Manual.tactic

--- a/src/verso-manual/VersoManual/HighlightedCode.lean
+++ b/src/verso-manual/VersoManual/HighlightedCode.lean
@@ -42,24 +42,21 @@ public def tippyJs : JsFile where
     contents := tippy.map
   }
 
-public def tippyCss := ("tippy-border.css", tippy.border.css)
+public def tippyCss : CssFile where
+  filename := "tippy-border.css"
+  contents := tippy.border.css
+
+public def highlightAssets : HtmlAssets where
+  extraCss := { CSS.mk highlightingStyle }
+  extraJs := { JS.mk highlightingJs }
+  extraJsFiles := { popperJs, tippyJs }
+  extraCssFiles := { tippyCss }
+  licenseInfo := { tippy.js, popper.js }
 
 public instance : CanHighlightCode BlockDescr where
   addDependencies b :=
-    {b with
-      extraCss := highlightingStyle :: b.extraCss
-      extraJs := highlightingJs :: b.extraJs
-      extraJsFiles := popperJs :: tippyJs :: b.extraJsFiles
-      extraCssFiles := tippyCss :: b.extraCssFiles
-      licenseInfo := b.licenseInfo |>.insert tippy.js |>.insert popper.js
-      }
+    { b with toHtmlAssets := b.toHtmlAssets.combine highlightAssets }
 
 public instance : CanHighlightCode InlineDescr where
   addDependencies i :=
-    {i with
-      extraCss := highlightingStyle :: i.extraCss
-      extraJs := highlightingJs :: i.extraJs
-      extraJsFiles := popperJs :: tippyJs :: i.extraJsFiles
-      extraCssFiles := tippyCss :: i.extraCssFiles
-      licenseInfo := i.licenseInfo |>.insert tippy.js |>.insert popper.js
-      }
+    { i with toHtmlAssets := i.toHtmlAssets.combine highlightAssets }

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -410,8 +410,8 @@ public def page
     (textTitle : String)
     (bookTitle : Html)
     (contents : Html)
-    (extraCss : HashSet String)
-    (extraJs : HashSet String)
+    (extraCss : HashSet CSS)
+    (extraJs : HashSet JS)
     (localItems : Array Html)
     (extraHead : Array Html := #[])
     (extraContents : Array Html := #[])
@@ -446,8 +446,8 @@ public def page
         <link rel="stylesheet" href="-verso-search/domain-display.css"/>
         {{extraJsFiles.map fun f => ({{<script src=s!"{f.1}" {{if f.2 then defer else #[]}}></script>}})}}
         {{extraStylesheets.map (fun url => {{<link rel="stylesheet" href={{url}}/> }})}}
-        {{extraCss.toArray.map ({{<style>{{Html.text false ·}}</style>}})}}
-        {{extraJs.toArray.map ({{<script>{{Html.text false ·}}</script>}})}}
+        {{extraCss.toArray.map ({{<style>{{Html.text false ·.css}}</style>}})}}
+        {{extraJs.toArray.map ({{<script>{{Html.text false ·.js}}</script>}})}}
         {{extraHead}}
         <script src="-verso-search/search-highlight.js" defer="defer"></script>
       </head>

--- a/src/verso-manual/VersoManual/Html/Basic.lean
+++ b/src/verso-manual/VersoManual/Html/Basic.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+
+public import Lean.Data.Json.FromToJson
+
+set_option linter.missingDocs true
+set_option doc.verso true
+
+open Lean
+namespace Verso.Genre.Manual
+
+/-!
+This module contains wrappers around strings that prevent different formats from being confused by
+accident.
+-/
+
+/--
+Cascading Stylesheet code.
+-/
+public structure CSS where
+  /-- The CSS code -/
+  css : String
+deriving BEq, Hashable, Ord, DecidableEq, Repr
+
+public instance : ToString CSS := ⟨CSS.css⟩
+
+public instance : LE CSS where
+  le x y := x.css ≤ y.css
+
+public instance : DecidableLE CSS := fun x y => inferInstanceAs (DecidableLE String) x.css y.css
+
+public instance : LT CSS where
+  lt x y := x.css < y.css
+
+public instance : DecidableLT CSS := fun x y => inferInstanceAs (DecidableLT String) x.css y.css
+
+public instance : Coe String CSS where
+  coe := CSS.mk
+
+public instance : ToJson CSS where
+  toJson v := .str v.css
+
+public instance : FromJson CSS where
+  fromJson? v := do
+    CSS.mk <$> v.getStr?
+
+/--
+JavaScript code.
+-/
+public structure JS where
+  /-- The JavaScript code -/
+  js : String
+deriving BEq, Hashable, Ord, DecidableEq, Repr
+
+public instance : ToString JS := ⟨JS.js⟩
+
+public instance : LE JS where
+  le x y := x.js ≤ y.js
+
+public instance : DecidableLE JS := fun x y => inferInstanceAs (DecidableLE String) x.js y.js
+
+public instance : LT JS where
+  lt x y := x.js < y.js
+
+public instance : DecidableLT JS := fun x y => inferInstanceAs (DecidableLT String) x.js y.js
+
+public instance : Coe String JS where
+  coe := JS.mk
+
+public instance : ToJson JS where
+  toJson v := .str v.js
+
+public instance : FromJson JS where
+  fromJson? v := do
+    JS.mk <$> v.getStr?

--- a/src/verso-manual/VersoManual/Html/CssFile.lean
+++ b/src/verso-manual/VersoManual/Html/CssFile.lean
@@ -6,6 +6,8 @@ Author: David Thrane Christiansen
 
 module
 public import Lean.Data.Json.FromToJson
+public import VersoManual.Html.Basic
+
 
 namespace Verso.Genre.Manual
 
@@ -22,5 +24,5 @@ deriving BEq, Repr, Hashable, Ord
 An extra JS file to be emitted and added to the page.
 -/
 public structure CssFile extends StaticCssFile where
-  contents : String
+  contents : CSS
 deriving BEq, ToJson, FromJson, Repr, Hashable, Ord

--- a/src/verso-manual/VersoManual/Html/JsFile.lean
+++ b/src/verso-manual/VersoManual/Html/JsFile.lean
@@ -6,6 +6,7 @@ Author: David Thrane Christiansen
 
 module
 public import Lean.Data.Json.FromToJson
+public import VersoManual.Html.Basic
 
 namespace Verso.Genre.Manual
 
@@ -36,6 +37,6 @@ deriving BEq, ToJson, FromJson, Repr, Hashable, Ord
 An extra JS file to be emitted and added to the page.
 -/
 public structure JsFile extends StaticJsFile where
-  contents : String
+  contents : JS
   sourceMap? : Option JsSourceMap
 deriving BEq, ToJson, FromJson, Repr, Hashable, Ord

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -393,7 +393,7 @@ def theIndex.descr : BlockDescr where
     some <| fun _ go _ _ content => do
       pure <| .seq <| ← content.mapM fun b => do
         pure <| .seq #[← go b, .raw "\n"]
-  extraCss := [indexCss]
+  extraCss := {indexCss}
   toHtml :=
     open Verso.Output.Html Doc.Html HtmlT in
     some <| fun goI _goB _ _ _content => do
@@ -427,7 +427,7 @@ def theIndex.descr : BlockDescr where
           </div>
         }}
 where
-  indexCss := r###"
+  indexCss : CSS := r###"
     main .theIndex {
       padding-left: 0;
       font-family: var(--verso-text-font-family);

--- a/src/verso-manual/VersoManual/InlineLean/Signature.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Signature.lean
@@ -20,17 +20,13 @@ open Lean Elab
 
 namespace Verso.Genre.Manual.InlineLean
 
-block_extension Block.signature where
+block_extension Block.signature via withHighlighting where
   traverse _ _ _ := do
     pure none
   toTeX :=
     some <| fun _ go _ _ content => do
       pure <| .seq <| ← content.mapM fun b => do
         pure <| .seq #[← go b, .raw "\n"]
-  extraCss := [highlightingStyle]
-  extraJs := [highlightingJs]
-  extraJsFiles := [popperJs, tippyJs]
-  extraCssFiles := [tippyCss]
   toHtml :=
     open Verso.Output.Html in
     some <| fun _ _ _ data _ => do

--- a/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
+++ b/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
@@ -22,7 +22,7 @@ open Lean Elab
 namespace Verso.Genre.Manual.InlineLean
 
 
-block_extension Block.syntaxError where
+block_extension Block.syntaxError via withHighlighting where
   traverse _ _ _ := pure none
   toTeX :=
     some <| fun _ go _ _ content => do
@@ -71,11 +71,6 @@ block_extension Block.syntaxError where
 }
 "
   ]
-  extraJs := [
-    highlightingJs
-  ]
-  extraJsFiles := [popperJs, tippyJs]
-  extraCssFiles := [tippyCss]
   toHtml :=
     open Verso.Output Html in
     some <| fun _ _ _ data _ => do


### PR DESCRIPTION
This PR makes bugs that confuse JS and CSS code, or that forget to propagate one of the fields, much more difficult by wrapping each code type in a structure and by using the same HTML assets type consistently.