### PR TITLE
fix(blog): fix handling of hidden lean blocks 

### DIFF
--- a/src/tests/Tests/VersoBlog.lean
+++ b/src/tests/Tests/VersoBlog.lean
@@ -42,7 +42,6 @@ def freshId_second_is_hint_with_1 (hint : LetterString) (path : Path) : Bool := 
   let i' := st.freshId path hint.sluggify
   i != i' && (hint.isEmpty || (i == hint.sluggify && i' == (s!"{hint}1").sluggify))
 
-
 open scoped Plausible.Decorations in
 private def testProp
     (p : Prop) (cfg : Configuration := {})
@@ -65,3 +64,24 @@ def runBlogTests : IO Nat := do
     unless res matches .success .. do
       failures := failures + 1
   return failures
+
+-- Regression test for hidden blog Lean blocks.
+#doc (Post) "Hidden Lean Block Flags" =>
+```leanInit post
+```
+
+```lean post -show
+def base : Nat := 40
+```
+
+```lean post -keep
+def scratch : Nat := base + 2
+```
+
+```lean post
+example : base = 40 := rfl
+```
+
+```lean post +error
+#check scratch
+```

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -525,7 +525,7 @@ def lean : CodeBlockExpanderOf LeanBlockConfig
       if config.show then
         `(Block.other (Blog.BlockExt.highlightedCode { contextName := $(quote x.getId), showProofStates := $(quote config.showProofStates) } $(quote hls)) #[Block.code $(quote str.getString)])
       else
-        ``(Block.concat [])
+        ``(Block.concat #[])
 
 
 structure LeanInlineConfig where


### PR DESCRIPTION
- replace hidden blog Lean block expansion from `Block.concat []` to `Block.concat #[]` in `src/verso-blog/VersoBlog.lean`
- add a regression `#doc` in `src/tests/Tests/VersoBlog.lean` covering `-show` and `-keep` flags for blog Lean code blocks

Fixes #760.