### PR TITLE
chore: deploy generated manual to Netlify for PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,9 @@ jobs:
                   publish-dir: _out/html-multi
                   production-branch: main
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  alias: ${{ github.event_name == 'pull_request' && format('verso-pr-{0}', github.event.number) || format('ref-{0}', github.ref_name) }}
+                  alias:
+                      ${{ github.event_name == 'pull_request' && format('verso-pr-{0}',
+                      github.event.number) || format('ref-{0}', github.ref_name) }}
                   deploy-message: |
                       ${{ github.event_name == 'pull_request' && format('pr#{0}: {1}', github.event.number, github.event.pull_request.title) || format('ref/{0}: {1}', github.ref_name, steps.deploy-info.outputs.message) }}
                   enable-commit-comment: false


### PR DESCRIPTION
This PR adds a Netlify deployment for the main branch and for PRs. It deploys the Verso manual's HTML output. 