### PR TITLE
verso-manual: Increase responsive layout breakpoints

### DIFF
--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -140,7 +140,7 @@ header {
     padding-left: .5rem;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     .header-logo-wrapper {
         display: none;
     }
@@ -174,7 +174,7 @@ header {
     }
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     /* There's no header logo on mobile, so the title just needs to reserve space for the burger */
     .header-title {
         margin-left: calc(var(--verso-burger-width) + 1.5rem); /* There's 0.5 rem padding on the burger, and we want some space */
@@ -215,7 +215,7 @@ main [id] {
 }
 
 /** Mobile **/
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     .with-toc > main {
         padding-left: 0;
     }
@@ -233,7 +233,7 @@ main [id] {
     display: none;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     .toc-backdrop {
         display: block;
     }
@@ -258,7 +258,7 @@ main [id] {
     width: var(--verso-toc-width);
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     #toc {
         /* Push the toc off the page on mobile */
         right: 100%;
@@ -510,7 +510,7 @@ main [id] {
     display: none;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     #toggle-toc-click {
         display: inline-flex;
         cursor: pointer;
@@ -692,7 +692,7 @@ main > section {
     position: relative;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     /* Remove extra margin on mobile. */
     main > section > :first-child {
         margin-top: 0;

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -448,7 +448,7 @@ where
       scroll-margin-top: calc(var(--verso-header-height) + 7.5rem);
     }
 
-    @media screen and (max-width: 700px) {
+    @media screen and (max-width: 992px) {
       /* On mobile, the sticky index takes up half the screen. */
       main .theIndex nav {
         position: static;

--- a/static-web/search/search-box.css
+++ b/static-web/search/search-box.css
@@ -8,13 +8,13 @@
     --selected-color: var(--verso-selected-color, #def);
 }
 
-@media screen and (700px < width) {
+@media screen and (992px < width) {
     :root {
         --search-bar-width: 24rem;
     }
 }
 
-@media screen and (width <= 700px) {
+@media screen and (width <= 992px) {
     :root {
         --search-bar-width: 12rem;
     }
@@ -104,7 +104,7 @@
 
 /* Couple the domain tighter with the search term on smaller screens,
    otherwise it's easy to get lost in the results. */
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     #search-wrapper .search-result {
         gap: 0;
         padding: 0.3rem 0.2rem;
@@ -135,7 +135,7 @@
 
 /* Couple the domain tighter with the search term on smaller screens,
    otherwise it's easy to get lost in the results. */
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     #search-wrapper [role="listbox"].focus li[aria-selected="true"],
     #search-wrapper .search-result:hover {
         padding-bottom: calc(0.3rem - 1px);
@@ -187,7 +187,7 @@
 
 /* Couple the domain tighter with the search term on smaller screens,
    otherwise it's easy to get lost in the results. */
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     #search-wrapper .search-result .domain {
         text-align: left;
     }

--- a/static-web/search/search-highlight.css
+++ b/static-web/search/search-highlight.css
@@ -27,7 +27,7 @@
     display: flex;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     #highlight-controls {
         width: 100%;
         bottom: 0px;
@@ -46,7 +46,7 @@
     border: 1px solid #ddd;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 992px) {
     /* Touch-friendly sizing */
     #highlight-prev,
     #highlight-next,


### PR DESCRIPTION
Hello!

Many of the default media rules in verso trigger responsive layout changes when the screen size is at or below 700px. This works great for mobile, but makes sites rendered with verso a little awkward/uncomfortable to read at medium screen sizes, for example on tablets or in tiling window managers, where the sidebar takes up almost half of the screen.

I've increased some of these thresholds to 992px, chosen because it's the breakpoint for large screens in Bootstrap 5.0, and empirically this seemed to work better than larger breakpoints. I've built _Theorem Proving in Lean 4_ with these changes, and you can test/view them here: [https://tpil.ethantwardy.com](https://tpil.ethantwardy.com).