### PR TITLE
chore: switch from lychee to linkchecker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,14 +127,12 @@ jobs:
                   lake build Verso.Hover:literate
                   lake exe verso-html .lake/build/literate htmlout
 
+            - name: Install linkchecker
+              run: pip install linkchecker
+
             - name: Check internal links on the test website
-              uses: lycheeverse/lychee-action@v2.6.1
-              with:
-                  format: markdown
-                  jobSummary: true
-                  args:
-                      --base './_out/test-projects/demosite' --no-progress --offline
-                      './_out/test-projects/demosite/**/*.html'
+              run: |
+                  linkchecker --config=.linkchecker/linkcheckerrc --no-status ./_out/test-projects/demosite/
 
             - name: Generate the manual
               run: |

--- a/.linkchecker/linkcheckerrc
+++ b/.linkchecker/linkcheckerrc
@@ -1,0 +1,2 @@
+[filtering]
+ignorewarnings=url-content-too-large,url-too-long


### PR DESCRIPTION
We can't trivially upgrade lychee due to changes in command-line arguments (#738). Rather than updating the config, this PR switches to linkchecker, which is better for Verso anyway due to supporting `<base>` tags. We should standardize on it more broadly.