### PR TITLE
EXPERIMENT: rename VersoDoc to DocThunk

### DIFF
--- a/src/tests/TestMain.lean
+++ b/src/tests/TestMain.lean
@@ -36,7 +36,7 @@ Tests manual-genre TeX generation. `dir` is a subdirectory specific to a particu
 which is where actual output should go, and which contains the expected output directory.
 `doc` is the document to be rendered.
 -/
-def testTexOutput (dir : System.FilePath) (doc : Verso.Doc.VersoDoc Verso.Genre.Manual) :
+def testTexOutput (dir : System.FilePath) (doc : Verso.Doc.DocThunk Verso.Genre.Manual) :
     Config →  IO Unit := fun config =>
   let versoConfig : Verso.Genre.Manual.Config := {
     destination := "src/tests/integration" / dir / "output",
@@ -47,7 +47,7 @@ def testTexOutput (dir : System.FilePath) (doc : Verso.Doc.VersoDoc Verso.Genre.
   let runTest : IO Unit  :=
     open Verso Genre Manual in do
     let logError (msg : String) := IO.eprintln msg
-    ReaderT.run (emitTeX logError versoConfig doc.toPart) extension_impls%
+    ReaderT.run (emitTeX logError versoConfig doc.force) extension_impls%
 
   Verso.Integration.runTests {
     testDir := "src/tests/integration" / dir,

--- a/src/tests/Tests/Basic.lean
+++ b/src/tests/Tests/Basic.lean
@@ -16,7 +16,7 @@ set_option pp.rawOnError true
 :::::::
 /-- info: Verso.Doc.Part.mk #[Verso.Doc.Inline.text "Nothing"] "Nothing" none #[] #[] -/
 #guard_msgs in
-  #eval noDoc.toPart
+  #eval noDoc.force
 
 
 /- ----- -/
@@ -36,7 +36,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval littleParagraph.toPart
+  #eval littleParagraph.force
 
 
 /- ----- -/
@@ -56,7 +56,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval listOneItem.toPart
+  #eval listOneItem.force
 
 
 /- ----- -/
@@ -83,7 +83,7 @@ info: Verso.Doc.Part.mk
       #[]]
 -/
 #guard_msgs in
-  #eval sectionAndPara.toPart
+  #eval sectionAndPara.force
 
 
 /- ----- -/
@@ -128,7 +128,7 @@ info: Verso.Doc.Part.mk
           #[]]]
 -/
 #guard_msgs in
-  #eval nestedDoc1.toPart
+  #eval nestedDoc1.force
 
 
 /- ----- -/
@@ -173,7 +173,7 @@ info: Verso.Doc.Part.mk
           #[]]]
 -/
 #guard_msgs in
-  #eval nestedDoc2.toPart
+  #eval nestedDoc2.force
 
 
 /- ----- -/
@@ -223,7 +223,7 @@ info: Verso.Doc.Part.mk
           #[]]]
 -/
 #guard_msgs in
-  #eval nestedDoc3.toPart
+  #eval nestedDoc3.force
 
 
 /- ----- -/
@@ -260,7 +260,7 @@ info: Verso.Doc.Part.mk
       #[]]
 -/
 #guard_msgs in
-  #eval nestedDoc4.toPart
+  #eval nestedDoc4.force
 
 
 /- ----- -/
@@ -276,4 +276,3 @@ info: Verso.Doc.Part.mk
 #### Sub^3section
 
 :::::::
-

--- a/src/tests/Tests/GenericCode.lean
+++ b/src/tests/Tests/GenericCode.lean
@@ -39,7 +39,7 @@ info: Verso.Doc.Part.mk
       #[]]
 -/
 #guard_msgs in
-  #eval code1.toPart
+  #eval code1.force
 /--
 info: Verso.Output.Html.tag
   "section"
@@ -58,7 +58,7 @@ info: Verso.Output.Html.tag
               (Verso.Output.Html.text true "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n")])])
 -/
 #guard_msgs in
-  #eval Doc.Genre.none.toHtml (m:=Id) {logError := fun _ => ()} () () {} {} {} code1.toPart |>.run .empty |>.fst
+  #eval Doc.Genre.none.toHtml (m:=Id) {logError := fun _ => ()} () () {} {} {} code1.force |>.run .empty |>.fst
 
 
 /- ----- -/
@@ -92,4 +92,4 @@ info: Verso.Doc.Part.mk
       #[]]
 -/
 #guard_msgs in
