### PR TITLE
fix: deployment of PR previews was broken by actions update

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -39,6 +39,7 @@ jobs:
               with:
                   publish-dir: html-manual
                   production-branch: main
+                  production-deploy: false
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   alias: verso-pr-${{ steps.pr-info.outputs.pullRequestNumber }}
                   deploy-message:


### PR DESCRIPTION
I just noticed that PR deployments linked to the wrong place. This should fix it.