### PR TITLE
fix: easier access to remote link targets

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -214,7 +214,7 @@ structure RenderConfig extends Config where
   /--
   How to insert links in rendered code
   -/
-  linkTargets : TraverseState → LinkTargets Manual.TraverseContext := TraverseState.localTargets
+  linkTargets : TraverseState → Multi.AllRemotes → LinkTargets Manual.TraverseContext := (·.localTargets ++ ·.remoteTargets)
 
 namespace Config
 
@@ -232,6 +232,21 @@ def addSearch (config : Config) : Config := { config with features := config.fea
 
 end Config
 
+namespace RenderConfig
+
+/--
+Adds a bundled version of KaTeX to the document.
+-/
+@[deprecated "Set the `features` field instead (though KaTeX is enabled by default, so this is probably not needed)" (since := "2025-11-12")]
+def addKaTeX (config : Config) : Config := { config with features := config.features.insert .KaTeX }
+
+/--
+Adds search dependencies to the configuration.
+-/
+@[deprecated "Set the `features` field instead (though search is enabled by default, so this is probably not needed)" (since := "2025-11-12")]
+def addSearch (config : Config) : Config := { config with features := config.features.insert .search }
+
+end RenderConfig
 
 /--
 Removes all parts that are specified as draft-only.
@@ -576,7 +591,7 @@ where
     let opts : Html.Options IO := {logError := fun msg => logError msg}
     let ctxt := {logError}
     let definitionIds := state.definitionIds ctxt
-    let linkTargets := config.linkTargets state
+    let linkTargets := config.linkTargets state (← read)
     let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {})
     let introHtml ← Html.seq <$> text.content.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {})
     let bookToc ← text.subParts.mapM (fun p => toc 0 opts (ctxt.inPart p) state definitionIds linkTargets p)
@@ -668,7 +683,7 @@ where
     let opts : Html.Options IO := {logError := fun msg => logError msg}
     let ctxt := {logError}
     let definitionIds := state.definitionIds ctxt
-    let linkTargets := config.linkTargets state
+    let linkTargets := config.linkTargets state (← read)
     let toc ← text.subParts.toList.mapM fun p =>
       toc config.htmlDepth opts (ctxt.inPart p) state definitionIds linkTargets p
     let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {} ·)


### PR DESCRIPTION
Link target insertion became more difficult to connect to remote links in the tutorials branch due to the phase separation that it introduced. This PR makes it once again easy to have remote targets, and adds them by default.