-  #eval code2.toPart
+  #eval code2.force

--- a/src/tests/Tests/LeanCode.lean
+++ b/src/tests/Tests/LeanCode.lean
@@ -70,7 +70,7 @@ info: (some (Verso.Genre.Manual.InlineLean.Inline.lean, [{"seq":
      {"tok": {"kind": {"withType": {"type": "Nat"}}, "content": "3"}}}]}},
  []]))-/
 #guard_msgs in
-#eval match inspect.toPart.content[0]! with
+#eval match inspect.force.content[0]! with
   | .para x => match x[0]! with
     | .other code _ => Option.some (code.name, code.data)
     | _ => .none

--- a/src/tests/Tests/Refs.lean
+++ b/src/tests/Tests/Refs.lean
@@ -24,7 +24,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval regularLink.toPart
+  #eval regularLink.force
 
 
 /- ----- -/
@@ -46,7 +46,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval refLink.toPart
+  #eval refLink.force
 
 
 /- ----- -/
@@ -68,7 +68,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval noteLink.toPart
+  #eval noteLink.force
 
 
 /- ----- -/
@@ -95,7 +95,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval refAndLink.toPart
+  #eval refAndLink.force
 
 #docs (.none) refAndLink2 "Ref/link ordering" :=
 :::::::
@@ -123,13 +123,13 @@ Here's [a link][to here][^note]!
 :::::::
 
 /-- info: true -/
-#guard_msgs in #eval refAndLink.toPart == refAndLink2.toPart
+#guard_msgs in #eval refAndLink.force == refAndLink2.force
 
 /-- info: true -/
-#guard_msgs in #eval refAndLink.toPart == refAndLink3.toPart
+#guard_msgs in #eval refAndLink.force == refAndLink3.force
 
 /-- info: true -/
-#guard_msgs in #eval refAndLink.toPart == refAndLink4.toPart
+#guard_msgs in #eval refAndLink.force == refAndLink4.force
 
 #docs (.none) refAndLinkRecursion "Ref/link recursion" :=
 :::::::
@@ -162,7 +162,7 @@ info: Verso.Doc.Part.mk
   #[]
 -/
 #guard_msgs in
