### PR TITLE
fix: activate/deactivate scoped items with leanSection

### DIFF
--- a/src/tests/Tests/Integration/LeanSection.lean
+++ b/src/tests/Tests/Integration/LeanSection.lean
@@ -28,6 +28,26 @@ The variable {lean}`n` should be in scope here.
 
 After the section, `n` should no longer be in scope.
 
+:::leanSection "MacroScope"
+
+```lean -show
+private axiom innerVal : Nat
+local macro "myMacroTerm" : term => ``(innerVal)
+```
+
+Inside the section, {lean}`myMacroTerm` resolves to `innerVal`.
+
+:::
+
+Right after the section closes, `myMacroTerm` should be unknown: {lean +error}`myMacroTerm`
+
+```lean -show
+private axiom outerVal : Nat
+local macro "myMacroTerm" : term => ``(outerVal)
+```
+
+After the section, {lean}`myMacroTerm` should resolve unambiguously to `outerVal` only.
+
 :::::::
 
 end Verso.Integration.LeanSection

--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -592,10 +592,16 @@ def leanSection : DirectiveExpander
     let newScopes := headers.foldl (init := scopes) fun acc header =>
       { curScope with header } :: acc
     setScopes newScopes
+    -- Push scoped environment extensions for each scope level (matching what `section` does),
+    -- so that local macros and scoped attributes defined inside are properly deactivated on exit.
+    for _ in headers do
+      Lean.pushScope
     let result ← contents.mapM elabBlock
-    -- Pop the scopes we pushed
+    -- Pop the scopes we pushed (both the scope list and the scoped extensions)
     let scopes ← getScopes
     setScopes (scopes.drop headers.length)
+    for _ in headers do
+      Lean.popScope
     return result
 
 private def getClass : MessageSeverity → String


### PR DESCRIPTION
The prior fix to leanSection removed an important feature. This PR adds a test and fixes the bug.