### PR TITLE
chore: use directory references for lake input deps

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -19,7 +19,6 @@ input_dir staticWeb where
   path := "static-web"
 
 input_dir vendorJs where
-  text := true
   path := "vendored-js"
 
 @[default_target]


### PR DESCRIPTION
The main reason for not doing things this way previously was leanprover/lean4#10827, which is long since resolved. 