### PR TITLE
chore: add !consistent PR-comment auto-fix for lean-toolchain drift

### DIFF
--- a/.github/workflows/consistent-pr-comment.yml
+++ b/.github/workflows/consistent-pr-comment.yml
@@ -70,8 +70,18 @@ jobs:
 
             - name: Sync test-project lean-toolchains
               run: |
-                  for proj in test-projects/literate-config test-projects/literate-multi-root; do
-                    cp lean-toolchain "$proj/lean-toolchain"
+                  targets=(
+                    test-projects/literate-config/lean-toolchain
+                    test-projects/literate-multi-root/lean-toolchain
+                  )
+                  for t in "${targets[@]}"; do
+                    if [ -L "$t" ]; then
+                      echo "Refusing to write through symlink: $t"
+                      exit 1
+                    fi
+                  done
+                  for t in "${targets[@]}"; do
+                    cp lean-toolchain "$t"
                   done
 
             - name: Commit and push
@@ -79,7 +89,9 @@ jobs:
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add -A
+                  git add -- \
+                    test-projects/literate-config/lean-toolchain \
+                    test-projects/literate-multi-root/lean-toolchain
                   if git diff --cached --quiet; then
                     echo "No consistency fixes needed"
                     echo "changes=false" >> "$GITHUB_OUTPUT"
@@ -98,4 +110,16 @@ jobs:
                         repo: context.repo.repo,
                         comment_id: context.payload.comment.id,
                         content: '${{ steps.commit.outputs.changes == 'true' && 'rocket' || '+1' }}'
+                      });
+
+            - name: Add failure reaction
+              if: failure()
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      await github.rest.reactions.createForIssueComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        comment_id: context.payload.comment.id,
+                        content: 'confused'
                       });

--- a/.github/workflows/consistent-pr-comment.yml
+++ b/.github/workflows/consistent-pr-comment.yml
@@ -1,0 +1,101 @@
+name: Fix toolchain consistency on PR Comment
+
+on:
+    issue_comment:
+        types: [created]
+
+jobs:
+    consistent:
+        # Only run on PR comments containing "!consistent"
+        if: >-
+            github.event.issue.pull_request && contains(github.event.comment.body, '!consistent')
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Check user permission
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      const { data: permission } = await github.rest.repos.getCollaboratorPermissionLevel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        username: context.payload.comment.user.login
+                      });
+                      const level = permission.permission;
+                      if (level !== 'admin' && level !== 'write') {
+                        core.setFailed(
+                          `User ${context.payload.comment.user.login} does not have write access (permission: ${level})`
+                        );
+                      }
+
+            - name: Get PR details
+              id: pr-details
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      const { data: pr } = await github.rest.pulls.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.payload.issue.number
+                      });
+                      const isFork = pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+                      if (isFork && !pr.maintainer_can_modify) {
+                        core.setFailed(
+                          'Cannot push to this fork PR. The PR author must enable "Allow edits by maintainers".'
+                        );
+                      }
+
+            - name: Add reaction to acknowledge
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      await github.rest.reactions.createForIssueComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        comment_id: context.payload.comment.id,
+                        content: 'eyes'
+                      });
+
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Checkout PR branch
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: gh pr checkout ${{ github.event.issue.number }}
+
+            - name: Sync test-project lean-toolchains
+              run: |
+                  for proj in test-projects/literate-config test-projects/literate-multi-root; do
+                    cp lean-toolchain "$proj/lean-toolchain"
+                  done
+
+            - name: Commit and push
+              id: commit
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add -A
+                  if git diff --cached --quiet; then
+                    echo "No consistency fixes needed"
+                    echo "changes=false" >> "$GITHUB_OUTPUT"
+                  else
+                    git commit -m "ci: sync test-project lean-toolchains"
+                    git push
+                    echo "changes=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Add completion reaction
+              uses: actions/github-script@v8
+              with:
+                  script: |
+                      await github.rest.reactions.createForIssueComment({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        comment_id: context.payload.comment.id,
+                        content: '${{ steps.commit.outputs.changes == 'true' && 'rocket' || '+1' }}'
+                      });

--- a/.github/workflows/consistent-subverso-manifests.yml
+++ b/.github/workflows/consistent-subverso-manifests.yml
@@ -55,12 +55,10 @@ jobs:
                   ROOT_TC=$(cat lean-toolchain)
                   echo "Root lean-toolchain: $ROOT_TC"
                   FAILED=0
-                  FIXCMDS=""
                   for proj in test-projects/literate-config test-projects/literate-multi-root; do
                     PROJ_TC=$(cat "$proj/lean-toolchain")
                     if [ "$PROJ_TC" != "$ROOT_TC" ]; then
                       echo "MISMATCH: $proj/lean-toolchain ($PROJ_TC) does not match root ($ROOT_TC)"
-                      FIXCMDS+="cp lean-toolchain $proj/lean-toolchain"$'\n'
                       FAILED=1
                     else
                       echo "OK: $proj/lean-toolchain"
@@ -68,7 +66,6 @@ jobs:
                   done
                   if [ "$FAILED" -ne 0 ]; then
                     echo ""
-                    echo "To fix, run:"
-                    echo "$FIXCMDS"
+                    echo "To fix automatically, comment '!consistent' on the PR."
                     exit 1
                   fi

--- a/.github/workflows/consistent-subverso-manifests.yml
+++ b/.github/workflows/consistent-subverso-manifests.yml
@@ -55,15 +55,20 @@ jobs:
                   ROOT_TC=$(cat lean-toolchain)
                   echo "Root lean-toolchain: $ROOT_TC"
                   FAILED=0
+                  FIXCMDS=""
                   for proj in test-projects/literate-config test-projects/literate-multi-root; do
                     PROJ_TC=$(cat "$proj/lean-toolchain")
                     if [ "$PROJ_TC" != "$ROOT_TC" ]; then
                       echo "MISMATCH: $proj/lean-toolchain ($PROJ_TC) does not match root ($ROOT_TC)"
+                      FIXCMDS+="cp lean-toolchain $proj/lean-toolchain"$'\n'
                       FAILED=1
                     else
                       echo "OK: $proj/lean-toolchain"
                     fi
                   done
                   if [ "$FAILED" -ne 0 ]; then
+                    echo ""
+                    echo "To fix, run:"
+                    echo "$FIXCMDS"
                     exit 1
                   fi


### PR DESCRIPTION
When the test-project `lean-toolchain` files drift from the root `lean-toolchain`, the consistency check now points the reader at a new comment-triggered workflow: commenting `!consistent` on the PR runs `cp lean-toolchain test-projects/*/lean-toolchain` and pushes the fix back to the PR branch, matching the existing `!prettier` pattern.