### PR TITLE
chore: mark vendored-js as vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendored-js/** linguist-vendored


### PR DESCRIPTION
This causes GitHub Linguist to not count it as part of Verso per se.