### PR TITLE
chore: upgrade to TeX Live 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
             - name: Install PDF Dependencies
               uses: zauguin/install-texlive@v4
               with:
-                  texlive_version: 2025
+                  texlive_version: 2026
                   packages: |
                       scheme-minimal
                       l3packages
@@ -90,8 +90,8 @@ jobs:
                       textcase
                       memoir
                       sourcecodepro
-                      sourcesanspro
-                      sourceserifpro
+                      sourcesans
+                      sourceserif
                       fvextra
                       upquote
                       lineno


### PR DESCRIPTION
TeX Live 2026 was released on 2026-03-01. When a new release comes out, the previous version is archived to historic mirrors (https://tug.org/historic), which have very limited availability — the release announcement explicitly notes "More historic mirrors would be welcome."

This caused CI to fail immediately with `Error: No mirror available` for `texlive_version: 2025`.

This PR upgrades to TL2026, which required two additional fixes:
- `sourcesanspro` was renamed to `sourcesans` ([CTAN](https://www.ctan.org/pkg/sourcesans))
- `sourceserifpro` was renamed to `sourceserif` ([CTAN](https://ctan.org/pkg/sourceserifpro))

Both old names are absent from TL2026 even as aliases.

Ref: https://tug.org/pipermail/tex-live/2026-March/052232.html

🤖 Prepared with Claude Code