### PR TITLE
fix: linter activation

### DIFF
--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -16,6 +16,7 @@ import Tests.Integration.SampleDoc
 import Tests.Integration.CodeContent
 import Tests.Integration.ExtraFilesDoc
 import Tests.LeanCode
+import Tests.Linters
 import Tests.Integration.InheritanceDoc
 import Tests.Integration.FrontMatter
 import Tests.Integration.LeanSection

--- a/src/tests/Tests/Linters.lean
+++ b/src/tests/Tests/Linters.lean
@@ -1,0 +1,295 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import Verso
+import VersoManual
+
+namespace Verso.LinterTests
+
+set_option guard_msgs.diff true
+set_option pp.rawOnError true
+
+/-!
+# `linter.typography.quotes` (default: false)
+-/
+
+/-!
+By default, it is off: straight quotes in text do not result in warnings.
+-/
+#guard_msgs in
+#docs (.none) quotesDefault "Quotes default" :=
+:::::::
+
+Say "hello" to the world.
+
+:::::::
+
+/-!
+When it is enabled, straight quotes produce warnings.
+-/
+/--
+warning: Use curly quotes ('“')
+
+Hint: Replace with Unicode
+  "̵“̲
+
+Note: This linter can be disabled with `set_option linter.typography.quotes false`
+---
+warning: Use curly quotes ('”')
+
+Hint: Replace with Unicode
+  "̵”̲
+
+Note: This linter can be disabled with `set_option linter.typography.quotes false`
+-/
+#guard_msgs in
+set_option linter.typography.quotes true in
+#docs (.none) quotesOn "Quotes on" :=
+:::::::
+
+Say "hello" to the world.
+
+:::::::
+
+/-!
+# `linter.typography.dashes` (default: false)
+-/
+
+/-!
+By default, it is off: a triple dash in text does not produce a warning.
+-/
+#guard_msgs in
+#docs (.none) dashesDefault "Dashes default" :=
+:::::::
+
+An em dash --- really!
+
+:::::::
+
+/-!
+When it is enabled, a triple dash produces a warning.
+-/
+/--
+warning: Use an em dash ('—')
+
+Hint: Replace with Unicode
+   ̵-̵-̵-̵ ̵—̲
+
+Note: This linter can be disabled with `set_option linter.typography.dashes false`
+-/
+#guard_msgs in
+set_option linter.typography.dashes true in
+#docs (.none) dashesOn "Dashes on" :=
+:::::::
+
+An em dash --- really!
+
+:::::::
+
+/-!
+Regression test: checks that the two typography options are independent. When only `dashes` is
+enabled, ASCII quotes in the same document must not produce quote warnings (and vice versa).
+Previously both options shared a disjunctive gate and then logged unconditionally, so enabling one
+leaked warnings for the other.
+-/
+/--
+warning: Use an em dash ('—')
+
+Hint: Replace with Unicode
+   ̵-̵-̵-̵ ̵—̲
+
+Note: This linter can be disabled with `set_option linter.typography.dashes false`
+-/
+#guard_msgs in
+set_option linter.typography.dashes true in
+#docs (.none) typoDashesOnlyMixed "Dashes only mixed" :=
+:::::::
+
+Say "hello" --- really!
+
+:::::::
+
+/--
+warning: Use curly quotes ('“')
+
+Hint: Replace with Unicode
+  "̵“̲
+
+Note: This linter can be disabled with `set_option linter.typography.quotes false`
+---
+warning: Use curly quotes ('”')
+
+Hint: Replace with Unicode
+  "̵”̲
+
+Note: This linter can be disabled with `set_option linter.typography.quotes false`
+-/
+#guard_msgs in
+set_option linter.typography.quotes true in
+#docs (.none) typoQuotesOnlyMixed "Quotes only mixed" :=
+:::::::
+
+Say "hello" --- really!
+
+:::::::
+
+/-!
+# `linter.verso.markup.emph` (default: true)
+-/
+
+/-!
+By default, it is on: redundant `__` around emphasized text produces a warning.
+-/
+/--
+warning: Unnecessary '_'
+
+Hint: Use the minimal number of '_'s
+  __̵emphatic__̵
+
+Note: This linter can be disabled with `set_option linter.verso.markup.emph false`
+-/
+#guard_msgs in
+#docs (.none) emphDefault "Emph default" :=
+:::::::
+
+This is __emphatic__ text.
+
+:::::::
+
+/-!
+When it is disabled, redundant `__` does not produce a warning.
+-/
+#guard_msgs in
+set_option linter.verso.markup.emph false in
+#docs (.none) emphOff "Emph off" :=
+:::::::
+
+This is __emphatic__ text.
+
+:::::::
+
+/-!
+# `linter.verso.markup.code` (default: true)
+-/
+
+/-!
+By default, it is on: redundant backticks around inline code produce a warning.
+-/
+/--
+warning: Unnecessary '`'
+
+Hint: Use the minimal number of '`'s
+  `̵`̵f̵o̵o̵`̵`̵`̲f̲o̲o̲`̲
+
+Note: This linter can be disabled with `set_option linter.verso.markup.code false`
+-/
+#guard_msgs in
+#docs (.none) codeDefault "Code default" :=
+:::::::
+
+See ``foo`` for details.
+
+:::::::
+
+/-!
+When it is disabled, redundant inline-code backticks do not produce a warning.
+-/
+#guard_msgs in
+set_option linter.verso.markup.code false in
+#docs (.none) codeOff "Code off" :=
+:::::::
+
+See ``foo`` for details.
+
+:::::::
+
+/-!
+# `linter.verso.markup.codeBlock` (default: true)
+-/
+
+/-!
+By default, it is on: redundant backticks around a code block produce a warning.
+-/
+/--
+warning: Unnecessary '`'
+
+Hint: Use the minimal number of '`'s
+  ````̵
+  foo
+  ````̵
+
+Note: This linter can be disabled with `set_option linter.verso.markup.codeBlock false`
+-/
+#guard_msgs in
+#docs (.none) codeBlockDefault "Code block default" :=
+:::::::
+
+````
+foo
+````
+
+:::::::
+
+/-!
+When it is disabled, redundant code-block backticks do not produce a warning.
+-/
+#guard_msgs in
+set_option linter.verso.markup.codeBlock false in
+#docs (.none) codeBlockOff "Code block off" :=
+:::::::
+
+````
+foo
+````
+
+:::::::
+
+/-!
+# `linter.verso.manual.headerTags` (default: false, `Manual` genre only)
+-/
+
+/-!
+By default, it is off: untagged headers do not produce a warning.
+-/
+#guard_msgs in
+#docs (Verso.Genre.Manual) headerTagsDefault "Header tags default" :=
+:::::::
+
+# Untagged section
+
+Some text.
+
+:::::::
+
+/-!
+When it is enabled, an untagged header produces a warning.
+-/
+/--
+warning: Missing permalink tag
+
+Hint: Add a metadata block with a tag or explicitly indicate that no tag is desired:
+  • # Untagged section
+    ̲%̲%̲%̲
+    ̲t̲a̲g̲ ̲:̲=̲ ̲"̲u̲n̲t̲a̲g̲g̲e̲d̲-̲s̲e̲c̲t̲i̲o̲n̲"̲
+    ̲%̲%̲%̲
+  • # Untagged section
+    ̲%̲%̲%̲
+    ̲t̲a̲g̲ ̲:̲=̲ ̲n̲o̲n̲e̲
+    ̲%̲%̲%̲
+
+Note: The tag is used as a permanent name for the section or chapter. Writers of this or other documents may use it to link to the section, and it is used to share permanent links. In HTML content, they are used as IDs for headers. Section tags should remain unchanged over time.
+
+Note: This linter can be disabled with `set_option linter.verso.manual.headerTags false`
+-/
+#guard_msgs in
+set_option linter.verso.manual.headerTags true in
+#docs (Verso.Genre.Manual) headerTagsOn "Header tags on" :=
+:::::::
+
+# Untagged section
+
+Some text.
+
+:::::::