-  #eval refAndLinkRecursion.toPart
+  #eval refAndLinkRecursion.force
 
 /--
 error: Already defined link [foo] as 'https://example.com'

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -528,8 +528,8 @@ def elabLiteratePage (x : Ident) (path : StrLit) (mod : Ident) (config : LitPage
       | _ => p
     else finished
 
-  let ty ← ``(VersoDoc $genre)
-  let doc ← Command.runTermElabM fun _ => finished.toVersoDoc genre ctx docState partState
+  let ty ← ``(DocThunk $genre)
+  let doc ← Command.runTermElabM fun _ => finished.toThunkTerm genre ctx docState partState
   elabCommand <| ← `(def $x : $ty := $doc)
 
 end Literate

--- a/src/verso-blog/VersoBlog/LiterateModuleDocs.lean
+++ b/src/verso-blog/VersoBlog/LiterateModuleDocs.lean
@@ -78,7 +78,7 @@ def elabFromModuleDocs (x : Ident) (path : StrLit) (mod : Ident) (title : StrLit
     let title ← Meta.mkArrayLit (.app (mkConst ``Verso.Doc.Inline) g) title.toList
     withOptions (Compiler.LCNF.compiler.extract_closed.set · false) do
       addAndCompile <| .defnDecl {
-        name, levelParams := [], type := .app (mkConst ``Verso.Doc.VersoDoc) g,
+        name, levelParams := [], type := .app (mkConst ``Verso.Doc.DocThunk) g,
         value := ← Meta.mkAppM ``modToPage! #[
           ← Meta.mkAppM ``VersoLiterate.loadJsonString! #[mkConst jsonName, mkStrLit s!"JSON for {x.getId}"],
           title,
@@ -89,7 +89,7 @@ def elabFromModuleDocs (x : Ident) (path : StrLit) (mod : Ident) (title : StrLit
     pure name
 
   let metadata ← if let some m := metadata? then `(some $m) else `(none)
-  elabCommand <| ← `(command|def $x : VersoDoc $genre := $(mkIdent mod).withMetadata $metadata)
+  elabCommand <| ← `(command|def $x : DocThunk $genre := $(mkIdent mod).withMetadata $metadata)
 
 
 end

--- a/src/verso-literate/VersoLiterate/Exported.lean
+++ b/src/verso-literate/VersoLiterate/Exported.lean
@@ -247,7 +247,7 @@ private partial def mdBlock : MD4Lean.Block → Except String (Block g)
   | .html .. => throw "Literal HTML in Markdown not supported"
   | .hr => throw "Thematic break (horizontal rule) in Markdown not supported"
 
-partial def modToPage [LoadLiterate g] (mod : LitMod) (title : Array (Inline g)) (titleString : String) : Except String (VersoDoc g) := do
+partial def modToPage [LoadLiterate g] (mod : LitMod) (title : Array (Inline g)) (titleString : String) : Except String (DocThunk g) := do
   let mut stack : Array (Part g) := #[]
   let mut p : Part g := {title, titleString, metadata := none, content := #[], subParts := #[]}
 
@@ -305,7 +305,7 @@ partial def modToPage [LoadLiterate g] (mod : LitMod) (title : Array (Inline g))
     let p' := stack.back
     stack := stack.pop
     p := pushPart p' p
-  return VersoDoc.mk (fun _ => p) "{}"
+  return DocThunk.mk (fun _ => p) "{}"
 where
   docstringBlock (doc : LitVersoDocString) : Array (Block g) :=
     let parts := doc.subsections.map loadPart

--- a/src/verso-literate/VersoLiterate/Exported.lean
+++ b/src/verso-literate/VersoLiterate/Exported.lean
@@ -7,6 +7,7 @@ Author: David Thrane Christiansen
 import Lean.Data.Json
 import Lean.DocString.Extension
 import Verso.Doc
+import Verso.Doc.Reconstruct
 import SubVerso.Highlighting
 import SubVerso.Module
 import VersoLiterate.Basic
@@ -305,7 +306,7 @@ partial def modToPage [LoadLiterate g] (mod : LitMod) (title : Array (Inline g))
     let p' := stack.back
     stack := stack.pop
     p := pushPart p' p
-  return DocThunk.mk (fun _ => p) "{}"
+  return DocThunk.value p
 where
   docstringBlock (doc : LitVersoDocString) : Array (Block g) :=
     let parts := doc.subsections.map loadPart

--- a/src/verso-literate/VersoLiterate/Module.lean
+++ b/src/verso-literate/VersoLiterate/Module.lean
@@ -30,7 +30,7 @@ def load (jsonFile : System.FilePath) : IO LitMod := do
   | .error e => throw <| .userError e
   | .ok v => pure v
 
-def modToPage! [LoadLiterate g] (mod : LitMod) (title : Array (Inline g)) (titleString : String) : VersoDoc g :=
+def modToPage! [LoadLiterate g] (mod : LitMod) (title : Array (Inline g)) (titleString : String) : DocThunk g :=
   match modToPage mod title titleString with
   | .error e => panic! s!"Couldn't load {titleString}: {e}"
   | .ok v => v

--- a/src/verso-manual/VersoManual/Literate.lean
+++ b/src/verso-manual/VersoManual/Literate.lean
@@ -101,7 +101,7 @@ def getModuleWithDocs (path : StrLit) (mod : Ident) (title : StrLit) : PartElabM
     let title ← Meta.mkArrayLit (.app (mkConst ``Verso.Doc.Inline) g) title.toList
     withOptions (Compiler.LCNF.compiler.extract_closed.set · false) do
       addAndCompile <| .defnDecl {
-        name, levelParams := [], type := .app (mkConst ``Verso.Doc.VersoDoc) g,
+        name, levelParams := [], type := .app (mkConst ``Verso.Doc.DocThunk) g,
         value := ← Meta.mkAppM ``modToPage! #[
           ← Meta.mkAppM ``VersoLiterate.loadJsonString! #[mkConst jsonName, mkStrLit s!"JSON for {mod.getId}"],
           title,

--- a/src/verso/Verso/Doc/Concrete.lean
+++ b/src/verso/Verso/Doc/Concrete.lean
@@ -9,6 +9,7 @@ public meta import Verso.Parser
 public import Lean.Elab.Command
 public meta import SubVerso.Highlighting.Export
 import Verso.Doc
+import Verso.Doc.Reconstruct
 public import Verso.Doc.Elab
 public meta import Verso.Doc.Elab.Monad
 import Verso.Doc.Concrete.InlineString

--- a/src/verso/Verso/Doc/Concrete.lean
+++ b/src/verso/Verso/Doc/Concrete.lean
@@ -85,7 +85,7 @@ private meta def elabDoc (genre: Term) (title: StrLit) (topLevelBlocks : Array S
   let finished := partElabState.partContext.toPartFrame.close endPos
 
   pushInfoLeaf <| .ofCustomInfo {stx := (← getRef) , value := Dynamic.mk finished.toTOC}
-  finished.toVersoDoc genre ctx docElabState partElabState
+  finished.toThunkTerm genre ctx docElabState partElabState
 
 elab "#docs" "(" genre:term ")" n:ident title:str ":=" ":::::::" text:document ":::::::" : command => do
   findGenreCmd genre
@@ -97,7 +97,7 @@ elab "#docs" "(" genre:term ")" n:ident title:str ":=" ":::::::" text:document "
       | none => panic! "No final token!"
     | _ => panic! "Nothing"
   let doc ← Command.runTermElabM fun _ => elabDoc genre title text.raw.getArgs endTok.getPos!
-  Command.elabCommand (← `(def $n : VersoDoc $genre := $doc))
+  Command.elabCommand (← `(def $n : DocThunk $genre := $doc))
 
 elab "#doc" "(" genre:term ")" title:str "=>" text:completeDocument eoi : term => do
   findGenreTm genre
@@ -215,8 +215,8 @@ private meta def finishDoc (genreSyntax : Term) (title : StrLit) : Command.Comma
   let finished := versoEnv.partState.partContext.toPartFrame.close endPos
 
   let n := mkIdentFrom title (← currentDocName)
-  let doc ← Command.runTermElabM fun _ => finished.toVersoDoc genreSyntax versoEnv.ctx versoEnv.docState versoEnv.partState
-  let ty ← ``(VersoDoc $genreSyntax)
+  let doc ← Command.runTermElabM fun _ => finished.toThunkTerm genreSyntax versoEnv.ctx versoEnv.docState versoEnv.partState
+  let ty ← ``(DocThunk $genreSyntax)
   Command.elabCommand (← `(def $n : $ty := $doc))
 
 syntax (name := replaceDoc) "#doc" "(" term ")" str "=>" : command

