### PR TITLE
fix: align inline Lean role names with Manual

### DIFF
--- a/doc/UsersGuide/Releases.lean
+++ b/doc/UsersGuide/Releases.lean
@@ -6,7 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoManual
 
-import UsersGuide.Releases.«v4_29_0_rc2»
+import UsersGuide.Releases.«v4_29_0»
 import UsersGuide.Releases.«v4_28_0»
 
 open Verso Genre Manual
@@ -27,5 +27,5 @@ Verso versioning follows Lean's.
 This means that we release a new version for each Lean release, usually once per month.
 In particular, note that Verso doesn't follow the [semantic versioning model](https://semver.org/).
 
-{include 0 UsersGuide.Releases.«v4_29_0_rc2»}
+{include 0 UsersGuide.Releases.«v4_29_0»}
 {include 0 UsersGuide.Releases.«v4_28_0»}

--- a/doc/UsersGuide/Releases/v4_29_0.lean
+++ b/doc/UsersGuide/Releases/v4_29_0.lean
@@ -11,10 +11,11 @@ open Verso.Genre
 -- To allow ```` below
 set_option linter.verso.markup.codeBlock false
 
-#doc (Manual) "Verso 4.29.0-rc2 (unreleased)" =>
+#doc (Manual) "Verso 4.29.0 (unreleased)" =>
 %%%
-tag := "release-v4.29.0-rc2"
-file := "v4.29.0-rc2"
+tag := "release-v4.29.0"
+file := "v4.29.0"
 %%%
 
-* [fix: Verso folding ranges / TOC for Lean.Doc syntax and #doc](https://github.com/leanprover/verso/pull/768)
+* Fix Verso folding ranges / TOC for Lean.Doc syntax and #doc (#768)
+* Align Blog inline Lean role naming with Manual; add `{lean}` and deprecate `{leanInline}` (#762)

--- a/src/tests/Tests/VersoBlog.lean
+++ b/src/tests/Tests/VersoBlog.lean
@@ -85,3 +85,23 @@ example : base = 40 := rfl
 ```lean post +error
 #check scratch
 ```
+
+-- Regression test for inline Lean role naming in Blog:
+-- canonical `{lean}` works without warnings.
+#docs (Post) inlineLeanRoleNames "Inline Lean Role Names" :=
+```leanInit post
+```
+
+Canonical role: {lean post}`Nat.succ 1`.
+
+/--
+warning: `{leanInline}` is deprecated; use `{lean}` instead.
+-/
+#docs (Post) inlineLeanRoleNamesDeprecated "Inline Lean Role Names (deprecated alias)" :=
+```leanInit post2
+```
+
+Legacy role: {leanInline post2}`Nat.succ 1`.
+
+#guard inlineLeanRoleNames.toPart.content.size > 0
+#guard inlineLeanRoleNamesDeprecated.toPart.content.size > 0

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -599,8 +599,7 @@ where
     modifyInfoState fun s => { s with trees := f s.trees }
 
 open SubVerso.Highlighting Highlighted in
-@[role]
-def leanInline : RoleExpanderOf LeanInlineConfig
+private def leanInlineImpl : RoleExpanderOf LeanInlineConfig
   | config, elts => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"lean block") <| do
     let #[code] := elts
       | throwError "Expected precisely one code element"
@@ -674,6 +673,19 @@ def leanInline : RoleExpanderOf LeanInlineConfig
       let hls := (← highlight stx #[] (PersistentArray.empty.push tree))
 
       `(Inline.other (Blog.InlineExt.highlightedCode { contextName := $(quote config.exampleContext.getId) } $(quote hls)) #[Inline.code $(quote str.getString)])
+
+@[role lean]
+def leanCanonical : RoleExpanderOf LeanInlineConfig :=
+  leanInlineImpl
+
+@[role]
+def leanInline : RoleExpanderOf LeanInlineConfig
+  | config, elts => do
+    if h : 0 < elts.size then
+      logWarningAt elts[0] "`{leanInline}` is deprecated; use `{lean}` instead."
+    else
+      logWarning "`{leanInline}` is deprecated; use `{lean}` instead."
+    leanInlineImpl config elts
 
 open Lean.Elab.Tactic.GuardMsgs
 export WhitespaceMode (exact lax normalized)


### PR DESCRIPTION
This PR harmonizes the naming of the inline Lean role between the blog and manual genres, so that users don't need to remember the difference.

Fixes #762