--- a/src/verso-manual/VersoManual/Linters.lean
+++ b/src/verso-manual/VersoManual/Linters.lean
@@ -27,84 +27,97 @@ partial def headerTagLinter : Linter where
     unless (`Verso.Doc.Concrete).isPrefixOf stx.getKind do return
     unless getLinterValue linter.verso.manual.headerTags (← getLinterOptions) do return
 
+    -- Identify the command form and extract its genre term. `#docs (...) ...` and the opening
+    -- `#doc (...) ... =>` both place the genre as their third syntax child. Individual blocks
+    -- in an incremental `#doc` document are parsed as `addBlockCmd`/`addLastBlockCmd` commands,
+    -- which don't carry the genre syntactically, so we read it from the environment extension
+    -- that `startDoc` populates when it processes the opening `#doc (...) =>` line.
+    let genreStx? : Option Syntax ←
+      match stx[0] with
+      | .atom _ "#docs" | .atom _ "#doc" => pure (some stx[2])
+      | _ =>
+        if stx.isOfKind ``Verso.Doc.Concrete.addBlockCmd
+            || stx.isOfKind ``Verso.Doc.Concrete.addLastBlockCmd then
+          pure (some (Verso.Doc.Concrete.docEnvironmentExt.getState (← getEnv)).genreSyntax)
+        else pure none
+
+    let some genreStx := genreStx? | return
+    let genreName ←
+      try runTermElabM <| fun _ => realizeGlobalConstNoOverload genreStx
+      catch | _ => return
+    unless genreName == `Verso.Genre.Manual do return
+
     let text ← getFileMap
 
-    discard <| stx.replaceM fun cmd => do
-      if cmd.isOfKind ``Verso.Doc.Concrete.addBlockCmd || cmd.isOfKind ``Verso.Doc.Concrete.addLastBlockCmd then
-        let block := cmd[0]
-        let genre := cmd[1]
-        let genreName ←
-          try runTermElabM <| fun _ => realizeGlobalConstNoOverload genre
-          catch | _ => return none
-        unless genreName == `Verso.Genre.Manual do return none
-        if let `(block|header($n){$inls*}) := block then
-          let some ⟨start, stop⟩ := block.getRange?
-            | return none
-          let mut nextLine : String.Legacy.Iterator := {s := text.source, i := stop}
-          while h : nextLine.hasNext do
-            if (nextLine.curr' h).isWhitespace then nextLine := nextLine.next' h
-            else break
-          -- Attempt to parse the next command as a metadata block.
-          let ictx := {
-            inputString := text.source,
-            fileName := ← getFileName,
-            fileMap := text
-          }
-          let pmctx := {
-            env := ← getEnv,
-            options := ← getOptions
-          }
-          let toks := Parser.getTokenTable (← getEnv)
-          let s := { cache := { tokenCache := {}, parserCache := {} }, pos := nextLine.i }
-          let s := Lean.Doc.Parser.metadataBlock.run ictx pmctx toks s
-          let tagNote :=
-            MessageData.note <|
-              "The tag is used as a permanent name for the section or chapter. Writers "++
-              "of this or other documents may use it to link to the section, and it is " ++
-              "used to share permanent links. In HTML content, they are used as IDs for " ++
-              "headers. Section tags should remain unchanged over time."
-          if s.hasError || !s.recoveredErrors.isEmpty then
-            -- Next block is not metadata, so suggest inserting one
+    discard <| stx.replaceM fun block => do
+      if let `(block|header($n){$inls*}) := block then
+        let some ⟨start, stop⟩ := block.getRange?
+          | return none
+        let mut nextLine : String.Legacy.Iterator := {s := text.source, i := stop}
+        while h : nextLine.hasNext do
+          if (nextLine.curr' h).isWhitespace then nextLine := nextLine.next' h
+          else break
+        -- Attempt to parse the next command as a metadata block.
+        let ictx := {
+          inputString := text.source,
+          fileName := ← getFileName,
+          fileMap := text
+        }
+        let pmctx := {
+          env := ← getEnv,
+          options := ← getOptions
+        }
+        let toks := Parser.getTokenTable (← getEnv)
+        let s := { cache := { tokenCache := {}, parserCache := {} }, pos := nextLine.i }
+        let s := Lean.Doc.Parser.metadataBlock.run ictx pmctx toks s
+        let tagNote :=
+          MessageData.note <|
+            "The tag is used as a permanent name for the section or chapter. Writers "++
+            "of this or other documents may use it to link to the section, and it is " ++
+            "used to share permanent links. In HTML content, they are used as IDs for " ++
+            "headers. Section tags should remain unchanged over time."
+        if s.hasError || !s.recoveredErrors.isEmpty then
+          -- Next block is not metadata, so suggest inserting one
+          let name := suggestId inls
+          let blockStr := start.extract text.source stop
+          let suggestions : Array Meta.Hint.Suggestion := #[
+            s!"{blockStr}\n%%%\ntag := \"{name}\"\n%%%",
+            s!"{blockStr}\n%%%\ntag := none\n%%%"
+          ]
+          let h ← runTermElabM fun _ => MessageData.hint "Add a metadata block with a tag or explicitly indicate that no tag is desired:" suggestions (ref? := some block)
+          logLint linter.verso.manual.headerTags block m!"Missing permalink tag{h}{tagNote}"
+          return none
+        let nextStx ←
+            if s.stxStack.size = 1 then
+              pure (s.stxStack.get! 0)
+            else return none
+        if let`(block|%%%%$tk1 $fieldOrAbbrev* %%%%$tk2) := nextStx then
+          let metadataStx ← `(term| { $fieldOrAbbrev* })
+          let isMissing ← runTermElabM fun _ => do
+            let type := .const `Verso.Genre.Manual.PartMetadata []
+            let metadataTerm ← Term.elabTerm metadataStx (some type)
+            let tagExpr ← Meta.whnf (← Meta.mkProjection metadataTerm `tag)
+            match_expr tagExpr with
+            | Option.none _ => pure true
+            | _ => pure false
+          -- The syntactic check is to disable the linter when an explicit `none` is used
+          if isMissing && noFieldIsTag fieldOrAbbrev then
             let name := suggestId inls
