### PR TITLE
fix: pick the first viable newCurrentOption, not the last one

### DIFF
--- a/static-web/search/search-box.js
+++ b/static-web/search/search-box.js
@@ -796,7 +796,7 @@ class SearchBox {
                     if (i === allResults.length - 1 && j === dataItems.length - 1) {
                         lastOption = searchResult;
                     }
-                    if (currentOptionText === resultToText(searchResult)) {
+                    if (currentOptionText === resultToText(searchResult) && !newCurrentOption) {
                         newCurrentOption = searchResult;
                     }
                 }
@@ -820,7 +820,7 @@ class SearchBox {
                     if (i === allResults.length - 1) {
                         lastOption = searchResult;
                     }
-                    if (currentOptionText === resultToText(searchResult)) {
+                    if (currentOptionText === resultToText(searchResult) && !newCurrentOption) {
                         newCurrentOption = searchResult;
                     }
                 }


### PR DESCRIPTION
This PR fixes a behavior I'd observed where search sometimes jumps to the last option where there's a complete word match. (Searching for "Result" on the current reference seems to reproduce this somewhat reliably.) I think this is because we're scrolling to a document that has the *last* complete word match, instead of a document that has the *first* complete word match, and this changes that behavior.