### PR TITLE
chore: format Python

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,4 +1,4 @@
-name: Check Formatting of JS/CSS/HTML and Markdown
+name: Check Code Formatting
 
 on:
     pull_request:
@@ -17,3 +17,15 @@ jobs:
                   dry: true
                   prettier_options: "--check ."
                   prettier_version: 3.7.4
+
+    check-python-formatting:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+
+            - name: Check Python formatting with ruff
+              run: uvx ruff format --check .

--- a/.github/workflows/ensure-format.yml
+++ b/.github/workflows/ensure-format.yml
@@ -1,4 +1,4 @@
-name: Format JS/CSS/HTML and Markdown
+name: Auto-format Code
 
 on:
     workflow_dispatch:
@@ -18,3 +18,23 @@ jobs:
                   prettier_options: "--write ."
                   commit_message: "Run the Prettier code formatter"
                   prettier_version: 3.7.4
+
+    ruff:
+        needs: prettier
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+
+            - name: Format Python with ruff
+              run: uvx ruff format .
+
+            - name: Commit and push if changed
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add -A
+                  git diff --staged --quiet || (git commit -m "Run the Ruff Python formatter" && git push)

--- a/browser-tests/conftest.py
+++ b/browser-tests/conftest.py
@@ -15,8 +15,9 @@ REDIRECTS_JSON_PATH = DEFAULT_SITE_DIR + "/xref.json"
 def find_free_port():
     """Find an available port by binding to port 0."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(('127.0.0.1', 0))
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
 
 def load_redirects():
     """Load redirects from JSON file and return a list of (source, target) tuples."""
@@ -24,8 +25,11 @@ def load_redirects():
     with open(json_path) as f:
         data = json.load(f)
 
-    sections = data['Verso.Genre.Manual.section']['contents']
-    return [(s, sections[s][0]['address'] + '#' + sections[s][0]['id']) for s in sections]
+    sections = data["Verso.Genre.Manual.section"]["contents"]
+    return [
+        (s, sections[s][0]["address"] + "#" + sections[s][0]["id"]) for s in sections
+    ]
+
 
 def get_sample_redirects(n=10):
     """Get a random sample of n redirects for testing."""
@@ -34,45 +38,48 @@ def get_sample_redirects(n=10):
         return redirects
     return random.sample(redirects, n)
 
+
 def pytest_addoption(parser):
     parser.addoption(
         "--port",
         action="store",
         default=None,
-        help="Port for the local test server (default: auto-select)"
+        help="Port for the local test server (default: auto-select)",
     )
     parser.addoption(
         "--site-dir",
         action="store",
         default=DEFAULT_SITE_DIR,
-        help="Path to the built site directory"
+        help="Path to the built site directory",
     )
     parser.addoption(
         "--server-url",
         action="store",
         default=None,
-        help="Use an existing server instead of starting one (e.g., http://localhost:3000)"
+        help="Use an existing server instead of starting one (e.g., http://localhost:3000)",
     )
     parser.addoption(
         "--num-redirects",
         action="store",
         default=10,
         type=int,
-        help="Number of random redirects to test (default: 10)"
+        help="Number of random redirects to test (default: 10)",
     )
     parser.addoption(
         "--seed",
         action="store",
         default=None,
         type=int,
-        help="Random seed for reproducible redirect selection"
+        help="Random seed for reproducible redirect selection",
     )
+
 
 def pytest_configure(config):
     """Set random seed if provided."""
     seed = config.getoption("--seed")
     if seed is not None:
         random.seed(seed)
+
 
 def pytest_generate_tests(metafunc):
     """Generate test cases for each sampled redirect."""
@@ -82,6 +89,7 @@ def pytest_generate_tests(metafunc):
         # Create readable test IDs
         ids = [f"{source}->{target}" for source, target in redirects]
         metafunc.parametrize("redirect_case", redirects, ids=ids)
+
 
 @pytest.fixture(scope="session")
 def server(request):
@@ -105,17 +113,19 @@ def server(request):
         ["python", "-m", "http.server", str(port), "--bind", "127.0.0.1"],
         cwd=site_dir,
         stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL
+        stderr=subprocess.DEVNULL,
     )
     time.sleep(1)
     yield f"http://127.0.0.1:{port}"
     proc.terminate()
     proc.wait()
 
+
 @pytest.fixture(scope="session")
 def playwright_instance():
     with sync_playwright() as p:
         yield p
+
 
 @pytest.fixture(scope="session", params=["chromium", "firefox"])
 def browser(request, playwright_instance):
@@ -124,6 +134,7 @@ def browser(request, playwright_instance):
     browser = getattr(playwright_instance, browser_type).launch()
     yield browser
     browser.close()
+
 
 @pytest.fixture
 def page(browser):

--- a/browser-tests/literate/test_accessibility.py
+++ b/browser-tests/literate/test_accessibility.py
@@ -54,7 +54,12 @@ class TestAccessibility:
 
     def test_heading_hierarchy(self, server: str, page: Page):
         """Test at most one h1 per page and no heading level gaps."""
-        for path in ["/LitConfig/", "/LitConfig/Core/", "/LitConfig/Core/Basic/", "/LitConfig/NoDocstrings/"]:
+        for path in [
+            "/LitConfig/",
+            "/LitConfig/Core/",
+            "/LitConfig/Core/Basic/",
+            "/LitConfig/NoDocstrings/",
+        ]:
             page.goto(f"{server}{path}")
             page.wait_for_load_state("networkidle")
 
@@ -74,7 +79,7 @@ class TestAccessibility:
             for i in range(1, len(levels)):
                 gap = levels[i] - levels[i - 1]
                 assert gap <= 1, (
-                    f"Page {path}: heading gap from h{levels[i-1]} to h{levels[i]} "
+                    f"Page {path}: heading gap from h{levels[i - 1]} to h{levels[i]} "
                     f"(levels: {levels})"
                 )
 
@@ -92,7 +97,9 @@ class TestAccessibility:
         found_search = False
         for _ in range(10):
             page.keyboard.press("Tab")
-            focused = page.evaluate("() => document.activeElement?.getAttribute('role')")
+            focused = page.evaluate(
+                "() => document.activeElement?.getAttribute('role')"
+            )
             if focused == "searchbox":
                 found_search = True
                 break
@@ -109,7 +116,9 @@ class TestAccessibility:
         expect(skip_link).to_be_focused()
 
         outline = skip_link.evaluate("el => getComputedStyle(el).outlineStyle")
-        assert outline != "none", f"Expected focus outline on skip-link, got outline-style: {outline}"
+        assert outline != "none", (
+            f"Expected focus outline on skip-link, got outline-style: {outline}"
+        )
 
     def test_collapsible_aria(self, server: str, page: Page):
         """Test <details> open/closed state is correct and keyboard-operable."""
@@ -139,7 +148,12 @@ class TestAccessibility:
         page.wait_for_load_state("networkidle")
 
         # Inject axe-core from vendored local copy
-        axe_js_path = Path(__file__).parent.parent.parent / "vendored-js" / "axe-core" / "axe.min.js"
+        axe_js_path = (
+            Path(__file__).parent.parent.parent
+            / "vendored-js"
+            / "axe-core"
+            / "axe.min.js"
+        )
         page.evaluate(axe_js_path.read_text())
 
         results = page.evaluate("""() => {
@@ -165,7 +179,9 @@ class TestAccessibility:
                 nodes = ", ".join(n.get("html", "?") for n in v.get("nodes", [])[:3])
                 messages.append(f"  - {v['id']}: {v['help']} ({nodes})")
             violation_report = "\n".join(messages)
-            assert False, f"axe-core found {len(violations)} accessibility violation(s):\n{violation_report}"
+            assert False, (
+                f"axe-core found {len(violations)} accessibility violation(s):\n{violation_report}"
+            )
 
     def test_reduced_motion(self, server: str, page: Page):
         """Test that with prefers-reduced-motion: reduce, transition durations are near 0."""
@@ -231,7 +247,7 @@ class TestAccessibility:
 
         # Parse RGB values and compute relative luminance
         def parse_rgb(color_str):
-            match = re.search(r'rgb[a]?\((\d+),\s*(\d+),\s*(\d+)', color_str)
+            match = re.search(r"rgb[a]?\((\d+),\s*(\d+),\s*(\d+)", color_str)
             if match:
                 return int(match.group(1)), int(match.group(2)), int(match.group(3))
             return None
@@ -249,7 +265,9 @@ class TestAccessibility:
         bg = parse_rgb(colors["backgroundColor"])
 
         assert fg is not None, f"Failed to parse foreground color: {colors['color']}"
-        assert bg is not None, f"Failed to parse background color: {colors['backgroundColor']}"
+        assert bg is not None, (
+            f"Failed to parse background color: {colors['backgroundColor']}"
+        )
 
         l1 = relative_luminance(*fg)
         l2 = relative_luminance(*bg)

--- a/browser-tests/literate/test_content.py
+++ b/browser-tests/literate/test_content.py
@@ -37,7 +37,9 @@ class TestContent:
         # Collect all mod-doc and code-box children in order
         elements = content.locator(":scope > .mod-doc, :scope > .code-box")
         count = elements.count()
-        assert count >= 3, f"Expected at least 3 content elements (mod-doc + code-box), got {count}"
+        assert count >= 3, (
+            f"Expected at least 3 content elements (mod-doc + code-box), got {count}"
+        )
 
         # Verify we have both types
         classes = [elements.nth(i).evaluate("el => el.className") for i in range(count)]
@@ -139,7 +141,9 @@ class TestContent:
         assert imports_list.count() >= 1, "Expected imports-list details element"
 
         # Should be collapsed by default
-        assert not imports_list.evaluate("el => el.open"), "imports-list should be collapsed by default"
+        assert not imports_list.evaluate("el => el.open"), (
+            "imports-list should be collapsed by default"
+        )
 
         # Click summary to open
         summary = imports_list.locator("summary")
@@ -165,7 +169,9 @@ class TestContent:
 
         # Before hover: opacity should be 0 (CSS: .copy-button { opacity: 0 })
         opacity = copy_btn.evaluate("el => getComputedStyle(el).opacity")
-        assert opacity == "0", f"Expected copy button opacity 0 before hover, got {opacity}"
+        assert opacity == "0", (
+            f"Expected copy button opacity 0 before hover, got {opacity}"
+        )
 
         # Verify the CSS rule exists: .code-box:hover .copy-button { opacity: 1 }
         has_hover_rule = page.evaluate("""() => {
@@ -180,7 +186,9 @@ class TestContent:
             }
             return false;
         }""")
-        assert has_hover_rule, "Expected CSS rule .code-box:hover .copy-button { opacity: 1 }"
+        assert has_hover_rule, (
+            "Expected CSS rule .code-box:hover .copy-button { opacity: 1 }"
+        )
 
     def test_copy_button_click(self, server: str, page: Page):
         """Test that clicking the copy button adds .copied class."""
@@ -250,4 +258,6 @@ class TestContent:
         # The h1 in module pages comes from the module docstring heading
         # LitConfig has "# LitConfig: A Test Module" as its first heading
         h1_text = h1.inner_text()
-        assert "LitConfig" in h1_text, f"Expected h1 to contain 'LitConfig', got '{h1_text}'"
+        assert "LitConfig" in h1_text, (
+            f"Expected h1 to contain 'LitConfig', got '{h1_text}'"
+        )

--- a/browser-tests/literate/test_search.py
+++ b/browser-tests/literate/test_search.py
@@ -52,7 +52,9 @@ class TestSearch:
 
         # Should have navigated away from the current page
         url = page.url
-        assert url != f"{server}/LitConfig/", f"Expected navigation from search result, still at {url}"
+        assert url != f"{server}/LitConfig/", (
+            f"Expected navigation from search result, still at {url}"
+        )
 
     def test_search_no_results(self, server: str, page: Page):
         """Test that gibberish query shows no results."""

--- a/browser-tests/test_katex.py
+++ b/browser-tests/test_katex.py
@@ -1,5 +1,6 @@
 from playwright.sync_api import expect, Page
 
+
 class TestKaTeX:
     def test_katex_render(self, server: str, page: Page):
         """Test that the markup page contains at least one rendered KaTeX math."""

--- a/browser-tests/test_redirect.py
+++ b/browser-tests/test_redirect.py
@@ -1,8 +1,7 @@
-
-
 import pytest
 import re
 from playwright.sync_api import expect, Page
+
 
 class TestRedirect:
     def test_redirect(self, server: str, page: Page, redirect_case: tuple[str, str]):

--- a/browser-tests/test_search.py
+++ b/browser-tests/test_search.py
@@ -1,14 +1,18 @@
 from playwright.sync_api import expect, Page
 
+
 class TestSearch:
     def test_searchbar(self, server: str, page: Page):
         """Test that the search box can find suggestions."""
-        page.goto(f"{server}") 
+        page.goto(f"{server}")
 
         page.get_by_role("searchbox").type("syntactic ASTs libraries extensions")
-        expect(page.get_by_role("searchbox")).to_match_aria_snapshot('- searchbox "Search": syntactic ASTs libraries extensions')
+        expect(page.get_by_role("searchbox")).to_match_aria_snapshot(
+            '- searchbox "Search": syntactic ASTs libraries extensions'
+        )
         print(page.get_by_label("Results").aria_snapshot())
-        expect(page.get_by_label("Results")).to_match_aria_snapshot("""
+        expect(page.get_by_label("Results")).to_match_aria_snapshot(
+            """
           - listbox "Results":
             - option "5. Output Formats …reduce the syntactic overhead of constructing ASTs. These libraries may also be used by authors of extensions to the Manual… Writing Documentation in Lean with Verso" [selected]:
               - paragraph:
@@ -22,25 +26,32 @@ class TestSearch:
                 - emphasis: extensions
                 - text: to the Manual…
               - paragraph: Writing Documentation in Lean with Verso
-            - listitem: Showing 1/1 results""".strip())
+            - listitem: Showing 1/1 results""".strip()
+        )
 
         page.get_by_role("searchbox").clear()
         page.get_by_role("searchbox").type("Html.visitM")
-        expect(page.get_by_label("Results")).to_match_aria_snapshot("""
+        expect(page.get_by_label("Results")).to_match_aria_snapshot(
+            """
           - listbox "Results":
             - option "Verso.Output.Html.visitM Documentation" [selected]:
               - paragraph:
                 - text: Verso.Output.
                 - emphasis: Html.visitM
               - paragraph: Documentation
-            - listitem: Showing 1/1 results""".strip())
+            - listitem: Showing 1/1 results""".strip()
+        )
 
         page.get_by_role("searchbox").type("onadsville")
-        expect(page.get_by_role("searchbox")).to_match_aria_snapshot('- searchbox "Search": Html.visitMonadsville')
+        expect(page.get_by_role("searchbox")).to_match_aria_snapshot(
+            '- searchbox "Search": Html.visitMonadsville'
+        )
         print(page.get_by_label("Results").aria_snapshot())
-        expect(page.get_by_label("Results")).to_match_aria_snapshot("""
+        expect(page.get_by_label("Results")).to_match_aria_snapshot(
+            """
           - listbox "Results":
-            - listitem: No results""".strip())
+            - listitem: No results""".strip()
+        )
 
     def test_unicode_input(self, server: str, page: Page):
         """Test that the search box converts Unicode abbreviations."""
@@ -61,10 +72,13 @@ class TestSearch:
 
     def test_suggestion(self, server: str, page: Page):
         """Test that the search box can find suggestions."""
-        page.goto(f"{server}") 
+        page.goto(f"{server}")
         page.get_by_role("searchbox").type("Html.none")
-        expect(page.get_by_role("searchbox")).to_match_aria_snapshot('- searchbox "Search": Html.none')
-        expect(page.get_by_label("Results")).to_match_aria_snapshot("""
+        expect(page.get_by_role("searchbox")).to_match_aria_snapshot(
+            '- searchbox "Search": Html.none'
+        )
+        expect(page.get_by_label("Results")).to_match_aria_snapshot(
+            """
           - listbox "Results":
             - option "Verso.Output.Html.none ↪ Verso.Output.Html.empty Suggestion" [selected]:
               - paragraph:
@@ -72,14 +86,18 @@ class TestSearch:
                 - emphasis: Html.none
                 - text: ↪ Verso.Output.Html.empty
               - paragraph: Suggestion
-            - listitem: Showing 1/1 results""".strip())
+            - listitem: Showing 1/1 results""".strip()
+        )
 
         page.get_by_role("searchbox").press("Backspace")
         page.get_by_role("searchbox").press("Backspace")
         page.get_by_role("searchbox").press("Backspace")
         page.get_by_role("searchbox").type("il")
-        expect(page.get_by_role("searchbox")).to_match_aria_snapshot('- searchbox "Search": Html.nil')
-        expect(page.get_by_label("Results")).to_match_aria_snapshot("""
+        expect(page.get_by_role("searchbox")).to_match_aria_snapshot(
+            '- searchbox "Search": Html.nil'
+        )
+        expect(page.get_by_label("Results")).to_match_aria_snapshot(
+            """
           - listbox "Results":
             - option "Verso.Output.Html.nil ↪ Verso.Output.Html.empty Suggestion" [selected]:
               - paragraph:
@@ -87,4 +105,5 @@ class TestSearch:
                 - emphasis: Html.nil
                 - text: ↪ Verso.Output.Html.empty
               - paragraph: Suggestion
-            - listitem: Showing 1/1 results""".strip())
+            - listitem: Showing 1/1 results""".strip()
+        )

--- a/deploy/overlay.py
+++ b/deploy/overlay.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
 import argparse
 import os
-from release_utils import run_git_command, is_git_ancestor, find_latest_version, find_latest_stable_version
+from release_utils import (
+    run_git_command,
+    is_git_ancestor,
+    find_latest_version,
+    find_latest_stable_version,
+)
 from pathlib import Path
 
 UNICODE_INPUT_FILES = [
@@ -36,12 +41,18 @@ def add_metadata(directory, version_name, extensions=(".html", ".htm")):
                         canonical_path = f"latest/{filename}"
                     else:
                         canonical_path = f"latest/{relative}/{filename}"
-                    href = f"https://verso.lean-lang.org/doc/{canonical_path}".removesuffix("index.html")
+                    href = f"https://verso.lean-lang.org/doc/{canonical_path}".removesuffix(
+                        "index.html"
+                    )
 
-                    noindex = '' if version_name == "latest" else '\n<meta name="robots" content="noindex">'
+                    noindex = (
+                        ""
+                        if version_name == "latest"
+                        else '\n<meta name="robots" content="noindex">'
+                    )
                     new_content = content.replace(
                         "<head>",
-                        f'<head>{noindex}\n<link rel="canonical" href="{href}" />\n'
+                        f'<head>{noindex}\n<link rel="canonical" href="{href}" />\n',
                     )
 
                     # Write back the modified file
@@ -91,8 +102,7 @@ def inject_stats_html(directory, stats_html_content, extensions=(".html", ".htm"
 
                 if "</head>" in content:
                     new_content = content.replace(
-                        "</head>",
-                        f'{stats_html_content}</head>'
+                        "</head>", f"{stats_html_content}</head>"
                     )
                     with open(filepath, "w", encoding="utf-8") as f:
                         f.write(new_content)
@@ -154,7 +164,9 @@ def deploy_overlays(deploy_dir, src_branch, tgt_branch):
                 unicode_input_files[filename] = f.read()
             print(f"overlay.py: read Unicode input file from main: {filepath}")
         else:
-            print(f"overlay.py: Unicode input file not found on main, skipping: {filepath}")
+            print(
+                f"overlay.py: Unicode input file not found on main, skipping: {filepath}"
+            )
 
     # Read stats.html from the current branch (main) before switching
     stats_html_content = None
@@ -196,7 +208,19 @@ def deploy_overlays(deploy_dir, src_branch, tgt_branch):
         # All of this complication is due to the fact that "-s theirs" doesn't
         # exist and "-X theirs" isn't what we want.
         # (see https://stackoverflow.com/questions/4911794 for context)
-        run_git_command(["git", "merge", "-m", "merge overlays", "--no-ff", "--no-edit", "-s", "ours", tgt_branch])
+        run_git_command(
+            [
+                "git",
+                "merge",
+                "-m",
+                "merge overlays",
+                "--no-ff",
+                "--no-edit",
+                "-s",
+                "ours",
+                tgt_branch,
+            ]
+        )
         run_git_command(["git", "switch", tgt_branch])
         run_git_command(["git", "reset", "--hard", src_branch, "--"])
         run_git_command(["git", "switch", src_branch])
@@ -210,14 +234,18 @@ def deploy_overlays(deploy_dir, src_branch, tgt_branch):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Apply overlays to a deployment branch")
+    parser = argparse.ArgumentParser(
+        description="Apply overlays to a deployment branch"
+    )
     parser.add_argument("deploy_dir", help="Directory to operate on")
     parser.add_argument("src_branch", help="Git branch to apply overlays to")
     parser.add_argument("tgt_branch", help="Git branch to commit to")
 
     args = parser.parse_args()
 
-    print(f"Applying overlays to {args.deploy_dir} branch {args.src_branch} to produce {args.tgt_branch}")
+    print(
+        f"Applying overlays to {args.deploy_dir} branch {args.src_branch} to produce {args.tgt_branch}"
+    )
 
     deploy_overlays(args.deploy_dir, args.src_branch, args.tgt_branch)
 

--- a/deploy/release.py
+++ b/deploy/release.py
@@ -7,14 +7,20 @@ import argparse
 import datetime
 import functools
 from release_utils import (
-    run_git_command, find_latest_version, find_latest_stable_version,
-    git_has_changes, parse_version, compare_versions
+    run_git_command,
+    find_latest_version,
+    find_latest_stable_version,
+    git_has_changes,
+    parse_version,
+    compare_versions,
 )
 
 
 def stamp_html_files(source_dir, commit_sha):
     """Prepend a commit stamp comment to every HTML file in source_dir."""
-    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    timestamp = datetime.datetime.now(datetime.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
     stamp = f"<!-- Generated from commit {commit_sha} at {timestamp} -->\n"
     for root, _, files in os.walk(source_dir):
         for filename in files:
@@ -58,7 +64,9 @@ def generate_index_html(latest_version, stable_version):
 
     stable_link = ""
     if stable_version:
-        stable_link = f'<a href="stable/">Latest stable ({stable_version})</a> &middot; '
+        stable_link = (
+            f'<a href="stable/">Latest stable ({stable_version})</a> &middot; '
+        )
 
     latest_link = ""
     if latest_version:
@@ -120,7 +128,9 @@ def deploy_version(source_dir, version, commit_sha, branch):
 
             # Switch to the deploy branch
             print(f"Checking out branch: {branch}")
-            run_git_command(["git", "switch", "-c", branch, "--track", "origin/" + branch])
+            run_git_command(
+                ["git", "switch", "-c", branch, "--track", "origin/" + branch]
+            )
 
             # Remove existing version directory if it exists
             version_dir = version
@@ -190,7 +200,9 @@ def main():
 
     args = parser.parse_args()
 
-    print(f"Deploying from {args.source_dir} as version {args.version} into {args.branch}")
+    print(
+        f"Deploying from {args.source_dir} as version {args.version} into {args.branch}"
+    )
 
     deploy_version(args.source_dir, args.version, args.commit_sha, args.branch)
 

--- a/deploy/release_utils.py
+++ b/deploy/release_utils.py
@@ -4,9 +4,11 @@ import subprocess
 import shlex
 from pathlib import Path
 
+
 def eprint(*args, **kwargs):
     """Print to stderr instead of stdout"""
     print(*args, file=sys.stderr, **kwargs)
+
 
 def parse_version(version_str):
     """
@@ -24,7 +26,7 @@ def parse_version(version_str):
         "minor": None,
         "patch": None,
         "rc": None,
-        "date": None
+        "date": None,
     }
 
     # Check for nightly builds (date-based versions)
@@ -78,6 +80,7 @@ def parse_version(version_str):
             return None
 
     return result
+
 
 def compare_versions(version1, version2):
     """
@@ -150,13 +153,17 @@ def compare_versions(version1, version2):
     # If we get here, the types are unknown or incomparable
     return None
 
+
 def find_latest_version(versions_dir):
     """Find the latest version in the versions directory"""
     if not os.path.exists(versions_dir):
         return None
 
-    version_dirs = [d for d in os.listdir(versions_dir)
-                   if os.path.isdir(os.path.join(versions_dir, d)) and d != "latest"]
+    version_dirs = [
+        d
+        for d in os.listdir(versions_dir)
+        if os.path.isdir(os.path.join(versions_dir, d)) and d != "latest"
+    ]
 
     if not version_dirs:
         return None
@@ -165,7 +172,11 @@ def find_latest_version(versions_dir):
     parsed_versions = [(d, parse_version(d)) for d in version_dirs]
 
     # Filter out any unparseable versions
-    valid_versions = [(d, pv) for d, pv in parsed_versions if pv is not None and pv["type"] is not None]
+    valid_versions = [
+        (d, pv)
+        for d, pv in parsed_versions
+        if pv is not None and pv["type"] is not None
+    ]
 
     if not valid_versions:
         return None
@@ -179,13 +190,17 @@ def find_latest_version(versions_dir):
 
     return latest[0]
 
+
 def find_latest_stable_version(versions_dir):
     """Find the latest stable version in the versions directory"""
     if not os.path.exists(versions_dir):
         return None
 
-    version_dirs = [d for d in os.listdir(versions_dir)
-                   if os.path.isdir(os.path.join(versions_dir, d)) and d != "latest"]
+    version_dirs = [
+        d
+        for d in os.listdir(versions_dir)
+        if os.path.isdir(os.path.join(versions_dir, d)) and d != "latest"
+    ]
 
     if not version_dirs:
         return None
@@ -194,7 +209,11 @@ def find_latest_stable_version(versions_dir):
     parsed_versions = [(d, parse_version(d)) for d in version_dirs]
 
     # Filter out any unparseable, nightly, or rc versions
-    valid_versions = [(d, pv) for d, pv in parsed_versions if pv is not None and pv["type"] == "semantic" and pv["rc"] is None]
+    valid_versions = [
+        (d, pv)
+        for d, pv in parsed_versions
+        if pv is not None and pv["type"] == "semantic" and pv["rc"] is None
+    ]
 
     if not valid_versions:
         return None
@@ -208,6 +227,7 @@ def find_latest_stable_version(versions_dir):
 
     return latest[0]
 
+
 def run_git_command(command):
     """Run a git command and return the output"""
     print(f"\tRunning {shlex.join(command)}")
@@ -217,6 +237,7 @@ def run_git_command(command):
         eprint(f"Stdout: {result.stdout}\nStderr: {result.stderr}")
         sys.exit(1)
     return result.stdout.strip()
+
 
 def is_git_ancestor(branch1, branch2):
     """
@@ -229,8 +250,11 @@ def is_git_ancestor(branch1, branch2):
     Returns:
         bool: True iff branch1 is an ancestor of branch2
     """
-    result = subprocess.run(["git", "merge-base", "--is-ancestor", branch1, branch2], capture_output=False)
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", branch1, branch2], capture_output=False
+    )
     return result.returncode == 0
+
 
 def git_has_changes():
     """Check if the git repository has any changes that could be
@@ -240,7 +264,7 @@ def git_has_changes():
     result = subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=no"],
         capture_output=True,
-        text=True
+        text=True,
     )
 
     # If successful and output is empty, there are no changes

--- a/server.py
+++ b/server.py
@@ -3,7 +3,7 @@
 # This wrapper turns off the Python HTTP server's overly aggressive
 # cache headers, which can get in the way of Verso hovers.
 
-from http import server # Python 3
+from http import server  # Python 3
 from http.server import ThreadingHTTPServer, test
 import os
 
@@ -18,39 +18,52 @@ class NonCachingHTTPRequestHandler(server.SimpleHTTPRequestHandler):
         self.send_header("Pragma", "no-cache")
         self.send_header("Expires", "0")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     import argparse
     import contextlib
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-b', '--bind', metavar='ADDRESS',
-                        help='bind to this address '
-                             '(default: all interfaces)')
-    parser.add_argument('-d', '--directory', default="_out/html-multi",
-                        help='serve this directory '
-                             '(default: _out/html-multi)')
-    parser.add_argument('-p', '--protocol', metavar='VERSION',
-                        default='HTTP/1.0',
-                        help='conform to this HTTP version '
-                             '(default: %(default)s)')
-    parser.add_argument('port', default=8000, type=int, nargs='?',
-                        help='bind to this port '
-                             '(default: %(default)s)')
+    parser.add_argument(
+        "-b",
+        "--bind",
+        metavar="ADDRESS",
+        help="bind to this address (default: all interfaces)",
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        default="_out/html-multi",
+        help="serve this directory (default: _out/html-multi)",
+    )
+    parser.add_argument(
+        "-p",
+        "--protocol",
+        metavar="VERSION",
+        default="HTTP/1.0",
+        help="conform to this HTTP version (default: %(default)s)",
+    )
+    parser.add_argument(
+        "port",
+        default=8000,
+        type=int,
+        nargs="?",
+        help="bind to this port (default: %(default)s)",
+    )
     args = parser.parse_args()
 
     # ensure dual-stack is not disabled; ref #38907
     class DualStackServer(ThreadingHTTPServer):
-
         def server_bind(self):
             # suppress exception when protocol is IPv4
             with contextlib.suppress(Exception):
-                self.socket.setsockopt(
-                    socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+                self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
             return super().server_bind()
 
         def finish_request(self, request, client_address):
-            self.RequestHandlerClass(request, client_address, self,
-                                     directory=args.directory)
+            self.RequestHandlerClass(
+                request, client_address, self, directory=args.directory
+            )
 
     print(args)
 


### PR DESCRIPTION
The Python code in the test and deployment systems is now formatted via `ruff`, a lightweight Python formatter, as we use Prettier for other dependencies.