### PR TITLE
chore: abstract out TeX setup in Actions

### DIFF
--- a/.github/actions/install-texlive/action.yml
+++ b/.github/actions/install-texlive/action.yml
@@ -1,0 +1,52 @@
+name: Install TeXLive
+description: Install TeXLive with packages needed for Verso PDF generation
+
+runs:
+    using: composite
+    steps:
+        - name: Install PDF Dependencies
+          uses: zauguin/install-texlive@v4
+          with:
+              texlive_version: 2026
+              packages: |
+                  scheme-minimal
+                  l3packages
+                  tools
+                  latex-bin
+                  xpatch
+                  booktabs
+                  footmisc
+                  environ
+                  hyperref
+                  titlesec
+                  tocloft
+                  enumitem
+                  fmtcount
+                  glossaries
+                  datatool
+                  caption
+                  babel
+                  fontspec
+                  textcase
+                  memoir
+                  sourcecodepro
+                  sourcesans
+                  sourceserif
+                  fvextra
+                  upquote
+                  lineno
+                  float
+                  tcolorbox
+                  tikzfill
+                  pdfcol
+                  listings
+                  epstopdf-pkg
+                  pgf
+                  environ
+                  etoolbox
+                  ulem
+                  newunicodechar
+
+        - name: Check `tlmgr` version
+          shell: bash
+          run: tlmgr --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,50 +65,7 @@ jobs:
                   lake build
 
             - name: Install PDF Dependencies
-              uses: zauguin/install-texlive@v4
-              with:
-                  texlive_version: 2026
-                  packages: |
-                      scheme-minimal
-                      l3packages
-                      tools
-                      latex-bin
-                      xpatch
-                      booktabs
-                      footmisc
-                      environ
-                      hyperref
-                      titlesec
-                      tocloft
-                      enumitem
-                      fmtcount
-                      glossaries
-                      datatool
-                      caption
-                      babel
-                      fontspec
-                      textcase
-                      memoir
-                      sourcecodepro
-                      sourcesans
-                      sourceserif
-                      fvextra
-                      upquote
-                      lineno
-                      float
-                      tcolorbox
-                      tikzfill
-                      pdfcol
-                      listings
-                      epstopdf-pkg
-                      pgf
-                      environ
-                      etoolbox
-                      ulem
-                      newunicodechar
-
-            - name: Check `tlmgr` version
-              run: tlmgr --version
+              uses: ./.github/actions/install-texlive
 
             - name: Run tests
               run: |

--- a/.github/workflows/merge-main-nightly.yml
+++ b/.github/workflows/merge-main-nightly.yml
@@ -64,50 +64,7 @@ jobs:
                   lake exe simplepage
 
             - name: Install PDF Dependencies
-              uses: zauguin/install-texlive@v4
-              with:
-                  texlive_version: 2025
-                  packages: |
-                      scheme-minimal
-                      l3packages
-                      tools
-                      latex-bin
-                      xpatch
-                      booktabs
-                      footmisc
-                      environ
-                      hyperref
-                      titlesec
-                      tocloft
-                      enumitem
-                      fmtcount
-                      glossaries
-                      datatool
-                      caption
-                      babel
-                      fontspec
-                      textcase
-                      memoir
-                      sourcecodepro
-                      sourcesanspro
-                      sourceserifpro
-                      fvextra
-                      upquote
-                      lineno
-                      float
-                      tcolorbox
-                      tikzfill
-                      pdfcol
-                      listings
-                      epstopdf-pkg
-                      pgf
-                      environ
-                      etoolbox
-                      ulem
-                      newunicodechar
-
-            - name: Check `tlmgr` version
-              run: tlmgr --version
+              uses: ./.github/actions/install-texlive
 
             - name: Generate the manual
               run: |

--- a/.github/workflows/update-nightly.yml
+++ b/.github/workflows/update-nightly.yml
@@ -121,50 +121,7 @@ jobs:
                   lake exe simplepage
 
             - name: Install PDF Dependencies
-              uses: zauguin/install-texlive@v4
-              with:
-                  texlive_version: 2025
-                  packages: |
-                      scheme-minimal
-                      l3packages
-                      tools
-                      latex-bin
-                      xpatch
-                      booktabs
-                      footmisc
-                      environ
-                      hyperref
-                      titlesec
-                      tocloft
-                      enumitem
-                      fmtcount
-                      glossaries
-                      datatool
-                      caption
-                      babel
-                      fontspec
-                      textcase
-                      memoir
-                      sourcecodepro
-                      sourcesanspro
-                      sourceserifpro
-                      fvextra
-                      upquote
-                      lineno
-                      float
-                      tcolorbox
-                      tikzfill
-                      pdfcol
-                      listings
-                      epstopdf-pkg
-                      pgf
-                      environ
-                      etoolbox
-                      ulem
-                      newunicodechar
-
-            - name: Check `tlmgr` version
-              run: tlmgr --version
+              uses: ./.github/actions/install-texlive
 
             - name: Generate the manual
               run: |


### PR DESCRIPTION
This gets rid of issues around inconsistent setups.