### PR TITLE
chore: update plausible dependency to v4.28.0-rc1

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "009dc1e6f2feb2c96c081537d80a0905b2c6498f",
+   "rev": "7311586e1a56af887b1081d05e80c11b6c41d212",
    "name": "plausible",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
During the v4.28.0-rc1 release, verso's dependency on plausible wasn't recorded in release_repos.yml, so the manifest wasn't updated when bumping the toolchain.

This updates the plausible dependency to the v4.28.0-rc1 tagged commit.