### PR TITLE
fix: create well-spanned syntax on verso blocks

### DIFF
--- a/doc/UsersGuide/Releases/v4_28_0.lean
+++ b/doc/UsersGuide/Releases/v4_28_0.lean
@@ -17,4 +17,5 @@ tag := "release-v4.28.0"
 file := "v4.28.0"
 %%%
 
-* Add Release Notes / Changelog to Verso Users guide (@ejgallego, #708)
+* Add Release Notes / Changelog to Verso Users guide (@david-christiansen, @ejgallego, #708)
+* Fix infoview display for inline lean code (@david-christiansen, @ejgallego, #700)

--- a/src/tests/interactive/test-cases/completion_inline.lean
+++ b/src/tests/interactive/test-cases/completion_inline.lean
@@ -8,11 +8,12 @@ open Verso.Genre Manual InlineLean
 ```lean
 theorem test : ∀ (n : Nat), n = n := by
   intros
-     --^ textDocument/completion
+    --^ textDocument/completion
   rfl
 
-def a : Nat := Nat.add 3 2
-                --^ textDocument/completion
+def a (x y z : Nat) : x + y + z = x + (y + z):=
+  Nat.add_assoc x y z
+           --^ textDocument/completion
 
 #print a
 ```

--- a/src/tests/interactive/test-cases/completion_inline.lean.expected.out
+++ b/src/tests/interactive/test-cases/completion_inline.lean.expected.out
@@ -1,8 +1,25 @@
 {"textDocument":
  {"uri": "file:///src/tests/interactive/test-cases/completion_inline.lean"},
- "position": {"line": 9, "character": 7}}
+ "position": {"line": 9, "character": 6}}
 {"items": [], "isIncomplete": true}
 {"textDocument":
  {"uri": "file:///src/tests/interactive/test-cases/completion_inline.lean"},
- "position": {"line": 13, "character": 18}}
-{"items": [], "isIncomplete": true}
+ "position": {"line": 14, "character": 13}}
+{"items":
+ [{"label": "add_sub_assoc",
+   "kind": 23,
+   "data":
+   ["«external:file:///src/tests/interactive/test-cases/completion_inline.lean»",
+    14,
+    13,
+    0,
+    "cNat.add_sub_assoc"]},
+  {"label": "add_assoc",
+   "kind": 23,
+   "data":
+   ["«external:file:///src/tests/interactive/test-cases/completion_inline.lean»",
+    14,
+    13,
+    0,
+    "cNat.add_assoc"]}],
+ "isIncomplete": false}

--- a/src/tests/interactive/test-cases/inline_goals.lean.expected.out
+++ b/src/tests/interactive/test-cases/inline_goals.lean.expected.out
@@ -19,4 +19,5 @@
 {"textDocument":
  {"uri": "file:///src/tests/interactive/test-cases/inline_goals.lean"},
  "position": {"line": 20, "character": 7}}
-null
+{"rendered": "```lean\nn✝ : Nat\n⊢ n✝ = n✝\n```",
+ "goals": ["n✝ : Nat\n⊢ n✝ = n✝"]}


### PR DESCRIPTION
We did push `genre` and `title` to the last block syntax, but this
broke the infotree span invariant, causing problems when retrieving
the goals.

Co-authored-by: David Thrane Christiansen <david@lean-fro.org>