+            -- Find the beginning of the line after the token
+            let some ⟨start1, stop1⟩ := tk1.getRange?
+              | return none
+            let some ⟨start2, stop2⟩ := tk2.getRange?
+              | return none
             let blockStr := start.extract text.source stop
             let suggestions : Array Meta.Hint.Suggestion := #[
-              s!"{blockStr}\n%%%\ntag := \"{name}\"\n%%%",
-              s!"{blockStr}\n%%%\ntag := none\n%%%"
+              s!"{blockStr}\n%%%\ntag := \"{name}\"" ++ stop1.extract text.source stop2,
+              s!"{blockStr}\n%%%\ntag := none" ++ stop1.extract text.source stop2
             ]
-            let h ← runTermElabM fun _ => MessageData.hint "Add a metadata block with a tag or explicitly indicate that no tag is desired:" suggestions (ref? := some block)
-            logLint linter.verso.manual.headerTags block m!"Missing permalink tag{h}{tagNote}"
-            return none
-          let nextStx ←
-              if s.stxStack.size = 1 then
-                pure (s.stxStack.get! 0)
-              else return none
-          if let`(block|%%%%$tk1 $fieldOrAbbrev* %%%%$tk2) := nextStx then
-            let metadataStx ← `(term| { $fieldOrAbbrev* })
-            let isMissing ← runTermElabM fun _ => do
-              let type := .const `Verso.Genre.Manual.PartMetadata []
-              let metadataTerm ← Term.elabTerm metadataStx (some type)
-              let tagExpr ← Meta.whnf (← Meta.mkProjection metadataTerm `tag)
-              match_expr tagExpr with
-              | Option.none _ => pure true
-              | _ => pure false
-            -- The syntactic check is to disable the linter when an explicit `none` is used
-            if isMissing && noFieldIsTag fieldOrAbbrev then
-              let name := suggestId inls
-              -- Find the beginning of the line after the token
-              let some ⟨start1, stop1⟩ := tk1.getRange?
-                | return none
-              let some ⟨start2, stop2⟩ := tk2.getRange?
-                | return none
-              let blockStr := start.extract text.source stop
-              let suggestions : Array Meta.Hint.Suggestion := #[
-                s!"{blockStr}\n%%%\ntag := \"{name}\"" ++ stop1.extract text.source stop2,
-                s!"{blockStr}\n%%%\ntag := none" ++ stop1.extract text.source stop2
-              ]
 
