### PR TITLE
fix: skip Lean comment syntax

### DIFF
--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Copyright (c) 2025-2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
@@ -7,6 +7,7 @@ import Tests.Basic
 import Tests.Elab
 import Tests.GenericCode
 import Tests.Golden
+import Tests.CommentSkipping
 import Tests.HighlightedToTeX
 import Tests.HtmlEntities
 import Tests.Integration

--- a/src/tests/Tests/CommentSkipping.lean
+++ b/src/tests/Tests/CommentSkipping.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import Tests.CommentSkipping.Doc
+
+/-!
+This test ensures that Lean's parser doesn't skip Lean comment syntax while parsing Verso blocks as
+Lean commands.
+-/
+
+/--
+info: Verso.Doc.Part.mk
+  #[Verso.Doc.Inline.text "Title"]
+  "Title"
+  none
+  #[Verso.Doc.Block.para
+      #[Verso.Doc.Inline.text "/-", Verso.Doc.Inline.linebreak "\n",
+        Verso.Doc.Inline.text "This text should be in the document.", Verso.Doc.Inline.linebreak "\n",
+        Verso.Doc.Inline.text "-/"],
+    Verso.Doc.Block.para #[Verso.Doc.Inline.text "This text is after the Lean comment that should be skipped."],
+    Verso.Doc.Block.ul #[{ contents := #[Verso.Doc.Block.para #[Verso.Doc.Inline.text "abc"]] }],
+    Verso.Doc.Block.para #[Verso.Doc.Inline.text "/- Also this text should be there -/"],
+    Verso.Doc.Block.para #[Verso.Doc.Inline.text "def", Verso.Doc.Inline.linebreak "\n"]]
+  #[]
+-/
+#guard_msgs in
+#eval %doc Tests.CommentSkipping.Doc

--- a/src/tests/Tests/CommentSkipping/Doc.lean
+++ b/src/tests/Tests/CommentSkipping/Doc.lean
@@ -1,0 +1,27 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+import Verso
+
+/-!
+This test ensures that Lean's parser doesn't skip Lean comment syntax while parsing Verso blocks as
+Lean commands.
+-/
+
+#doc (.none) "Title" =>
+
+/-
+This text should be in the document.
+-/
+
+
+This text is after the Lean comment that should be skipped.
+
+* abc
+
+/- Also this text should be there -/
+
+def

--- a/src/verso/Verso/Doc/Elab/Block.lean
+++ b/src/verso/Verso/Doc/Elab/Block.lean
@@ -33,7 +33,7 @@ public partial def elabBlock (block : TSyntax `block) : DocElabM (TSyntax `term)
   decorateClosing block
   match block.raw with
   | .missing =>
-    ``(sorryAx Block (synthetic := true))
+    ``(sorryAx (Block _) (synthetic := true))
   | stx@(.node _ kind _) =>
     let env ← getEnv
     let result ← match (← liftMacroM (expandMacroImpl? env stx)) with


### PR DESCRIPTION
Closes #678. Adding comment syntax to Verso is perhaps a good idea, but we should do so intentionally, not as a side effect of a bug.