### PR TITLE
perf: avoid re-exporting imported doc expanders

### DIFF
--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -8,6 +8,7 @@ import Tests.Elab
 import Tests.GenericCode
 import Tests.Golden
 import Tests.CommentSkipping
+import Tests.DocElabExtensions.Use
 import Tests.HighlightedToTeX
 import Tests.Html
 import Tests.HtmlEntities

--- a/src/tests/Tests/DocElabExtensions/Define.lean
+++ b/src/tests/Tests/DocElabExtensions/Define.lean
@@ -1,0 +1,40 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio Jesus Gallego Arias
+-/
+import Tests.DocElabExtensions.LocalExtension
+import VersoManual
+
+namespace Verso.Tests.DocElabExtensions
+
+/-!
+This module defines the local entries used by the transitive-import regression.
+It registers one test-only local-persistent entry and one custom expander for each document
+extension kind. `Middle` imports this module without adding entries, and `Use` imports `Middle`
+to check that transitive lookup works without re-exporting `Middle`'s imported entries.
+-/
+
+open Verso Genre Manual
+open Verso.Doc.Elab
+open Lean
+
+#register_inherited_test_local_entry
+
+@[role]
+def inheritedRole : RoleExpanderOf Unit
+  | (), _contents => ``(Doc.Inline.text "inherited role")
+
+@[code_block]
+def inheritedCode : CodeBlockExpanderOf Unit
+  | (), str => ``(Doc.Block.code $(quote str.getString))
+
+@[directive]
+def inheritedDirective : DirectiveExpanderOf Unit
+  | (), blocks => do
+    let blocks ← blocks.mapM elabBlock
+    ``(Doc.Block.concat #[$blocks,*])
+
+@[block_command]
+def inheritedCommand : BlockCommandOf Unit
+  | () => ``(Doc.Block.para #[Doc.Inline.text "inherited command"])

--- a/src/tests/Tests/DocElabExtensions/LocalExtension.lean
+++ b/src/tests/Tests/DocElabExtensions/LocalExtension.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio Jesus Gallego Arias
+-/
+import Lean.Elab.Command
+import Verso.EnvExtension
+
+namespace Verso.Tests.DocElabExtensions
+
+/-!
+This module defines a small test-only `LocalPersistentEnvExtension`.
+`Define` adds one local entry, `Middle` imports `Define` without adding entries, and `Use` checks
+that lookup in the final importer sees the entry while `Middle`'s serialized entries for this
+extension are empty.
+-/
+
+open Lean Elab Command
+
+private def addTestEntry (entries : Lean.NameMap (Array Name)) (key value : Name) :
+    Lean.NameMap (Array Name) :=
+  entries.insert key <| (entries.find? key |>.getD #[]).push value
+
+private abbrev TestLocalExtension :=
+  LocalPersistentEnvExtension (Name × Array Name) (Name × Name) (Lean.NameMap (Array Name))
+
+initialize testLocalExt : TestLocalExtension ←
+  LocalPersistentEnvExtension.register {
+    name := `Verso.Tests.DocElabExtensions.testLocalExt
+    mkInitialState := pure {}
+    addImportedEntryFn
+      | entries, (key, values) =>
+        values.foldl (init := entries) fun entries value =>
+          addTestEntry entries key value
+    addEntryFn
+      | entries, (key, value) =>
+        addTestEntry entries key value
+    exportEntriesFn _ entries :=
+      .uniform entries.toArray
+  }
+
+def testLocalExtensionEntries (env : Environment) (key : Name) : Array Name :=
+  testLocalExt.getState env |>.find? key |>.getD #[]
+
+def testLocalExtensionModuleEntries (env : Environment) (moduleIdx : ModuleIdx) :
+    Array (Name × Array Name) :=
+  testLocalExt.getModuleEntries env moduleIdx
+
+elab "#register_inherited_test_local_entry" : command => do
+  modifyEnv fun env =>
+    testLocalExt.addEntry env (`inheritedTestLocalExtension, `inheritedTestEntry)

--- a/src/tests/Tests/DocElabExtensions/Middle.lean
+++ b/src/tests/Tests/DocElabExtensions/Middle.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio Jesus Gallego Arias
+-/
+import Tests.DocElabExtensions.Define
+
+namespace Verso.Tests.DocElabExtensions
+
+/-!
+This module is the middle import in the transitive-import regression.
+It imports the local entries from `Define` but intentionally adds no new entries itself, so `Use`
+can check that this module does not re-export inherited local-persistent entries.
+-/
+
+def importedThroughMiddle : Bool := true

--- a/src/tests/Tests/DocElabExtensions/Use.lean
+++ b/src/tests/Tests/DocElabExtensions/Use.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio Jesus Gallego Arias
+-/
+import Tests.DocElabExtensions.Middle
+
+namespace Verso.Tests.DocElabExtensions
+
+/-!
+This module consumes the entries through `Middle`.
+The command guard checks the test-only local-persistent extension directly: the final lookup state
+contains the entry from `Define`, but `Middle` exported no entries for the extension. The `#docs`
+block separately checks the real doc expander registries for role, code block, directive, and block
+command expanders through the same transitive import.
+-/
+
+open Verso Genre Manual
+open Lean Elab Command
+
+elab "#guard_middle_exports_no_local_persistent_entries" : command => do
+  let env ← getEnv
+  let some middleIdx := env.getModuleIdxFor? ``importedThroughMiddle
+    | throwError "could not find the module for importedThroughMiddle"
+  let entries := testLocalExtensionEntries env `inheritedTestLocalExtension
+  unless entries.contains `inheritedTestEntry do
+    throwError "expected lookup state to include the entry imported through the middle module"
+  let middleEntries := testLocalExtensionModuleEntries env middleIdx
+  unless middleEntries.isEmpty do
+    throwError "middle module should export no inherited local-persistent entries, but exported {middleEntries.size}"
+
+#guard_middle_exports_no_local_persistent_entries
+
+#docs (Manual) inheritedDocElabExtensions "Inherited Doc Elab Extensions" :=
+:::::::
+This custom {inheritedRole}[] is provided through a transitive import.
+
+```inheritedCode
+code block body
+```
+
+:::inheritedDirective
+Directive body
+:::
+
+{inheritedCommand}
+:::::::
+
+#guard importedThroughMiddle
+#guard inheritedDocElabExtensions.toPart.content.size == 4

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -14,6 +14,7 @@ import Lean.DocString
 
 import SubVerso.Highlighting
 import Verso.Doc
+import Verso.EnvExtension
 public import Verso.Doc.ArgParse
 public import Verso.Doc.Elab.InlineString
 meta import Verso.Doc.Elab.InlineString
@@ -549,18 +550,19 @@ unsafe def blockExpandersForUnsafe (x : Name) : DocElabM (Array BlockExpander) :
 @[implemented_by blockExpandersForUnsafe]
 public opaque blockExpandersFor (x : Name) : DocElabM (Array BlockExpander)
 
-initialize expanderSignatureExt : PersistentEnvExtension (Name × SigDoc) (Name × SigDoc) (NameMap SigDoc) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure {},
-    addImportedFn xss :=
-      pure <| xss.foldl (init := {}) fun ns xs =>
-        xs.foldl (init := ns) fun ns (x, s) =>
-          ns.insert x s
+initialize expanderSignatureExt :
+    LocalPersistentEnvExtension (Name × SigDoc) (Name × SigDoc) (NameMap SigDoc) ←
+  LocalPersistentEnvExtension.register {
+    name := `expanderSignatureExt
+    mkInitialState := pure {}
+    addImportedEntryFn
+      | entries, (x, y) =>
+        entries.insert x y
     addEntryFn
-      | xs, (x, y) =>
-        xs.insert x y
-    exportEntriesFn xs :=
-      xs.toArray
+      | entries, (x, y) =>
+        entries.insert x y
+    exportEntriesFn _ entries :=
+      .uniform entries.toArray
   }
 
 public def sig (α) [inst : FromArgs α DocElabM] : Option ArgParse.SigDoc :=
@@ -579,6 +581,28 @@ unsafe def partCommandsForUnsafe (x : Name) : PartElabM (Array PartCommand) := d
 public opaque partCommandsFor (x : Name) : PartElabM (Array PartCommand)
 
 
+private def addExpanderEntry (entries : NameMap (Array Name)) (key value : Name) :
+    NameMap (Array Name) :=
+  entries.insert key <| (entries.find? key |>.getD #[]).push value
+
+private abbrev ExpanderExtension :=
+  LocalPersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name))
+
+private def mkExpanderExtension (name : Name) : IO ExpanderExtension :=
+  LocalPersistentEnvExtension.register {
+    name
+    mkInitialState := pure {}
+    addImportedEntryFn
+      | entries, (x, ys) =>
+        ys.foldl (init := entries) fun entries y =>
+          addExpanderEntry entries x y
+    addEntryFn
+      | entries, (x, y) =>
+        addExpanderEntry entries x y
+    exportEntriesFn _ entries :=
+      .uniform entries.toArray
+  }
+
 public abbrev RoleExpander := Array Arg → TSyntaxArray `inline → DocElabM (Array (TSyntax `term))
 
 public abbrev RoleExpanderOf α := α → TSyntaxArray `inline → DocElabM Term
@@ -595,19 +619,8 @@ public section
 syntax (name := role) "role " (ident)? : attr
 end
 
-initialize roleExpanderExt : PersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name)) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure {},
-    addImportedFn xss :=
-      pure <| xss.foldl (init := {}) fun ns xs =>
-        xs.foldl (init := ns) fun ns (x, ys) =>
-          ns.insert x <| (ns.find? x |>.getD #[]) ++ ys
-    addEntryFn
-      | xs, (x, y) =>
-        xs.insert x (xs.find? x |>.getD #[] |>.push y)
-    exportEntriesFn xs :=
-      xs.toArray
-  }
+initialize roleExpanderExt : ExpanderExtension ←
+  mkExpanderExtension `roleExpanderExt
 
 private unsafe def roleExpandersForUnsafe' (x : Name) : DocElabM (Array (RoleExpander × Option String × Option SigDoc)) := do
   let expanders := roleExpanderExt.getState (← getEnv) |>.find? x |>.getD #[]
@@ -741,19 +754,8 @@ public def toCodeBlock {α : Type} [FromArgs α DocElabM] (expander : α → Str
 
 syntax (name := code_block) "code_block " (ident)? : attr
 
-initialize codeBlockExpanderExt : PersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name)) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure {},
-    addImportedFn xss :=
-      pure <| xss.foldl (init := {}) fun ns xs =>
-        xs.foldl (init := ns) fun ns (x, ys) =>
-          ns.insert x <| (ns.find? x |>.getD #[]) ++ ys
-    addEntryFn
-      | xs, (x, y) =>
-        xs.insert x (xs.find? x |>.getD #[] |>.push y)
-    exportEntriesFn xs :=
-      xs.toArray
-  }
+initialize codeBlockExpanderExt : ExpanderExtension ←
+  mkExpanderExtension `codeBlockExpanderExt
 
 unsafe initialize registerBuiltinAttribute {
   name := `code_block,
@@ -843,19 +845,8 @@ public def toDirective {α : Type} [FromArgs α DocElabM] (expander : α → TSy
 
 syntax (name := directive) "directive " (ident)? : attr
 
-initialize directiveExpanderExt : PersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name)) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure {},
-    addImportedFn xss :=
-      pure <| xss.foldl (init := {}) fun ns xs =>
-        xs.foldl (init := ns) fun ns (x, ys) =>
-          ns.insert x <| (ns.find? x |>.getD #[]) ++ ys
-    addEntryFn
-      | xs, (x, y) =>
-        xs.insert x (xs.find? x |>.getD #[] |>.push y)
-    exportEntriesFn xs :=
-      xs.toArray
-  }
+initialize directiveExpanderExt : ExpanderExtension ←
+  mkExpanderExtension `directiveExpanderExt
 
 unsafe initialize registerBuiltinAttribute {
   name := `directive,
@@ -945,19 +936,8 @@ public def toBlockCommand {α : Type} [FromArgs α DocElabM] (expander : α → 
 
 syntax (name := block_command) "block_command " (ident)? : attr
 
-initialize blockCommandExpanderExt : PersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name)) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure {},
-    addImportedFn xss :=
-      pure <| xss.foldl (init := {}) fun ns xs =>
-        xs.foldl (init := ns) fun ns (x, ys) =>
-          ns.insert x <| (ns.find? x |>.getD #[]) ++ ys
-    addEntryFn
-      | xs, (x, y) =>
-        xs.insert x (xs.find? x |>.getD #[] |>.push y)
-    exportEntriesFn xs :=
-      xs.toArray
-  }
+initialize blockCommandExpanderExt : ExpanderExtension ←
+  mkExpanderExtension `blockCommandExpanderExt
 
 unsafe initialize registerBuiltinAttribute {
   name := `block_command,

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -550,6 +550,19 @@ unsafe def blockExpandersForUnsafe (x : Name) : DocElabM (Array BlockExpander) :
 @[implemented_by blockExpandersForUnsafe]
 public opaque blockExpandersFor (x : Name) : DocElabM (Array BlockExpander)
 
+-- We eagerly rebuild a `NameMap` from imported entries instead of keeping the
+-- exported arrays sorted and doing binary search at lookup time, which is the
+-- more common pattern for local persistent extensions.
+--
+-- This preserves the existing eager lookup-state initialization: doc expander
+-- signatures are looked up by name repeatedly during elaboration, so the hot path
+-- should be a single map lookup. The import-time cost should be small in the
+-- expected case, since few signatures are exported by typical modules.
+--
+-- Another reason not to rely on per-module sorted arrays is that expanders are
+-- not required to be registered in the same module as their associated
+-- identifier, so lookup would otherwise need to search all imported arrays unless
+-- we built an index anyway.
 initialize expanderSignatureExt :
     LocalPersistentEnvExtension (Name × SigDoc) (Name × SigDoc) (NameMap SigDoc) ←
   LocalPersistentEnvExtension.register {

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -654,7 +654,7 @@ private unsafe def roleExpandersForUnsafe (x : Name) : DocElabM (Array (RoleExpa
 public opaque roleExpandersFor (x : Name) : DocElabM (Array (RoleExpander × Option String × Option SigDoc))
 
 private def registeredExpanderNames
-    (ext : PersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name)))
+    (ext : LocalPersistentEnvExtension (Name × Array Name) (Name × Name) (NameMap (Array Name)))
     (attr : KeyedDeclsAttribute α) : DocElabM (Array Name) := do
   let env ← getEnv
   let mut names : NameSet := {}

--- a/src/verso/Verso/EnvExtension.lean
+++ b/src/verso/Verso/EnvExtension.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio Jesus Gallego Arias
+-/
+module
+public import Lean.Environment
+
+namespace Verso
+
+open Lean
+
+/-
+`LocalPersistentEnvExtension` wraps a persistent extension whose state is split into a complete
+lookup state and a local export delta.
+
+Imported entries initialize only the complete lookup state. Local entries update both states. Export
+receives only the local delta, so the extension cannot accidentally re-serialize transitive imported
+entries.
+
+This is the same persistence discipline as `SimplePersistentEnvExtension`, staged for extension
+shapes where the serialized entry type and the added entry type differ. The complete lookup state and
+local export delta intentionally have the same type here. Extensions that need different state types,
+async support, or replay support should use `PersistentEnvExtension` directly.
+
+Imported entries are eagerly folded into the complete lookup state when the module is imported. This
+matches the existing Verso doc-expander lookup pattern, where document elaboration repeatedly queries
+the complete map by key. Extensions whose import-time initialization cost matters more than direct
+lookup should use `PersistentEnvExtension` directly and keep a custom serialized representation.
+-/
+public structure LocalPersistentEnvExtension (α β σ : Type) where
+  private ext : PersistentEnvExtension α β (σ × σ)
+
+namespace LocalPersistentEnvExtension
+
+public instance {α β σ : Type} [Inhabited σ] :
+    Nonempty (LocalPersistentEnvExtension α β σ) :=
+  ⟨{ ext := default }⟩
+
+public structure Descr (α β σ : Type) where
+  name : Name := by exact decl_name%
+  mkInitialState : IO σ
+  addImportedEntryFn : σ → α → σ
+  addEntryFn : σ → β → σ
+  exportEntriesFn : Environment → σ → OLeanEntries (Array α)
+
+public def register {α β σ : Type} [Inhabited σ]
+    (descr : Descr α β σ) :
+    IO (LocalPersistentEnvExtension α β σ) := do
+  let ext ← registerPersistentEnvExtension {
+    name := descr.name
+    mkInitial := do
+      pure (← descr.mkInitialState, ← descr.mkInitialState)
+    addImportedFn := fun entrySets => do
+      let mut state ← descr.mkInitialState
+      for entries in entrySets do
+        for entry in entries do
+          state := descr.addImportedEntryFn state entry
+      pure (state, ← descr.mkInitialState)
+    addEntryFn := fun (state, delta) entry =>
+      (descr.addEntryFn state entry, descr.addEntryFn delta entry)
+    exportEntriesFnEx := fun env (_, delta) =>
+      descr.exportEntriesFn env delta
+    asyncMode := .mainOnly
+  }
+  pure { ext }
+
+public def getState {α β σ : Type} [Inhabited σ]
+    (ext : LocalPersistentEnvExtension α β σ) (env : Environment) : σ :=
+  match ext with
+  | ⟨rawExt⟩ => (PersistentEnvExtension.getState rawExt env).1
+
+public def addEntry {α β σ : Type} (ext : LocalPersistentEnvExtension α β σ)
+    (env : Environment) (entry : β) : Environment :=
+  match ext with
+  | ⟨rawExt⟩ => PersistentEnvExtension.addEntry rawExt env entry
+
+public def getModuleEntries {α β σ : Type} [Inhabited σ]
+    (ext : LocalPersistentEnvExtension α β σ) (env : Environment) (moduleIdx : ModuleIdx)
+    (level := OLeanLevel.exported) : Array α :=
+  match ext with
+  | ⟨rawExt⟩ => PersistentEnvExtension.getModuleEntries (level := level) rawExt env moduleIdx

--- a/src/verso/Verso/EnvExtension.lean
+++ b/src/verso/Verso/EnvExtension.lean
@@ -30,12 +30,9 @@ lookup should use `PersistentEnvExtension` directly and keep a custom serialized
 -/
 public structure LocalPersistentEnvExtension (α β σ : Type) where
   private ext : PersistentEnvExtension α β (σ × σ)
+deriving Inhabited
 
 namespace LocalPersistentEnvExtension
-
-public instance {α β σ : Type} [Inhabited σ] :
-    Nonempty (LocalPersistentEnvExtension α β σ) :=
-  ⟨{ ext := default }⟩
 
 public structure Descr (α β σ : Type) where
   name : Name := by exact decl_name%


### PR DESCRIPTION
Verso Blueprint exposed very large `.olean` files. For example, a file that imports all test blueprints produced an `.olean` above 10 GiB.

The cause was that doc expander and signature environment extension state were re-exported. Importer modules therefore serialized transitive expander entries again, which can compound across import chains.

This patch introduces `LocalPersistentEnvExtension`, a small Verso-side helper for persistent extensions that keep complete imported lookup state alongside a separate local export delta. It then uses the helper to store doc expander and signature extension state as separate local and complete maps.

Only local entries are exported, while lookup still uses the complete imported state. This prevents importer modules from reserializing every transitive expander entry.

The patch adds transitive-import regressions covering role, code block, directive, and block-command expanders, plus a direct regression for the local-persistent-extension failure mode.

## Measurements

For blueprints, the size reduction is substantial, on the order of 100x or more.

Additional benchmarks:

Reference manual at `8ae381a3`, Lean `v4.30.0-rc2`, command `lake --no-cache build Manual`, baseline Verso `ba73c230`:

| Build | Elapsed | Max RSS |
| --- | ---: | ---: |
| baseline run 1 | 157.13s | 2,518,464 KB |
| baseline run 2 | 155.61s | 2,525,236 KB |
| patched | 144.25s | 2,537,208 KB |

Compared reference-manual artifacts:
- total artifacts: `637,348,589 B -> 599,759,959 B`, `-37,588,630 B` / about `-35.8 MiB`
- `.olean` total: `546,283,272 B -> 508,649,832 B`, `-37,633,440 B`

Synthetic importer test, `Manual.PerfImportPair` importing `Manual.Terms` and `Manual.Tactics.Reference`:
- Lake-built `.olean`: `375,456 B -> 17,072 B`, `-95.5%`
- direct Lean `.olean`: `375,392 B -> 17,008 B`
- direct compile time stayed flat: `1.66s -> 1.65s`

UsersGuide comparison:
- elapsed time effectively flat: `56.59s -> 56.84s`
- compared `.olean` artifacts dropped by about `432 KiB`