--- a/src/verso/Verso/Doc/Elab/Basic.lean
+++ b/src/verso/Verso/Doc/Elab/Basic.lean
@@ -21,7 +21,7 @@ deriving Repr, TypeName, Inhabited
 
 public inductive FinishedPart where
   | mk (titleSyntax : Syntax) (expandedTitle : Array (TSyntax `term)) (titlePreview : String) (metadata : Option (TSyntax `term)) (blocks : Array (TSyntax `term)) (subParts : Array FinishedPart) (endPos : String.Pos.Raw)
-    /-- A name representing a value of type {lean}`VersoDoc` -/
+    /-- A name representing a value of type {lean}`DocThunk` -/
   | included (name : Ident)
 deriving Repr, BEq
 
@@ -41,7 +41,7 @@ public partial def FinishedPart.toSyntax [Monad m] [MonadQuotation m]
     -- let bindings introduced by "chunking" the elaboration may fail to infer types
     let typedBlocks ← blocks.mapM fun b => `(($b : Block $genre))
     ``(Part.mk #[$titleInlines,*] $(quote titleString) $metaStx #[$typedBlocks,*] #[$subStx,*])
-  | .included name => ``(VersoDoc.toPart $name)
+  | .included name => ``(DocThunk.force $name)
 
 public partial def FinishedPart.toTOC : FinishedPart → TOC
   | .mk titleStx _titleInlines titleString _metadata _blocks subParts endPos =>

--- a/src/verso/Verso/Doc/Elab/Basic.lean
+++ b/src/verso/Verso/Doc/Elab/Basic.lean
@@ -5,6 +5,7 @@ Author: David Thrane Christiansen, Rob Simmons
 -/
 module
 public import Verso.Doc
+import Verso.Doc.Reconstruct
 
 open Lean
 

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -14,6 +14,7 @@ import Lean.DocString
 
 import SubVerso.Highlighting
 import Verso.Doc
+import Verso.Doc.Reconstruct
 public import Verso.Doc.ArgParse
 public import Verso.Doc.Elab.InlineString
 meta import Verso.Doc.Elab.InlineString
@@ -532,7 +533,7 @@ public def FinishedPart.toThunkTerm
     | .none => Json.mkObj []
     | .some table => Json.mkObj [("highlight", table.toExport.toJson)]
 
-  ``(DocThunk.mk (fun $docReconstructionPlaceholder => $finishedSyntax) $(quote reconstJson.compress))
+  ``(DocThunk.serialized (fun $docReconstructionPlaceholder => $finishedSyntax) $(quote reconstJson.compress) none)
 
 @[deprecated FinishedPart.toThunkTerm (since := "2025-11-28")]
 public def FinishedPart.toVersoDoc : Term → FinishedPart → DocElabContext → DocElabM.State → PartElabM.State → TermElabM Term := FinishedPart.toThunkTerm

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -463,10 +463,10 @@ unsafe def inlineExpandersForUnsafe (x : Name) : DocElabM (Array InlineExpander)
 public opaque inlineExpandersFor (x : Name) : DocElabM (Array InlineExpander)
 
 /--
-Creates a term denoting a {lean}`VersoDoc` value from a {lean}`FinishedPart`. This is the final step
+Creates a term denoting a {lean}`DocThunk` value from a {lean}`FinishedPart`. This is the final step
 in turning a parsed verso doc into syntax.
 -/
-public def FinishedPart.toVersoDoc
+public def FinishedPart.toThunkTerm
     (genreSyntax : Term)
     (finished : FinishedPart)
     (ctx : DocElabContext)
@@ -532,8 +532,10 @@ public def FinishedPart.toVersoDoc
     | .none => Json.mkObj []
     | .some table => Json.mkObj [("highlight", table.toExport.toJson)]
 
-  ``(VersoDoc.mk (fun $docReconstructionPlaceholder => $finishedSyntax) $(quote reconstJson.compress))
+  ``(DocThunk.mk (fun $docReconstructionPlaceholder => $finishedSyntax) $(quote reconstJson.compress))
 
+@[deprecated FinishedPart.toThunkTerm (since := "2025-11-28")]
+public def FinishedPart.toVersoDoc : Term → FinishedPart → DocElabContext → DocElabM.State → PartElabM.State → TermElabM Term := FinishedPart.toThunkTerm
 
 public abbrev BlockExpander := Syntax → DocElabM (TSyntax `term)
 

--- a/src/verso/Verso/Doc/Name.lean
+++ b/src/verso/Verso/Doc/Name.lean
@@ -28,7 +28,7 @@ theorem unDocName_docName_eq_id : unDocName ∘ docName = id := by
 /-- Treats an identifier as a module that contains Verso using the standard convention -/
 macro "%doc" moduleName:ident : term => do
   let ident := mkIdentFrom moduleName <| docName moduleName.getId
-  `($(ident).toPart)
+  `($(ident).force)
 
 /--
 Treats an identifier as a module that contains Verso using the standard convention if it exists, or
@@ -38,8 +38,8 @@ macro "%doc?" nameOrModuleName:ident : term => do
   let n := mkIdentFrom nameOrModuleName (docName nameOrModuleName.getId)
   let r ← Macro.resolveGlobalName n.getId
   let r := r.filter (·.2.isEmpty) -- ignore field access possibilities here
-  if r.isEmpty then `($(nameOrModuleName).toPart)
-  else `($(n).toPart)
+  if r.isEmpty then `($(nameOrModuleName).force)
+  else `($(n).force)
 
 macro "%docName" moduleName:ident : term =>
   let n := mkIdentFrom moduleName (docName moduleName.getId) |>.getId

--- a/src/verso/Verso/Doc/Reconstruct.lean
+++ b/src/verso/Verso/Doc/Reconstruct.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Rob Simmons
+-/
+
+module
+public import SubVerso.Highlighting
+public import Verso.Doc
+
+set_option doc.verso true
+set_option pp.rawOnError true
+
+namespace Verso.Doc
+open Lean
+
+public structure DocReconstruction where
+  highlightDeduplication : SubVerso.Highlighting.Export
+
+/--
+The result type of values created by Verso's {lit}`#doc` and {lit}`#docs` commands. A value of type
+{name}`DocThunk` represents a partially-serialized document of type {lean}`Part` that can be turned
+into a value by invoking the `DocThunk.force` method. The internal structure of a {name}`DocThunk`
+should not be relied upon.
+-/
+public inductive DocThunk (genre : Genre) where
+  /--
+  A partially-serialized document. If the {name}`replacementMetadata?` is non-{name}`none`, the
+  value will replace the outermost {name}`Part.metadata` field of the reconstructed document.
+  -/
+  | serialized
+      (construct : DocReconstruction → Part genre)
+      (docReconstructionData : String := "{}")
+      (replacementMetadata? : Option (Option genre.PartMetadata))
+
+  /--
+  For pathways that build {lean}`Part` values directly, there is no value in, or need for, a
+  serialization phase.
+  -/
+  | value (part : Part genre)
+
+instance : Inhabited (DocThunk genre) where
+  default := .value default
+
+/--
+Replace the top-level metadata in a {name}`DocThunk` without forcing the thunk.
+-/
+public def DocThunk.withMetadata (metadata? : Option genre.PartMetadata)  : DocThunk genre → DocThunk genre
+  | .serialized construct docReconstStr _ =>
+    .serialized construct docReconstStr (.some metadata?)
+  | .value part =>
+    .value { part with metadata := metadata? }
+
+/--
+A {name}`DocThunk` represents a potentially-not-fully-evaluated {name}`Part`. Calling
+{name}`DocThunk.force` forces evaluation of the {name}`DocThunk` to a {name}`Part`.
+-/
+public def DocThunk.force: DocThunk genre → Part genre
+  | .serialized construct highlight metadata? =>
+    match Json.parse highlight with
+    | .error e => panic! s!"Failed to parse DocThunk's Export data as JSON: {e}"
+    | .ok json =>
+      let part :=
+        if let .ok highlightJson := json.getObjVal? "highlight" then
+          match SubVerso.Highlighting.Export.fromJson? highlightJson with
+          | .error e => panic! s!"Failed to deserialize Export data from parsed JSON: {e}"
+          | .ok table => construct ⟨table⟩
+        else construct ⟨{}⟩
+      match metadata? with
+      | .none => part
+      | .some replacement => { part with metadata := replacement }
+  | .value part => part
+
+@[deprecated DocThunk (since := "2025-12-28")]
+public def VersoDoc : Genre → Type := DocThunk
+
+@[deprecated DocThunk.force (since := "2025-12-28")]
+public def VersoDoc.force : DocThunk genre → Part genre := DocThunk.force
+
+@[deprecated DocThunk.force (since := "2025-12-28")]
+public def VersoDoc.toPart : DocThunk genre → Part genre := DocThunk.force
+
+@[deprecated DocThunk.force (since := "2025-12-28")]
+public def DocThunk.toPart : DocThunk genre → Part genre := DocThunk.force

--- a/src/verso/Verso/Doc/Reconstruct.lean
+++ b/src/verso/Verso/Doc/Reconstruct.lean
@@ -55,7 +55,7 @@ public def DocThunk.withMetadata (metadata? : Option genre.PartMetadata)  : DocT
 A {name}`DocThunk` represents a potentially-not-fully-evaluated {name}`Part`. Calling
 {name}`DocThunk.force` forces evaluation of the {name}`DocThunk` to a {name}`Part`.
 -/
-public def DocThunk.force: DocThunk genre → Part genre
+public def DocThunk.force : DocThunk genre → Part genre
   | .serialized construct highlight metadata? =>
     match Json.parse highlight with
     | .error e => panic! s!"Failed to parse DocThunk's Export data as JSON: {e}"

--- a/src/verso/Verso/Doc/Reconstruct.lean
+++ b/src/verso/Verso/Doc/Reconstruct.lean
@@ -43,7 +43,7 @@ instance : Inhabited (DocThunk genre) where
   default := .value default
 
 /--
-Replace the top-level metadata in a {name}`DocThunk` without forcing the thunk.
+Replaces the top-level metadata in a {name}`DocThunk` without forcing the thunk.
 -/
 public def DocThunk.withMetadata (metadata? : Option genre.PartMetadata)  : DocThunk genre → DocThunk genre
   | .serialized construct docReconstStr _ =>


### PR DESCRIPTION
This PR is a refactoring of some of the intermediate data structure created in #594. `VersoDoc` was an extremely generic name, and `DocThunk`, with a corresponding `DocThunk.force : DocThunk genre -> Part genre` function, better communicates what is happening here: computation of a part is getting deferred during the metaprogramming phase until compiled-program-execution time.

The structure of a `DocThunk` is also changed somewhat, to better represent and support the operation of replacing metadata without evaluating the thunk, and to recognize that some applications build `Part` data directly and so don't have a meaningful serialization step.