### PR TITLE
fix: avoid netlify rewriting

### DIFF
--- a/doc/UsersGuide/Basic.lean
+++ b/doc/UsersGuide/Basic.lean
@@ -113,6 +113,7 @@ Mixing incompatible features results in an ordinary Lean type error.
 # Index
 %%%
 tag := "index"
+file := "the-index"
 number := false
 %%%
 


### PR DESCRIPTION
Netlify appears to turn `Index/` into `index.html`, even when Pretty URLs is disabled. 
Consequently, 
https://verso.lean-lang.org/doc/latest/Index/#index
is broken, because it has the same content as
https://verso.lean-lang.org/doc/latest/index.html
which in particular means a `<base>` href of `"."`, which is very wrong.

Compare a similar fix that was done to the lean reference manual:
https://github.com/leanprover/reference-manual/commit/8acff2f6e6fbaf748dc6d9ce0faae54d5a0e1bca