### PR TITLE
fix: add space and period to "et al" in citations

### DIFF
--- a/src/verso-manual/VersoManual/Bibliography.lean
+++ b/src/verso-manual/VersoManual/Bibliography.lean
@@ -271,7 +271,7 @@ where
     else if h : p.authors.size = 1 then
       go <| Bibliography.lastName p.authors[0]
     else if h : p.authors.size > 3 then
-      (· ++ {{<em>"et al"</em>}}) <$> go (Bibliography.lastName p.authors[0])
+      (· ++ {{" "<em>"et al."</em>}}) <$> go (Bibliography.lastName p.authors[0])
     else andList <$> p.authors.mapM (go ∘ Bibliography.lastName)
 
 open Verso.Doc.TeX in
@@ -308,7 +308,7 @@ where
     else if h : p.authors.size = 1 then
       go <| Bibliography.lastName p.authors[0]
     else if h : p.authors.size > 3 then
-      (· ++ \TeX{\em{"et al"} }) <$> go (Bibliography.lastName p.authors[0])
+      (· ++ \TeX{" " \em{"et al."} }) <$> go (Bibliography.lastName p.authors[0])
     else andListTeX <$> p.authors.mapM (go ∘ Bibliography.lastName)
 
 private def arrayOrd (ord : Ord α) : Ord (Array α) := inferInstance


### PR DESCRIPTION
This adds a missing space before "et al" and the standard trailing period ("et al.") in both HTML and TeX citation rendering.

Currently, when a reference has more than 3 authors, the inline citation renders as `Smithet al` instead of `Smith et al.`

**Before:**
![before](https://raw.githubusercontent.com/kim-em/verso-citation-mwe/master/pr783-before.png)

**After:**
![after](https://raw.githubusercontent.com/kim-em/verso-citation-mwe/master/pr783-after.png)

MWE: https://github.com/kim-em/verso-citation-mwe

Fixes #780

🤖 Prepared with Claude Code