-              let h ← runTermElabM fun _ => MessageData.hint "Add a tag to the metadata block or explicitly indicate that no tag is desired:" suggestions (ref? := some <| mkNullNode #[block, nextStx])
-              logLint linter.verso.manual.headerTags block m!"Missing permalink tag{h}{tagNote}"
-            pure ()
-          return none
+            let h ← runTermElabM fun _ => MessageData.hint "Add a tag to the metadata block or explicitly indicate that no tag is desired:" suggestions (ref? := some <| mkNullNode #[block, nextStx])
+            logLint linter.verso.manual.headerTags block m!"Missing permalink tag{h}{tagNote}"
+          pure ()
+        return none
       pure none
 
 where

--- a/src/verso/Verso/Doc/Concrete.lean
+++ b/src/verso/Verso/Doc/Concrete.lean
@@ -285,7 +285,7 @@ public meta structure DocElabEnvironment where
   partState : PartElabM.State := .init (.node .none nullKind #[])
 deriving Inhabited
 
-meta initialize docEnvironmentExt : EnvExtension DocElabEnvironment ← registerEnvExtension (pure {})
+public meta initialize docEnvironmentExt : EnvExtension DocElabEnvironment ← registerEnvExtension (pure {})
 
 /--
 The original parser for the `command` category, which is restored while elaborating a Verso block so

--- a/src/verso/Verso/Linters.lean
+++ b/src/verso/Verso/Linters.lean
@@ -74,7 +74,7 @@ def typography : Linter where
         Syntax.mkStrLit (String.singleton (pos.get text.source))
           (info := .original {str := text.source, startPos := pos, stopPos := pos} pos {str := text.source, startPos := stop, stopPos := stop} stop)
         let h ← liftTermElabM <| MessageData.hint m!"Replace with Unicode" #[{suggestion := replacement}] (ref? := strLit)
-        logLint linter strLit (m!"Use {what} ('{replacement}')" ++ h)
+        logLintIf linter strLit (m!"Use {what} ('{replacement}')" ++ h)
 
     discard <| stx.replaceM fun
       | `(inline|$s:str) => do


### PR DESCRIPTION
The typography linters were accidentally enabled if _either_ option was enabled. This PR fixes that.

Additionally, internal changes had rendered the Manual linter that warns about missing tags inoperative. It's reactivated and tested.