### PR TITLE
refactor: handle error and warning logs consistently

### DIFF
--- a/doc/UsersGuide/Markup.lean
+++ b/doc/UsersGuide/Markup.lean
@@ -134,10 +134,10 @@ block_extension MarkupExample (title : String) where
   traverse _ _ _ := pure none
   toHtml := some fun _goI goB _id data contents => open Verso.Output.Html in do
     let .str title := data
-      | Verso.Doc.Html.HtmlT.logError s!"Expected a string, got {data.compress}"
+      | reportError s!"Expected a string, got {data.compress}"
         return .empty
     let #[stx, parsed] := contents
-      | Verso.Doc.Html.HtmlT.logError s!"Expected two blocks, got {contents.size}"
+      | reportError s!"Expected two blocks, got {contents.size}"
         return .empty
     pure {{
       <div class="markup-example">
@@ -212,10 +212,10 @@ r#"
   ]
   toTeX := some fun _goI _goB _id data contents => open Verso.Output.TeX in open Verso.Doc.TeX in do
     let .str title := data
-      | logError s!"Expected title as string, got {data.compress}"
+      | reportError s!"Expected title as string, got {data.compress}"
         return \TeX{}
     let #[.code stx, .code parsed] := contents
-      | logError s!"Expected two code blocks, got {contents.size}"
+      | reportError s!"Expected two code blocks, got {contents.size}"
         return \TeX{}
     pure \TeX{
       \begin{markupexample}{\Lean{title}}

--- a/doc/UsersGuide/Releases.lean
+++ b/doc/UsersGuide/Releases.lean
@@ -6,6 +6,7 @@ Author: Emilio J. Gallego Arias
 
 import VersoManual
 
+import UsersGuide.Releases.«v4_31_0»
 import UsersGuide.Releases.«v4_30_0»
 import UsersGuide.Releases.«v4_29_0»
 import UsersGuide.Releases.«v4_28_0»
@@ -28,6 +29,7 @@ Verso versioning follows Lean's.
 This means that we release a new version for each Lean release, usually once per month.
 In particular, note that Verso doesn't follow the [semantic versioning model](https://semver.org/).
 
+{include 0 UsersGuide.Releases.«v4_31_0»}
 {include 0 UsersGuide.Releases.«v4_30_0»}
 {include 0 UsersGuide.Releases.«v4_29_0»}
 {include 0 UsersGuide.Releases.«v4_28_0»}

--- a/doc/UsersGuide/Releases/v4_31_0.lean
+++ b/doc/UsersGuide/Releases/v4_31_0.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+
+import VersoManual
+
+open Verso.Genre Manual InlineLean
+
+
+#doc (Manual) "Verso 4.31.0 (unreleased)" =>
+%%%
+tag := "release-v4.31.0"
+file := "v4.31.0"
+%%%
+
+* Refactored the build's error reporting into a {ref "feat-build-log"}[logging abstraction] with severities and structured source locations, improving the consistency of Verso's internal APIs and external error reports.
+  While this was primarily an internal change, there is a {ref "feat-build-log-breaking"}[breaking change] to the signature of {name}`Verso.Genre.Manual.ExtraStep`.
+
+# Logging Abstraction
+%%%
+tag := "feat-build-log"
+%%%
+
+The build pipeline previously threaded a bare `String → IO Unit` error callback through traversal and output generation, and several monads carried their own ad-hoc error loggers.
+There was no way to emit a warning.
+
+This release introduces {name}`Verso.MonadBuildLog`, a uniform logging interface shared across the genres.
+A message carries a {name}`Verso.Severity` (either {name}`Verso.Severity.error` or {name}`Verso.Severity.warning`) and an optional source location.
+
+
+## Breaking Change: `ExtraStep`
+%%%
+tag := "feat-build-log-breaking"
+%%%
+
+{name}`Verso.Genre.Manual.ExtraStep` no longer takes a `String → IO Unit` error callback.
+Instead, it runs in a monad that has an instance of {name}`Verso.MonadBuildLog`, so a step can emit both errors and warnings with {name}`Verso.reportError` and {name}`Verso.reportWarning`.

--- a/src/tests/TestMain.lean
+++ b/src/tests/TestMain.lean
@@ -56,8 +56,8 @@ def testTexOutput
 
   let runTest : IO Unit  :=
     open Verso Genre Manual in do
-    let logError (msg : String) := IO.eprintln msg
-    ReaderT.run (emitTeX logError versoConfig doc.toPart) extension_impls%
+    let logger ← Verso.Logger.new
+    emitTeX versoConfig doc.toPart |>.run extension_impls% |>.run logger
 
   Verso.Integration.runTests { config with
     testDir := "src/tests/integration" / dir,
@@ -259,8 +259,99 @@ def testSetupLiterate (_ : Config) : IO Unit := do
 
   IO.println "  All setup-literate tests passed."
 
+open Verso in
+def testBuildLog (_ : Config) : IO Unit := do
+  IO.println "Running build-log tests..."
+  -- A message logged with a position is saved with that location (a location always names a file).
+  let logger ← Logger.new
+  let pos : Lean.Lsp.Position := { line := 4, character := 2 }
+  (reportError "boom" (some { file := "PosSave.lean", span := .pos pos }) : BuildLogT IO Unit).run logger
+  let errs ← logger.errors
+  let some m := errs[0]?
+    | throw <| IO.userError s!"expected 1 saved error, got {errs.size}"
+  unless m.severity == .error do throw <| IO.userError "expected error severity"
+  match m.loc with
+  | some { file := "PosSave.lean", span := .pos p } =>
+    unless p.line == 4 && p.character == 2 do
+      throw <| IO.userError "saved position does not match the logged span"
+  | _ => throw <| IO.userError "expected a saved `PosSave.lean` `pos` location"
+
+  -- A `range` span is likewise saved.
+  let logger2 ← Logger.new
+  let r : Lean.Lsp.Range :=
+    { start := { line := 1, character := 0 }, «end» := { line := 1, character := 5 } }
+  (reportWarning "careful" (some { file := "RangeSave.lean", span := .range r }) : BuildLogT IO Unit).run logger2
+  let some w := (← logger2.warnings)[0]?
+    | throw <| IO.userError "expected 1 saved warning"
+  match w.loc with
+  | some { span := .range _, .. } => pure ()
+  | _ => throw <| IO.userError "expected a `range` span to be saved"
+
+  -- Range formatting defers to Lean's `mkErrorStringWithPos`: `file:line:col-line:col`, 1-based
+  -- line, 0-based column, with the full end position even within one line (no `line:col-col` collapse).
+  let crossLine : LogMessage :=
+    { severity := .error, text := "msg",
+      loc := some { file := "CrossLine.lean",
+                    span := .range { start := { line := 19, character := 4 }, «end» := { line := 20, character := 7 } } } }
+  unless crossLine.format == "CrossLine.lean:20:4-21:7: msg" do
+    throw <| IO.userError s!"cross-line range formatted as \"{crossLine.format}\""
+  let sameLine : LogMessage :=
+    { severity := .error, text := "msg",
+      loc := some { file := "SameLine.lean",
+                    span := .range { start := { line := 42, character := 4 }, «end» := { line := 42, character := 21 } } } }
+  unless sameLine.format == "SameLine.lean:43:4-43:21: msg" do
+    throw <| IO.userError s!"same-line range formatted as \"{sameLine.format}\""
+
+  -- A located message is formatted uniformly as `file:line:col: text`.
+  let loggerF ← Logger.new
+  let errBufF ← IO.mkRef ({} : IO.FS.Stream.Buffer)
+  IO.withStderr (IO.FS.Stream.ofBuffer errBufF) <|
+    (reportError "bad term" (some { file := "FileLoc.lean", span := .pos { line := 6, character := 3 } })
+      : BuildLogT IO Unit).run loggerF
+  let some mF := (← loggerF.errors)[0]?
+    | throw <| IO.userError "expected 1 saved error with a file location"
+  unless mF.loc.map (·.file) == some "FileLoc.lean" do
+    throw <| IO.userError "saved location should carry the filename"
+  unless hasSubstring (String.fromUTF8! (← errBufF.get).data) "FileLoc.lean:7:3: bad term" do
+    throw <| IO.userError "a file location should format as file:line:col:"
+
+  -- A single logging action can emit both severities; errors set the exit code, warnings do not.
+  let logger3 ← Logger.new
+  (do reportError "e1"; reportWarning "w1"; reportError "e2" : BuildLogT IO Unit).run logger3
+  unless (← logger3.errors).size == 2 do throw <| IO.userError "expected 2 errors"
+  unless (← logger3.warnings).size == 1 do throw <| IO.userError "expected 1 warning"
+  unless (← logger3.exitCode) == 1 do throw <| IO.userError "errors must yield a non-zero exit code"
+
+  let logger4 ← Logger.new
+  (reportWarning "just a warning" : BuildLogT IO Unit).run logger4
+  unless (← logger4.exitCode) == 0 do
+    throw <| IO.userError "warnings must not affect the exit code"
+
+  -- Logging prints to the *ambient* stderr, resolved at log time: a logger created before a
+  -- stderr redirection still writes into the redirected stream, and nothing goes to stdout.
+  let logger5 ← Logger.new
+  let outBuf ← IO.mkRef ({} : IO.FS.Stream.Buffer)
+  let errBuf ← IO.mkRef ({} : IO.FS.Stream.Buffer)
+  IO.withStdout (IO.FS.Stream.ofBuffer outBuf) <|
+    IO.withStderr (IO.FS.Stream.ofBuffer errBuf) <|
+      (do
+        reportError "first problem" (some { file := "X.lean", span := .pos { line := 0, character := 0 } })
+        reportWarning "second problem" : BuildLogT IO Unit).run logger5
+  let errText := String.fromUTF8! (← errBuf.get).data
+  let outText := String.fromUTF8! (← outBuf.get).data
+  unless hasSubstring errText "X.lean:1:0: first problem" do
+    throw <| IO.userError s!"stderr buffer is missing the formatted error; got: {errText}"
+  unless hasSubstring errText "second problem" do
+    throw <| IO.userError s!"stderr buffer is missing the warning; got: {errText}"
+  unless outText.isEmpty do
+    throw <| IO.userError s!"logging must not write to stdout; got: {outText}"
+  unless (← logger5.errors).size == 1 && (← logger5.warnings).size == 1 do
+    throw <| IO.userError "redirected logging should still accumulate into the logger's buffers"
+  IO.println "  All build-log tests passed."
+
 open Verso.Integration in
 def tests := [
+  testBuildLog,
   testSerialization,
   testSearchJs,
   testBlog,

--- a/src/tests/Tests/GenericCode.lean
+++ b/src/tests/Tests/GenericCode.lean
@@ -58,7 +58,7 @@ info: Verso.Output.Html.tag
               (Verso.Output.Html.text true "(define (zero f z) z)\n(define (succ n) (lambda (f x) (f (n f z))))\n")])])
 -/
 #guard_msgs in
-  #eval Doc.Genre.none.toHtml (m:=Id) {logError := fun _ => ()} () () {} {} {} code1.toPart |>.run .empty |>.fst
+  #eval Doc.Genre.none.toHtml (m := Id) {} () () {} {} {} code1.toPart |>.run .empty |>.fst
 
 
 /- ----- -/

--- a/src/tests/Tests/TexUtil.lean
+++ b/src/tests/Tests/TexUtil.lean
@@ -19,23 +19,24 @@ This requires the `IO` monad because `TraverseM` does.
 -/
 def toTex (block : Doc.Block Genre.Manual) : IO Output.TeX := do
   let extension_impls := extension_impls%
+  let logger ← Verso.Logger.new
 
   -- Traversal monadic data
-  let traverseContext : TraverseContext := {
-    logError msg := IO.println msg,
-  }
+  let traverseContext : TraverseContext := {}
   let traverseState : TraverseState := .initialize {}
 
   -- Traverse the block. This shadows both `block` and `traverseState`.
   -- This is where we engage with the IO at the bottom of TraverseM.
-  let ⟨block, traverseState⟩ ← Doc.Genre.traverseBlock Genre.Manual block
-    |>.run extension_impls traverseContext traverseState
+  let ⟨block, traverseState⟩ ←
+    Doc.Genre.traverseBlock Genre.Manual block
+      |>.run extension_impls traverseContext traverseState logger
 
   -- Options for TeX
-  let options : Doc.TeX.Options Genre.Manual (ReaderT ExtensionImpls IO) := {
-    headerLevel := none,
-    logError msg := IO.println msg,
+  let options : Doc.TeX.Options Genre.Manual := {
+    headerLevel := none
   }
 
   -- Convert the block to TeX
-  block.toTeX.run ⟨options, traverseContext, traverseState, {}⟩ |>.run' {} |>.run extension_impls
+  block.toTeX
+    |>.run ⟨options, traverseContext, traverseState, {}⟩
+    |>.run' {} |>.run extension_impls |>.run logger

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -835,39 +835,33 @@ Optional parameters:
 def blogMain (theme : Theme) (site : Site) (linkTargets : Code.LinkTargets TraverseContext := {})
     (options : List String) (components : Components := by exact %registered_components)
     (header : String := Html.doctype) :
-    IO UInt32 := do
-  let hasError ← IO.mkRef false
-  let logError msg := do hasError.set true; IO.eprintln msg
-  let cfg ← opts {logError := logError} options
-  let (site, xref) ← site.traverse cfg components
-  let initGenCtx : Generate.Context := {
-    theme, site,
-    ctxt := { path := .root, config := cfg, components },
-    xref := xref,
-    dir := cfg.destination,
-    config := cfg,
-    header := header,
-    linkTargets := linkTargets,
-    components := components
-  }
-  let (((), st), _) ← site.generate theme initGenCtx .empty {}
-  IO.FS.writeFile (cfg.destination.join "-verso-docs.json") (toString st.dedup.docJson)
-  for (name, content, srcMap?) in xref.jsFiles do
-    FS.ensureDir (cfg.destination.join "-verso-data")
-    IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
-    if let some (name, content) := srcMap? then
+    IO UInt32 :=
+  withLogger fun logger => do
+    let cfg ← opts {} options
+    let (site, xref) ← site.traverse cfg components |>.run logger
+    let initGenCtx : Generate.Context := {
+      theme, site,
+      ctxt := { path := .root, config := cfg, components },
+      xref := xref,
+      dir := cfg.destination,
+      config := cfg,
+      header := header,
+      linkTargets := linkTargets,
+      components := components
+    }
+    let (((), st), _) ← site.generate theme initGenCtx .empty {} |>.run logger
+    IO.FS.writeFile (cfg.destination.join "-verso-docs.json") (toString st.dedup.docJson)
+    for (name, content, srcMap?) in xref.jsFiles do
+      FS.ensureDir (cfg.destination.join "-verso-data")
       IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
-  for (name, content, _) in theme.jsFiles do
-    FS.ensureDir (cfg.destination.join "-verso-data")
-    IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
-  for (name, content) in theme.cssFiles ++ xref.cssFiles do
-    FS.ensureDir (cfg.destination.join "-verso-data")
-    IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
-  if (← hasError.get) then
-    IO.eprintln "Errors were encountered!"
-    return 1
-  else
-    return 0
+      if let some (name, content) := srcMap? then
+        IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
+    for (name, content, _) in theme.jsFiles do
+      FS.ensureDir (cfg.destination.join "-verso-data")
+      IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
+    for (name, content) in theme.cssFiles ++ xref.cssFiles do
+      FS.ensureDir (cfg.destination.join "-verso-data")
+      IO.FS.writeFile (cfg.destination.join "-verso-data" |>.join name) content
 where
   opts (cfg : Config)
     | ("--output"::dir::more) => opts {cfg with destination := dir} more

--- a/src/verso-blog/VersoBlog/Basic.lean
+++ b/src/verso-blog/VersoBlog/Basic.lean
@@ -220,7 +220,6 @@ structure Config where
   destination : System.FilePath := "./_site"
   showDrafts : Bool := false
   postName : Date → String → String := defaultPostName
-  logError : String → IO Unit
   remoteInfoConfigPath : Option System.FilePath := none
   verbose : Bool := false
 deriving Inhabited
@@ -230,8 +229,9 @@ class MonadConfig (m : Type → Type u) where
 
 export MonadConfig (currentConfig)
 
-def logError [Monad m] [MonadConfig m] [MonadLiftT IO m] (message : String) : m Unit := do
-  (← currentConfig).logError message
+@[deprecated "Use `Verso.reportError` instead." (since := "2026-05-29")]
+def logError [MonadBuildLog m] (message : String) : m Unit :=
+  Verso.reportError message
 
 structure Components where
   /--
@@ -483,7 +483,7 @@ instance : BEq TraverseState where
       err1.toList == err2.toList &&
       rem1 == rem2
 
-abbrev TraverseM := ReaderT Blog.TraverseContext (StateT Blog.TraverseState IO)
+abbrev TraverseM := ReaderT Blog.TraverseContext (StateT Blog.TraverseState (BuildLogT IO))
 
 instance : MonadConfig TraverseM where
   currentConfig := do pure (← read).config

--- a/src/verso-blog/VersoBlog/Component.lean
+++ b/src/verso-blog/VersoBlog/Component.lean
@@ -83,7 +83,7 @@ def State.freshId (state : State) : String × State := Id.run do
 
 end Component
 
-abbrev ComponentM := ReaderT Components (StateT Component.State IO)
+abbrev ComponentM := ReaderT Components (StateT Component.State (BuildLogT IO))
 
 abbrev HtmlM genre := HtmlT genre ComponentM
 
@@ -259,7 +259,7 @@ def deJson [Monad m] [MonadQuotation m]
   let (x, t) := b
   `(Lean.Parser.Term.doSeqItem| let $x ← match FromJson.fromJson? (α := $t) $x with
       | .error e => do
-        (HtmlT.logError e : HtmlM Page Unit)
+        (reportError e : HtmlM Page Unit)
         return Html.empty
       | .ok v => pure v)
 
@@ -288,7 +288,7 @@ elab_rules : command
                   $noJson*
                   ($tm id json goI goB contents)
                 | _ => do
-                  HtmlT.logError s!"Expected array, got {json}"
+                  reportError s!"Expected array, got {json}"
                   return .empty)
     let other := toHtml.toArray ++ other
     let cmd2 ←
@@ -340,7 +340,7 @@ elab_rules : command
                   $noJson*
                   ($tm id json goI contents)
                 | _ => do
-                  HtmlT.logError s!"Expected array, got {json}"
+                  reportError s!"Expected array, got {json}"
                   return .empty)
     let other := toHtml.toArray ++ other
     let cmd2 ←

--- a/src/verso-blog/VersoBlog/Generate.lean
+++ b/src/verso-blog/VersoBlog/Generate.lean
@@ -32,7 +32,7 @@ structure Generate.Context where
   dir : System.FilePath
   config : Config
   header : String
-  rewriteHtml : Option ((logError : String → IO Unit) → TraverseContext → Html → IO Html) := none
+  rewriteHtml : Option (TraverseContext → Html → BuildLogT IO Html) := none
   components : Components := {}
   theme : Theme
   extraParams : Multi.Path → Template.Params := fun _ => {}
@@ -50,20 +50,17 @@ def Generate.Context.templateContext (ctxt : Generate.Context) (params : Templat
     components := ctxt.components
   }
 
-abbrev GenerateM := ReaderT Generate.Context (StateT (State Html) (StateT Component.State IO))
+abbrev GenerateM := ReaderT Generate.Context (StateT (State Html) (StateT Component.State (BuildLogT IO)))
 
 instance : Template.MonadComponents GenerateM where
   componentImpls := do return (← read).components
   saveJs js := modifyThe Component.State fun s => {s with headerJs := s.headerJs.insert js}
   saveCss css := modifyThe Component.State fun s => {s with headerCss := s.headerCss.insert css}
 
-instance : MonadLift IO GenerateM where
-  monadLift act := fun _ st => (·, st) <$> act
-
 def Generate.rewriteOutput (html : Html) : GenerateM Html := do
-  let {ctxt, config, rewriteHtml := some rewriter, ..} := (← read)
+  let {ctxt, rewriteHtml := some rewriter, ..} := (← read)
     | pure html
-  rewriter config.logError ctxt html
+  rewriter ctxt html
 
 instance : MonadPath GenerateM where
   currentPath := do return (← read).ctxt.path
@@ -78,7 +75,7 @@ def GenerateM.toHtml (g : Genre)
   let {ctxt := ctxt, xref := state, linkTargets, ..} ← read
   let (out, st') ← g.toHtml
     (m := ComponentM)
-    {logError := fun x => ctxt.config.logError x, headerLevel := 2}
+    { headerLevel := 2 }
     (bg.context_eq ▸ ctxt)
     (bg.state_eq ▸ state)
     {}
@@ -185,7 +182,7 @@ def writeBlog (theme : Theme) (id : Lean.Name) (txt : Part Page) (posts : Array 
 
   let «meta» ←
     match (← read).xref.blogs.find? id with
-    | none => logError s!"Blog {id} not found in traverse pass!"; pure {}
+    | none => reportError s!"Blog {id} not found in traverse pass!"; pure {}
     | some «meta» => pure «meta»
 
   for (cat, contents) in meta.categories.toArray.qsort (·.1.name < ·.1.name) do
@@ -242,7 +239,7 @@ partial def Dir.generate (theme : Theme) (dir : Dir) : GenerateM Unit :=
         IO.FS.removeDirAll dest
       else
         IO.FS.removeFile dest
-    copyRecursively (← currentConfig).logError file dest
+    copyRecursively file dest
 
 def Site.generate (theme : Theme) (site : Site) : GenerateM Unit := do
   match site with

--- a/src/verso-blog/VersoBlog/Site.lean
+++ b/src/verso-blog/VersoBlog/Site.lean
@@ -87,7 +87,7 @@ def Site.traverse1 (site : Site) : Blog.TraverseM Site := do
 def Site.traverse
     (site : Site) (config : Config)
     (components : Components) :
-    IO (Site × Blog.TraverseState) := do
+    BuildLogT IO (Site × Blog.TraverseState) := do
   let topCtxt : Blog.TraverseContext := {path := .root, config, components}
   let logVerbose := (if config.verbose then (fun _ => pure ()) else IO.println)
   let remoteContent ← Multi.updateRemotes false config.remoteInfoConfigPath logVerbose

--- a/src/verso-blog/VersoBlog/Template.lean
+++ b/src/verso-blog/VersoBlog/Template.lean
@@ -167,11 +167,11 @@ def blockHtml (g : Genre)
     let ⟨_, _, _, _⟩ := bg
     match (← readThe Components).blocks.find? name with
     | none =>
-      HtmlT.logError s!"No component implementation found for block '{name}' in {(← readThe Components).blocks.toList.map (·.fst)}"
+      reportError s!"No component implementation found for block '{name}' in {(← readThe Components).blocks.toList.map (·.fst)}"
       pure .empty
     | some dyn =>
       let some {toHtml := impl, ..} := dyn.get? BlockComponent
-        | HtmlT.logError s!"Wrong type for block components: {dyn.typeName}"; pure .empty
+        | reportError s!"Wrong type for block components: {dyn.typeName}"; pure .empty
       let id ← modifyGetThe Component.State fun s => s.freshId
       impl ⟨id⟩ json
         (fun x => goI (x.cast bg.inline_eq.symm) |>.cast)
@@ -185,7 +185,7 @@ def blockHtml (g : Genre)
     }}
   | .docstringSection lvl, contents => do
     if lvl > 5 then
-      logError s!"Docstring header level {lvl + 1} is greater than the allowed HTML nesting of `<h6>`"
+      reportError s!"Docstring header level {lvl + 1} is greater than the allowed HTML nesting of `<h6>`"
     if let some (Block.para first) := contents[0]? then
       let contents := contents.extract 1
       return {{
@@ -195,7 +195,7 @@ def blockHtml (g : Genre)
         </section>
       }}
     else
-      logError "Internal error: docstring section missing leading paragraph as title"
+      reportError "Internal error: docstring section missing leading paragraph as title"
       contents.mapM goB
 
 
@@ -222,7 +222,7 @@ def inlineHtml (g : Genre) [bg : BlogGenre g]
     let st ← bg.state_eq ▸ state
     match st.targets.find? x with
     | none =>
-      HtmlT.logError s!"Can't find target {x}"
+      reportError s!"Can't find target {x}"
       pure {{<strong class="internal-error">s!"Can't find target {x}"</strong>}}
     | some tgt =>
       let addr := tgt.relativeLink
@@ -231,7 +231,7 @@ def inlineHtml (g : Genre) [bg : BlogGenre g]
     let st ← bg.state_eq ▸ state
     match st.pageIds.find? x <|> st.pageIds.find? (docName x) with
     | none =>
-      HtmlT.logError s!"Can't find target {x} - options are {st.pageIds.toList.map (·.fst)}"
+      reportError s!"Can't find target {x} - options are {st.pageIds.toList.map (·.fst)}"
       pure {{<strong class="internal-error">s!"Can't find target {x}"</strong>}}
     | some «meta» =>
       let addr := meta.path.relativeLink ++ (id?.map ("#" ++ ·) |>.getD "")
@@ -243,11 +243,11 @@ def inlineHtml (g : Genre) [bg : BlogGenre g]
     let ⟨_, _, _, _⟩ := bg
     match (← readThe Components).inlines.find? name with
     | none =>
-      HtmlT.logError s!"No component implementation found for inline '{name}' in {(← readThe Components).inlines.toList.map (·.fst)}"
+      reportError s!"No component implementation found for inline '{name}' in {(← readThe Components).inlines.toList.map (·.fst)}"
       pure .empty
     | some dyn =>
       let some {toHtml := impl, ..} := dyn.get? InlineComponent
-        | HtmlT.logError s!"Wrong type for block components: {dyn.typeName}"; pure .empty
+        | reportError s!"Wrong type for block components: {dyn.typeName}"; pure .empty
       let id ← modifyGetThe Component.State fun s => s.freshId
       impl ⟨id⟩ json
         (fun x => go (x.cast bg.inline_eq.symm) |>.cast)

--- a/src/verso-blog/VersoBlog/Traverse.lean
+++ b/src/verso-blog/VersoBlog/Traverse.lean
@@ -26,7 +26,7 @@ def addCssFile (filename contents : String) : TraverseM Unit := do
   for (fn, css) in (← get).cssFiles do
     if filename == fn then
       if contents != css then
-        logError s!"Attempted to add different content for CSS file {filename}"
+        reportError s!"Attempted to add different content for CSS file {filename}"
       return
 
   modify fun s => s.addCssFile filename contents
@@ -35,9 +35,9 @@ def addJsFile (filename contents : String) (sourceMap? : Option (String × Strin
   for (fn, js, map?) in (← get).jsFiles do
     if filename == fn then
       if contents != js then
-        logError s!"Attempted to add different content for JS file {filename}"
+        reportError s!"Attempted to add different content for JS file {filename}"
       if sourceMap? != map? then
-        logError s!"Attempted to add different source map for JS file {filename}"
+        reportError s!"Attempted to add different source map for JS file {filename}"
       return
 
   modify fun s => s.addJsFile filename contents sourceMap?
@@ -53,7 +53,7 @@ def genreBlock (g : Genre) [bg : BlogGenre g] : Blog.BlockExt → Array (Block g
       pure none
     | .component name json, contents => do
       let some blk := (← read).components.blocks.find? name
-        | logError s!"No implementation found for block '{name}' during traversal"
+        | reportError s!"No implementation found for block '{name}' during traversal"
           pure none
       let some {traverse, jsFiles, cssFiles, ..} := blk.get? BlockComponent
         | panic! s!"Wrong type for block component! Got {blk.typeName}"
@@ -92,7 +92,7 @@ def genreInline (g : Genre) [bg : BlogGenre g] : Blog.InlineExt → Array (Inlin
     | .htmlSpan .., _ | .blob .., _ | .lexedText .., _ => pure none
     | .component name json, contents => do
       let some inl := (← read).components.inlines.find? name
-        | logError s!"No implementation found for inline '{name}' during traversal"
+        | reportError s!"No implementation found for inline '{name}' during traversal"
           pure none
       let some {traverse, jsFiles, cssFiles, ..} := inl.get? InlineComponent
         | panic! s!"Wrong type for inline component! Got {inl.typeName}"

--- a/src/verso-html/VersoHtmlMain.lean
+++ b/src/verso-html/VersoHtmlMain.lean
@@ -10,6 +10,7 @@ open Lean
 
 open Verso.Output.Html
 open Verso.Code
+open Verso (withLogger)
 
 open VersoLiterate
 open VersoLiterateCode
@@ -69,12 +70,14 @@ def emitMod (root : Dir) (outDir: System.FilePath) (mod : LitMod) : EmitM Unit :
         {{<li><a href={{(components.map toString |> "/".intercalate) ++ "/" ++ toString c.1}}>{{mod.name ++ c.1 |> toString}}</a></li>}}
     else #[]
 
-  let ctx := { (← read) with
-               options := {logError}
-               traverseContext := {currentModule := mod.name}
-               codeOptions := {} }
+  let base ← read
+  let ctx := { base with
+    options := {}
+    traverseContext := { currentModule := mod.name }
+    codeOptions := {}
+  }
 
-  let (results, st) ← mod.contents.mapIdxM (renderCode) |>.run ctx (← get).hlState
+  let (results, st) ← mod.contents.mapIdxM renderCode |>.run ctx (← get).hlState
   -- Discard the accumulated headers because there's no local ToC here
   let body : Html := .seq (results.map (·.1))
 
@@ -139,33 +142,27 @@ def main (args : List String) : IO UInt32 := do
     match getConfig args with
     | .error e => throw <| .userError e
     | .ok v => pure v
-  let errorCount ← IO.mkRef 0
-  IO.FS.createDirAll config.outputDir
-  IO.FS.writeFile (config.outputDir / "popper.js") Verso.Code.Highlighted.WebAssets.popper
-  IO.FS.writeFile (config.outputDir / "tippy.js") Verso.Code.Highlighted.WebAssets.tippy
-  IO.FS.writeFile (config.outputDir / "tippy-border.css") Verso.Code.Highlighted.WebAssets.tippy.border.css
-  IO.FS.writeFile (config.outputDir / "code.css") code.css
-  emitSearchBox (config.outputDir / "-verso-search") (searchPagePath := some "search/")
-  let dir ← loadDir config.inputDir
-  let dir := dir.sort
-  let (dir, traverseState) ← traverse dir
-  let ctx := {
-    logError msg := errorCount.modify (· + 1) *> IO.eprintln msg
-    definitionIds := traverseState.definitionIds
-    linkTargets := traverseState.linkTargets
-    moduleIds := traverseState.moduleIds
-    traverseState
-  }
-  let ((), st) ← emitDir config.outputDir dir |>.run ctx |>.run {}
-  emitIndex {} traverseState dir (config.outputDir / "-verso-search") ctx.logError
-  emitSearchResultsPage config.outputDir
-  let domainData : Verso.NameMap Verso.Multi.Domain := ({} : Verso.NameMap _)
-    |>.insert constDomainName traverseState.constantDefDomain
-    |>.insert moduleDomainName traverseState.moduleDomain
-  IO.FS.writeFile (config.outputDir / "xref.json") <| Json.compress <| Verso.Multi.xrefJson domainData traverseState.allLinks
-  IO.FS.writeFile (config.outputDir / "-verso-docs.json") st.hlState.dedup.docJson.compress
-  let count ← errorCount.get
-  if count > 0 then
-    IO.eprintln s!"{count} errors occurred"
-    return 1
-  else return 0
+  withLogger fun logger => do
+    IO.FS.createDirAll config.outputDir
+    IO.FS.writeFile (config.outputDir / "popper.js") Verso.Code.Highlighted.WebAssets.popper
+    IO.FS.writeFile (config.outputDir / "tippy.js") Verso.Code.Highlighted.WebAssets.tippy
+    IO.FS.writeFile (config.outputDir / "tippy-border.css") Verso.Code.Highlighted.WebAssets.tippy.border.css
+    IO.FS.writeFile (config.outputDir / "code.css") code.css
+    emitSearchBox (config.outputDir / "-verso-search") (searchPagePath := some "search/")
+    let dir ← loadDir config.inputDir
+    let dir := dir.sort
+    let (dir, traverseState) ← traverse dir
+    let ctx := {
+      definitionIds := traverseState.definitionIds
+      linkTargets := traverseState.linkTargets
+      moduleIds := traverseState.moduleIds
+      traverseState
+    }
+    let ((), st) ← emitDir config.outputDir dir |>.run ctx |>.run {} |>.run logger
+    emitIndex {} traverseState dir (config.outputDir / "-verso-search") logger
+    emitSearchResultsPage config.outputDir
+    let domainData : Verso.NameMap Verso.Multi.Domain := ({} : Verso.NameMap _)
+      |>.insert constDomainName traverseState.constantDefDomain
+      |>.insert moduleDomainName traverseState.moduleDomain
+    IO.FS.writeFile (config.outputDir / "xref.json") <| Json.compress <| Verso.Multi.xrefJson domainData traverseState.allLinks
+    IO.FS.writeFile (config.outputDir / "-verso-docs.json") st.hlState.dedup.docJson.compress

--- a/src/verso-literate-code/VersoLiterateCode.lean
+++ b/src/verso-literate-code/VersoLiterateCode.lean
@@ -17,6 +17,7 @@ open Lean
 
 open Verso.Output.Html
 open Verso.Code
+open Verso (MonadBuildLog BuildLogT)
 
 open VersoLiterate
 open Std
@@ -97,7 +98,6 @@ def moduleContext (modName : Name) (litConfig : LiterateConfig)
     return { parents := entries.pop, self := entries.back }
 
 structure HtmlContext where
-  logError : String → IO Unit
   definitionIds : NameMap String
   moduleIds : NameMap String
   traverseState : Literate.TraverseState
@@ -118,10 +118,7 @@ open Verso.Output in
 structure HtmlState where
   hlState : Hover.State Html := {}
 
-abbrev EmitM := ReaderT HtmlContext (StateRefT HtmlState IO)
-
-def logError (msg : String) : EmitM Unit := do
-  (← read).logError msg
+abbrev EmitM := ReaderT HtmlContext (StateRefT HtmlState (BuildLogT IO))
 
 open Verso.Output Html Verso.Multi in
 open MD4Lean in
@@ -1079,10 +1076,10 @@ where
     for (_, ch) in dir.children do
       go ch
 
-def emitIndex (traverseContext : Context) (traverseState : State) (dir : Dir) (outputDir : System.FilePath) (logError : String → IO Unit) : IO Unit := do
+def emitIndex (traverseContext : Context) (traverseState : State) (dir : Dir) (outputDir : System.FilePath) (logger : Verso.Logger IO) : IO Unit := do
   match mkIndex traverseContext traverseState dir with
   | .error e =>
-    logError e
+    logger.reportError e
   | .ok (index, indexDocs) =>
     -- `context` (the breadcrumb text) is not an indexed field. In the past, it was indexed, but its
     -- boost was 0.1, so indexing it nearly duplicated another inverted index for negligible scoring

--- a/src/verso-literate-html/LiterateHtmlMain.lean
+++ b/src/verso-literate-html/LiterateHtmlMain.lean
@@ -10,6 +10,7 @@ open Lean
 
 open Verso.Output.Html
 open Verso.Code
+open Verso (withLogger)
 
 open VersoLiterate
 open VersoLiterateCode
@@ -208,22 +209,22 @@ Returns the body HTML and updated highlight state.
 -/
 private def renderModBody (mod : LitMod) (resolved : ResolvedConfig)
     (ctx : HtmlContext) (initHlState : HtmlState) :
-    IO (Html × HtmlState × Array Heading) := do
+    BuildLogT IO (Html × HtmlState × Array Heading) := do
   let emitCtx := { ctx with
-                   options := {logError := ctx.logError}
-                   traverseContext := {currentModule := mod.name}
-                   codeOptions := {} }
-  let hlCtx : HighlightHtmlM.Context Literate :=
-    ⟨emitCtx.linkTargets, emitCtx.traverseContext, emitCtx.definitionIds, emitCtx.codeOptions⟩
+    options := {}
+    traverseContext := { currentModule := mod.name }
+    codeOptions := {}
+  }
+  let hlCtx : HighlightHtmlM.Context Literate := { emitCtx with options := emitCtx.codeOptions }
 
   -- Render a single code item and its output messages
-  let renderCodeItemWithOutput (idx : Nat) (item : ModuleItem') (hlState : HtmlState) : IO (Html × HtmlState) := do
+  let renderCodeItemWithOutput (idx : Nat) (item : ModuleItem') (hlState : HtmlState) : BuildLogT IO (Html × HtmlState) := do
     let ((codeHtml, _, _), st) ← renderCode idx item |>.run emitCtx hlState.hlState
     let (outputHtml, st') := renderOutputMessages #[(idx, item)] resolved.showOutput hlCtx st
     return (codeHtml ++ outputHtml, { hlState with hlState := st' })
 
   -- Render accumulated code items into a code box
-  let flushCodeItems (items : Array (Nat × ModuleItem')) (hlState : HtmlState) : IO (Html × HtmlState) := do
+  let flushCodeItems (items : Array (Nat × ModuleItem')) (hlState : HtmlState) : BuildLogT IO (Html × HtmlState) := do
     if items.isEmpty then return (.empty, hlState)
     let mut boxHtml : Html := .empty
     let mut hlState := hlState
@@ -443,7 +444,7 @@ Emits the landing page using a specific module's rendered content.
 The module still appears at its normal location; we just also render it as index.html.
 -/
 def emitLandingFromModule (outDir : System.FilePath) (root : Dir) (modName : Name)
-    (ctx : HtmlContext) (initHlState : HtmlState := {})
+    (ctx : HtmlContext) (logger : Verso.Logger IO) (initHlState : HtmlState := {})
     (srcDirs : Lean.NameMap System.FilePath := {}) : IO HtmlState := do
   let litConfig := ctx.litConfig
   let resolved := litConfig.resolveForModule modName
@@ -456,7 +457,7 @@ def emitLandingFromModule (outDir : System.FilePath) (root : Dir) (modName : Nam
   let siteRoot := "./"
   let htmlId? := ctx.moduleIds.find? mod.name
 
-  let (body, hlState, headings) ← renderModBody mod resolved ctx initHlState
+  let (body, hlState, headings) ← renderModBody mod resolved ctx initHlState |>.run logger
 
   let headContents := mkHeadContents litConfig
   let tocHtml := if headings.size >= 2 then buildPageToc headings else .empty
@@ -473,87 +474,80 @@ def main (args : List String) : IO UInt32 := do
     match getConfig args with
     | .error e => throw <| .userError e
     | .ok v => pure v
-  let errorCount ← IO.mkRef 0
-  IO.FS.createDirAll config.outputDir
-  IO.FS.writeFile (config.outputDir / "popper.js") Verso.Code.Highlighted.WebAssets.popper
-  IO.FS.writeFile (config.outputDir / "tippy.js") Verso.Code.Highlighted.WebAssets.tippy
-  IO.FS.writeFile (config.outputDir / "tippy-border.css") Verso.Code.Highlighted.WebAssets.tippy.border.css
-  IO.FS.writeFile (config.outputDir / "marked.js") Verso.Code.Highlighted.WebAssets.marked
-  IO.FS.writeFile (config.outputDir / "literate.css") literate.css
-  -- Copy the copy-button JS
-  IO.FS.writeFile (config.outputDir / "copy-button.js") copyButtonJs
-  emitSearchBox (config.outputDir / "-verso-search") (searchPagePath := some "search/")
-  let (dir, srcDirs) ← loadModuleMap config.moduleMapFile
+  withLogger fun logger => do
+    IO.FS.createDirAll config.outputDir
+    IO.FS.writeFile (config.outputDir / "popper.js") Verso.Code.Highlighted.WebAssets.popper
+    IO.FS.writeFile (config.outputDir / "tippy.js") Verso.Code.Highlighted.WebAssets.tippy
+    IO.FS.writeFile (config.outputDir / "tippy-border.css") Verso.Code.Highlighted.WebAssets.tippy.border.css
+    IO.FS.writeFile (config.outputDir / "marked.js") Verso.Code.Highlighted.WebAssets.marked
+    IO.FS.writeFile (config.outputDir / "literate.css") literate.css
+    -- Copy the copy-button JS
+    IO.FS.writeFile (config.outputDir / "copy-button.js") copyButtonJs
+    emitSearchBox (config.outputDir / "-verso-search") (searchPagePath := some "search/")
+    let (dir, srcDirs) ← loadModuleMap config.moduleMapFile
 
-  -- Load config from TOML if provided
-  let litConfig ← match config.configFile with
-    | some path => loadLiterateConfig path
-    | none => pure ({} : LiterateConfig)
+    -- Load config from TOML if provided
+    let litConfig ← match config.configFile with
+      | some path => loadLiterateConfig path
+      | none => pure ({} : LiterateConfig)
 
-  -- Generate theme CSS file if theme overrides are present
-  if let some themeCssContent := generateThemeCss litConfig.theme litConfig.themeDark then
-    IO.FS.writeFile (config.outputDir / "literate-theme.css") themeCssContent
+    -- Generate theme CSS file if theme overrides are present
+    if let some themeCssContent := generateThemeCss litConfig.theme litConfig.themeDark then
+      IO.FS.writeFile (config.outputDir / "literate-theme.css") themeCssContent
 
-  -- Copy extra CSS files to output directory
-  for css in litConfig.extraCss do
-    let name := (⟨css⟩ : System.FilePath).fileName.getD css
-    IO.FS.writeFile (config.outputDir / name) (← IO.FS.readFile css)
-  -- Copy extra JS files to output directory
-  for js in litConfig.extraJs do
-    let name := (⟨js⟩ : System.FilePath).fileName.getD js
-    IO.FS.writeFile (config.outputDir / name) (← IO.FS.readFile js)
-  -- Copy favicon to output directory
-  if let some favicon := litConfig.metadata.favicon then
-    let name := (⟨favicon⟩ : System.FilePath).fileName.getD favicon
-    IO.FS.writeFile (config.outputDir / name) (← IO.FS.readFile favicon)
+    -- Copy extra CSS files to output directory
+    for css in litConfig.extraCss do
+      let name := (⟨css⟩ : System.FilePath).fileName.getD css
+      IO.FS.writeFile (config.outputDir / name) (← IO.FS.readFile css)
+    -- Copy extra JS files to output directory
+    for js in litConfig.extraJs do
+      let name := (⟨js⟩ : System.FilePath).fileName.getD js
+      IO.FS.writeFile (config.outputDir / name) (← IO.FS.readFile js)
+    -- Copy favicon to output directory
+    if let some favicon := litConfig.metadata.favicon then
+      let name := (⟨favicon⟩ : System.FilePath).fileName.getD favicon
+      IO.FS.writeFile (config.outputDir / name) (← IO.FS.readFile favicon)
 
-  -- Apply nav tree transformations (exclude, then order)
-  let dir := dir.applyExcludes litConfig.exclude
-  let dir := dir.applyOrder litConfig.order litConfig.orderChildren
+    -- Apply nav tree transformations (exclude, then order)
+    let dir := dir.applyExcludes litConfig.exclude
+    let dir := dir.applyOrder litConfig.order litConfig.orderChildren
 
-  -- Validate: declarations in show_docstrings_for / hide_docstrings_for must exist
-  if !litConfig.showDocstringsFor.isEmpty || !litConfig.hideDocstringsFor.isEmpty then
-    let declNames := collectDeclNames dir
-    for d in litConfig.showDocstringsFor do
-      unless declNames.contains d do
-        errorCount.modify (· + 1)
-        IO.eprintln s!"Error: declaration '{d}' in show_docstrings_for does not exist"
-    for d in litConfig.hideDocstringsFor do
-      unless declNames.contains d do
-        errorCount.modify (· + 1)
-        IO.eprintln s!"Error: declaration '{d}' in hide_docstrings_for does not exist"
+    -- Validate: declarations in show_docstrings_for / hide_docstrings_for must exist
+    if !litConfig.showDocstringsFor.isEmpty || !litConfig.hideDocstringsFor.isEmpty then
+      let declNames := collectDeclNames dir
+      for d in litConfig.showDocstringsFor do
+        unless declNames.contains d do
+          logger.reportError s!"declaration '{d}' in show_docstrings_for does not exist"
+      for d in litConfig.hideDocstringsFor do
+        unless declNames.contains d do
+          logger.reportError s!"declaration '{d}' in hide_docstrings_for does not exist"
 
-  let (dir, traverseState) ← traverse dir
-  let ctx := {
-    logError msg := errorCount.modify (· + 1) *> IO.eprintln msg
-    definitionIds := traverseState.definitionIds
-    linkTargets := traverseState.linkTargets
-    moduleIds := traverseState.moduleIds
-    traverseState
-    litConfig
-  }
-  let ((), st) ← emitDir config.outputDir dir srcDirs |>.run ctx |>.run {}
+    let (dir, traverseState) ← traverse dir
+    let ctx := {
+      definitionIds := traverseState.definitionIds
+      linkTargets := traverseState.linkTargets
+      moduleIds := traverseState.moduleIds
+      traverseState
+      litConfig
+    }
+    let ((), st) ← emitDir config.outputDir dir srcDirs |>.run ctx |>.run {} |>.run logger
 
-  -- Landing page: use configured module or auto-generated ToC
-  let st ← match litConfig.landingPage with
-    | some landingModName =>
-      emitLandingFromModule config.outputDir dir landingModName ctx st srcDirs
-    | none =>
-      emitLandingPage config.outputDir dir litConfig
-      pure st
+    -- Landing page: use configured module or auto-generated ToC
+    let st ← match litConfig.landingPage with
+      | some landingModName =>
+        emitLandingFromModule config.outputDir dir landingModName ctx logger st srcDirs
+      | none =>
+        emitLandingPage config.outputDir dir litConfig
+        pure st
 
-  emitIndex {} traverseState dir (config.outputDir / "-verso-search") ctx.logError
-  emitSearchResultsPage config.outputDir litConfig
-  let domainData : Verso.NameMap Verso.Multi.Domain := ({} : Verso.NameMap _)
-    |>.insert constDomainName traverseState.constantDefDomain
-    |>.insert moduleDomainName traverseState.moduleDomain
-  IO.FS.writeFile (config.outputDir / "xref.json") <| Json.compress <| Verso.Multi.xrefJson domainData traverseState.allLinks
-  IO.FS.writeFile (config.outputDir / "-verso-docs.json") st.hlState.dedup.docJson.compress
-  let count ← errorCount.get
-  if count > 0 then
-    IO.eprintln s!"{count} errors occurred"
-    return 1
-  else return 0
+    emitIndex {} traverseState dir (config.outputDir / "-verso-search") logger
+    emitSearchResultsPage config.outputDir litConfig
+    let domainData : Verso.NameMap Verso.Multi.Domain := ({} : Verso.NameMap _)
+      |>.insert constDomainName traverseState.constantDefDomain
+      |>.insert moduleDomainName traverseState.moduleDomain
+    IO.FS.writeFile (config.outputDir / "xref.json") <| Json.compress <| Verso.Multi.xrefJson domainData traverseState.allLinks
+    IO.FS.writeFile (config.outputDir / "-verso-docs.json") st.hlState.dedup.docJson.compress
+
 where
   copyButtonJs : String :=
     include_str "../../static-web/literate/copy-button.js"

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -59,6 +59,7 @@ open Verso.Genre.Manual.WordCount
 open Verso.Code (LinkTargets)
 open Verso.Code.Hover (Dedup State)
 open Verso.ArgParse
+open Verso (Logger Severity withLogger BuildLogT)
 
 namespace Verso.Genre
 
@@ -82,7 +83,7 @@ inline_extension Inline.ref (canonicalName : String) (domain : Option Name) (rem
   traverse := fun _ info content => do
     match FromJson.fromJson? (α := RefInfo) info with
     | .error e =>
-      logError e; pure none
+      reportError e; pure none
     | .ok { canonicalName := name, domain, remote := none, resolvedDestination := none } =>
       let domain := domain.getD sectionDomain
       match (← get).resolveDomainObject domain name with
@@ -99,11 +100,11 @@ inline_extension Inline.ref (canonicalName : String) (domain : Option Name) (rem
     some <| fun go _ info content => do
       match FromJson.fromJson? (α := RefInfo) info with
       | .error e =>
-        TeX.logError e; content.mapM go
+        reportError e; content.mapM go
       | .ok { canonicalName := name, domain, remote := none, resolvedDestination := none } =>
-        TeX.logError ("No destination found for tag '" ++ name ++ "' in " ++ toString domain); content.mapM go
+        reportError ("No destination found for tag '" ++ name ++ "' in " ++ toString domain); content.mapM go
       | .ok { canonicalName := name, domain, remote := some remote, resolvedDestination := none } =>
-        TeX.logError ("No destination found for remote '" ++ remote ++ "' tag '" ++ name ++ "' in " ++ toString domain); content.mapM go
+        reportError ("No destination found for remote '" ++ remote ++ "' tag '" ++ name ++ "' in " ++ toString domain); content.mapM go
       | .ok {resolvedDestination := some dest, remote, ..} =>
         if remote.isSome then
           -- Inter-document links should be URLs
@@ -118,9 +119,9 @@ inline_extension Inline.ref (canonicalName : String) (domain : Option Name) (rem
     some <| fun go _ info content => do
       match FromJson.fromJson? (α := RefInfo) info with
       | .error e =>
-        Html.HtmlT.logError e; content.mapM go
+        reportError e; content.mapM go
       | .ok { canonicalName := name, domain, remote := none, resolvedDestination := none } =>
-        Html.HtmlT.logError ("No destination found for tag '" ++ name ++ "' in " ++ toString domain); content.mapM go
+        reportError ("No destination found for tag '" ++ name ++ "' in " ++ toString domain); content.mapM go
       | .ok { canonicalName := name, domain, remote := some remote, resolvedDestination := _ } =>
         let domain := domain |>.getD sectionDomain
         let remoteData ← readThe AllRemotes
@@ -133,10 +134,10 @@ inline_extension Inline.ref (canonicalName : String) (domain : Option Name) (rem
                 return {{<a href={{dest}} data-verso-remote={{remote}}>{{← content.mapM go}}</a>}}
               else
                 let dests := objs.map (s!" * {·.link.link}") |>.toList |> "\n".intercalate
-                Html.HtmlT.logError s!"Remote '{remote}' domain '{domain}' contains multiple destinations for '{name}':\n{dests}"
-            else Html.HtmlT.logError s!"Remote '{remote}' contains domain '{domain}, but it not item '{name}'"
-          else Html.HtmlT.logError s!"Remote '{remote}' does not contain domain '{domain}' (looking up '{name}')"
-        else Html.HtmlT.logError s!"Remote '{remote}' not found for tag '{name}' in domain '{domain}'"
+                reportError s!"Remote '{remote}' domain '{domain}' contains multiple destinations for '{name}':\n{dests}"
+            else reportError s!"Remote '{remote}' contains domain '{domain}, but it not item '{name}'"
+          else reportError s!"Remote '{remote}' does not contain domain '{domain}' (looking up '{name}')"
+        else reportError s!"Remote '{remote}' not found for tag '{name}' in domain '{domain}'"
         -- If any error was logged, just don't emit a link
         content.mapM go
       | .ok {resolvedDestination := some dest, ..} =>
@@ -312,8 +313,13 @@ def TraverseState.ofConfig (config : HtmlConfig) : TraverseState := Id.run do
       st := st.addLicenseInfo li
   return st
 
-def traverse (logError : String → IO Unit) (text : Part Manual) (config : Config) : ReaderT ExtensionImpls IO (Part Manual × TraverseState) := do
-  let topCtxt : Manual.TraverseContext := {logError, draft := config.draft}
+/--
+The monad in which manuals are converted to an output format.
+-/
+abbrev EmitM : Type → Type := ReaderT ExtensionImpls (BuildLogT IO)
+
+def traverse (text : Part Manual) (config : Config) : EmitM (Part Manual × TraverseState) := do
+  let topCtxt : Manual.TraverseContext := { draft := config.draft }
   let mut state : Manual.TraverseState := .ofConfig config.toHtmlConfig
   let mut text := text
   if !config.draft then
@@ -366,25 +372,22 @@ where
   isUnnumbered (p : Part Manual) : Bool := p.metadata.map (·.number) |>.isEqSome false
 
 open IO.FS in
-def emitTeX (logError : String → IO Unit) (config : Config) (text : Part Manual) : ReaderT ExtensionImpls IO Unit := do
-  let (text, state) ← traverse logError text config
-  let opts : TeX.Options Manual (ReaderT ExtensionImpls IO) := {
+def emitTeX (config : Config) (text : Part Manual) : EmitM Unit := do
+  let (text, state) ← traverse text config
+  let opts : TeX.Options Manual := {
     headerLevels := #["chapter", "section", "subsection", "subsubsection", "paragraph"],
-    headerLevel := some ⟨0, by simp +arith [Array.size, List.length]⟩,
-    logError := fun msg => logError msg
+    headerLevel := some ⟨0, by grind⟩
   }
   let authors := text.metadata.map (·.authors) |>.getD []
   let date := text.metadata.bind (·.date) |>.getD ""
-  let ctxt := {logError}
-  let texCtxt := {}
   let { frontMatter := (frontText, frontParts), mainMatter, backMatter } := DividedDoc.ofPart text
-  let (frontMatter, extra) := (← frontText.mapM (·.toTeX (opts, ctxt, state, texCtxt)) {})
+  let (frontMatter, extra) ← frontText.mapM (·.toTeX (m := EmitM) (opts, {}, state, {})) {}
   -- Passing `none` as the label is fine here because traversal has assigned labels already so
   -- there's no need for a fallback.
-  let (frontParts, extra) ← frontParts.mapM (·.toTeX none (opts, ctxt, state, texCtxt)) extra
+  let (frontParts, extra) ← frontParts.mapM (·.toTeX (m := EmitM) none (opts, {}, state, {})) extra
   let frontMatter := frontMatter ++ frontParts
-  let (chapters, extra) ← mainMatter.mapM (·.toTeX none (opts, ctxt, state, texCtxt)) extra
-  let (appendices, extra) ← backMatter.mapM (·.toTeX none (opts, ctxt, state, texCtxt)) extra
+  let (chapters, extra) ← mainMatter.mapM (·.toTeX (m := EmitM) none (opts, {}, state, {})) extra
+  let (appendices, extra) ← backMatter.mapM (·.toTeX (m := EmitM) none (opts, {}, state, {})) extra
   let dir := config.destination.join "tex"
   ensureDir dir
   let packages := state.texPackages
@@ -409,17 +412,15 @@ def emitTeX (logError : String → IO Unit) (config : Config) (text : Part Manua
         h.putStrLn a.asString
     h.putStrLn postamble
   for (src, dest) in config.extraFiles do
-    copyRecursively logError src (dir.join dest)
+    copyRecursively src (dir.join dest)
   for (src, dest) in config.extraFilesTeX do
-    copyRecursively logError src (dir.join dest)
+    copyRecursively src (dir.join dest)
   for (f, content) in extra.extraFiles do
     IO.FS.writeFile (dir / f) content
 
 open Verso.Output (Html)
 
-instance : Inhabited (StateT (State Html) (ReaderT ExtensionImpls IO) Html.Toc) where
-  default := fun _ => default
-
+instance [Monad m] : Inhabited (StateT (State Html) m Html.Toc) := ⟨pure default⟩
 
 /--
 Generate a ToC structure for a document.
@@ -428,14 +429,14 @@ Here, `depth` is the current depth at which pages no longer receive their own HT
 depth of the table of contents in the document (which is controlled by a parameter to `Toc.html`).
 -/
 partial def toc [Monad m] [Html.ToHtml Manual m (Doc.Inline Manual)] [MonadLiftT IO m]
-    (depth : Nat) (opts : Html.Options IO)
+    (depth : Nat) (opts : Html.Options)
     (ctxt : TraverseContext)
     (state : TraverseState)
     (definitionIds : Lean.NameMap String)
     (linkTargets : LinkTargets Manual.TraverseContext) :
     Part Manual → StateT (State Html) m Html.Toc
   | .mk title sTitle «meta» _ sub => do
-    let titleHtml ← Html.seq <$> title.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {} ·)
+    let titleHtml ← Html.seq <$> title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets {} ·)
 
     let some {id := some id, ..} := «meta»
       | (throw <| .userError s!"No ID for {sTitle} - {repr «meta»}" : IO _)
@@ -579,7 +580,8 @@ def emitSearchResultsHtml
 section
 open Search
 
-def emitSearchIndex (dir : System.FilePath) (state : TraverseState) (ctx : TraverseContext) (logError : String → IO Unit) (doc : Part Manual) : IO Unit := do
+def emitSearchIndex [Monad m] [MonadLiftT IO m] [MonadBuildLog m]
+    (dir : System.FilePath) (state : TraverseState) (ctx : TraverseContext) (doc : Part Manual) : m Unit := do
   have : Indexable Manual := {
     partHeader p := do
       let ctxt ← IndexM.traverseContext
@@ -604,7 +606,7 @@ def emitSearchIndex (dir : System.FilePath) (state : TraverseState) (ctx : Trave
   }
 
   match mkIndexAndDocs doc ctx with
-  | .error e => logError e; return ()
+  | .error e => reportError e; return ()
   | .ok (index, indexDocs) =>
     -- `context` (the breadcrumb text) is no longer an indexed field — it's
     -- display-only and its boost was 0.1, so indexing it nearly duplicated
@@ -682,10 +684,9 @@ def emitSearchBox
 end
 
 def wordCount
-    (wcPath : System.FilePath)
-    (logError : String → IO Unit) (config : Config)
-    (text : Part Manual) : ReaderT ExtensionImpls IO Unit := do
-  let (text, _) ← traverse logError text config
+    (wcPath : System.FilePath) (config : Config)
+    (text : Part Manual) : EmitM Unit := do
+  let (text, _) ← traverse text config
   IO.FS.writeFile wcPath (wordCountReport skip "" 2 text |>.snd)
 where
   -- Skip included docstrings for word count purposes
@@ -694,9 +695,9 @@ where
 /--
 Resolves cross-references in a manner suitable for single-page HTML output.
 -/
-def traverseHtmlSingle (logError : String → IO Unit) (config : RenderConfig)
-    (text : Part Manual) : ReaderT ExtensionImpls IO (Part Manual × TraverseState) := do
-  traverse logError text {config with htmlDepth := 0}
+def traverseHtmlSingle (config : RenderConfig)
+    (text : Part Manual) : EmitM (Part Manual × TraverseState) := do
+  traverse text { config with htmlDepth := 0 }
 
 /--
 Emits single-page HTML for the document.
@@ -704,27 +705,27 @@ Emits single-page HTML for the document.
 The provided `text` and `state` parameters should be the result of running `traverseHtmlSingle`.
 -/
 def emitHtmlSingle
-    (logError : String → IO Unit) (config : RenderConfig)
-    (text : Part Manual) (state : TraverseState) : ReaderT ExtensionImpls IO Unit := do
+    (config : RenderConfig)
+    (text : Part Manual) (state : TraverseState) : EmitM Unit := do
   let dir := config.destination.join "html-single"
   ensureDir dir
   let remoteContent ← updateRemotes false config.remoteConfigFile (if config.verbose then IO.println else fun _ => pure ())
-  let ((), htmlState) ← emitContent dir .empty remoteContent
+  let ((), htmlState) ← emitContent dir |>.run .empty |>.run remoteContent
   IO.FS.writeFile (dir.join "-verso-docs.json") (toString htmlState.dedup.docJson)
   if .search ∈ config.features then
     emitSearchBox (dir / "-verso-search") state.quickJump config.searchPriorities (searchPagePath := some "search/")
-    emitSearchIndex (dir / "-verso-search") state {logError, draft := config.draft} logError text
+    emitSearchIndex (dir / "-verso-search") state { draft := config.draft } text
 where
-  emitContent (dir : System.FilePath) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls IO)) Unit := do
+  emitContent (dir : System.FilePath) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) Unit := do
     let authors := text.metadata.map (·.authors) |>.getD []
     let authorshipNote := text.metadata.bind (·.authorshipNote)
     let _date := text.metadata.bind (·.date) |>.getD "" -- TODO
-    let opts : Html.Options IO := {logError := fun msg => logError msg}
-    let ctxt := {logError}
+    let opts : Html.Options := { }
+    let ctxt : Manual.TraverseContext := {}
     let definitionIds := state.definitionIds ctxt
-    let linkTargets := config.linkTargets state (← read)
-    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {})
-    let introHtml ← Html.seq <$> text.content.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {})
+    let linkTargets := config.linkTargets state (← readThe AllRemotes)
+    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets {})
+    let introHtml ← Html.seq <$> text.content.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets {})
     let bookToc ← text.subParts.mapM (fun p => toc 0 opts (ctxt.inPart p) state definitionIds linkTargets p)
     let bookTocHtml := open Verso.Output.Html in
       if bookToc.size > 0 then {{
@@ -736,7 +737,7 @@ where
     let contents ←
       Html.seq <$>
       text.subParts.mapM fun p =>
-        Manual.toHtml {opts.lift with headerLevel := 2} (ctxt.inPart p) state definitionIds linkTargets {} p
+        Manual.toHtml { opts with headerLevel := 2 } (ctxt.inPart p) state definitionIds linkTargets {} p
     let pageContent := open Verso.Output.Html in
       {{<section>
           {{Html.titlePage titleHtml authors authorshipNote introHtml}}
@@ -745,8 +746,8 @@ where
         </section>}}
     let toc := (← text.subParts.mapM (toc 0 opts ctxt state definitionIds linkTargets)).toList
     let thisPageToc : Array Html ← do
-      let (errs, items) ← localContents opts.lift ctxt state text
-      for e in errs do logError e
+      let (errs, items) ← localContents opts ctxt state text
+      for e in errs do reportError e
       pure <| items.map (·.toHtml)
     let titleToShow : Html :=
       open Verso.Output.Html in
@@ -762,9 +763,9 @@ where
     IO.FS.withFile (dir.join "book.css") .write fun h => do
       h.putStrLn Html.Css.pageStyle
     for (src, dest) in config.extraFiles do
-      copyRecursively logError src (dir.join dest)
+      copyRecursively src (dir.join dest)
     for (src, dest) in config.extraFilesHtml do
-      copyRecursively logError src (dir.join dest)
+      copyRecursively src (dir.join dest)
     for f in state.extraJsFiles do
       ensureDir (dir.join "-verso-data")
       (dir / "-verso-data" / f.filename).parent |>.forM fun d => ensureDir d
@@ -784,9 +785,9 @@ where
 /--
 Resolves cross-references in a manner suitable for multi-page HTML output.
 -/
-def traverseHtmlMulti (logError : String → IO Unit) (config : RenderConfig)
-    (text : Part Manual) : ReaderT ExtensionImpls IO (Part Manual × TraverseState) := do
-  traverse logError text config.toConfig
+def traverseHtmlMulti (config : RenderConfig)
+    (text : Part Manual) : EmitM (Part Manual × TraverseState) := do
+  traverse text config.toConfig
 
 open Verso.Output.Html in
 /--
@@ -794,32 +795,32 @@ Emits multi-page HTML for the document.
 
 The provided `text` and `state` parameters should be the result of running `traverseHtmlSingle`.
 -/
-def emitHtmlMulti (logError : String → IO Unit) (config : RenderConfig)
-    (text : Part Manual) (state : TraverseState) : ReaderT ExtensionImpls IO Unit := do
+def emitHtmlMulti (config : RenderConfig)
+    (text : Part Manual) (state : TraverseState) : EmitM Unit := do
   let remoteContent ← updateRemotes false config.remoteConfigFile (if config.verbose then IO.println else fun _ => pure ())
   let root := config.destination.join "html-multi"
   ensureDir root
-  let ((), htmlState) ← emitContent root {} remoteContent
+  let ((), htmlState) ← emitContent root |>.run .empty |>.run remoteContent
   IO.FS.writeFile (root.join "-verso-docs.json") (toString htmlState.dedup.docJson)
   if .search ∈ config.features then
     emitSearchBox (root / "-verso-search") state.quickJump config.searchPriorities (searchPagePath := some "search/")
-    emitSearchIndex (root / "-verso-search") state {logError, draft := config.draft} logError text
+    emitSearchIndex (root / "-verso-search") state { draft := config.draft } text
 where
   /--
   Emits the data used by all pages in the site, such as JS and CSS, and then emits the root page
   (and thus its children).
   -/
-  emitContent (root : System.FilePath) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls IO)) Unit := do
+  emitContent (root : System.FilePath) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) Unit := do
     let authors := text.metadata.map (·.authors) |>.getD []
     let authorshipNote := text.metadata >>= (·.authorshipNote)
     let _date := text.metadata.bind (·.date) |>.getD "" -- TODO
-    let opts : Html.Options IO := {logError := fun msg => logError msg}
-    let ctxt := {logError}
+    let opts : Html.Options := { }
+    let ctxt : Manual.TraverseContext := {}
     let definitionIds := state.definitionIds ctxt
-    let linkTargets := config.linkTargets state (← read)
+    let linkTargets := config.linkTargets state (← readThe AllRemotes)
     let toc ← text.subParts.toList.mapM fun p =>
       toc config.htmlDepth opts (ctxt.inPart p) state definitionIds linkTargets p
-    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets {} ·)
+    let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets {} ·)
     let titleToShow : Html :=
       open Verso.Output.Html in
       if let some alt := text.metadata.bind (·.shortTitle) then
@@ -830,12 +831,12 @@ where
     IO.FS.withFile (root / "book.css") .write fun h => do
       h.putStrLn Html.Css.pageStyle
     for (src, dest) in config.extraFiles do
-      copyRecursively logError src (root.join dest)
+      copyRecursively src (root.join dest)
     for (src, dest) in config.extraFilesHtml do
-      copyRecursively logError src (root.join dest)
+      copyRecursively src (root.join dest)
     state.writeFiles (root / "-verso-data")
 
-    emitPart titleToShow authors authorshipNote toc opts.lift ctxt state definitionIds linkTargets {} true config.htmlDepth root text
+    emitPart titleToShow authors authorshipNote toc opts ctxt state definitionIds linkTargets {} true config.htmlDepth root text
     let xrefJson ← IO.FS.readFile (root / "xref.json")
     emitFindHtml toc root state xrefJson config.toConfig
     if .search ∈ config.features then
@@ -846,26 +847,26 @@ where
   -/
   emitPart (bookTitle : Html) (authors : List String) (authorshipNote : Option String) (bookContents)
       (opts ctxt state definitionIds linkTargets codeOptions)
-      (root : Bool) (depth : Nat) (dir : System.FilePath) (part : Part Manual) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls IO)) Unit := do
+      (root : Bool) (depth : Nat) (dir : System.FilePath) (part : Part Manual) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) Unit := do
     let thisFile := part.metadata.bind (·.file) |>.getD (part.titleString.sluggify.toString)
     let dir := if root then dir else dir.join thisFile
     let sectionNum := sectionHtml ctxt
-    let pageTitleHtml := sectionNum ++ (← Html.seq <$> part.title.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets codeOptions))
+    let pageTitleHtml := sectionNum ++ (← Html.seq <$> part.title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets codeOptions))
     let titleHtml :=
       pageTitleHtml ++
       if let some id := part.metadata.bind (·.id) then
         permalink id state
       else .empty
-    let introHtml ← Html.seq <$> part.content.mapM (Manual.toHtml opts.lift ctxt state definitionIds linkTargets codeOptions)
+    let introHtml ← Html.seq <$> part.content.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets codeOptions)
     let contents ←
       if depth == 0 || part.htmlSplit == .never then
-        Html.seq <$> part.subParts.mapM (fun p => Manual.toHtml {opts.lift with headerLevel := 2} (ctxt.inPart p) state definitionIds linkTargets codeOptions p)
+        Html.seq <$> part.subParts.mapM (fun p => Manual.toHtml {opts with headerLevel := 2} (ctxt.inPart p) state definitionIds linkTargets codeOptions p)
       else pure .empty
 
     let includeSubparts := if (depth == 0 || part.htmlSplit == .never) then .all else .depth 0
     let thisPageToc : Array LocalContentItem ← do
-      let (errs, items) ← localContents opts.lift ctxt state (includeTitle := false) (includeSubparts := includeSubparts) part
-      for e in errs do logError e
+      let (errs, items) ← localContents opts ctxt state (includeTitle := false) (includeSubparts := includeSubparts) part
+      for e in errs do reportError e
       pure items
 
     -- If there's no elements, then get rid of the contents entirely. This causes the ToC generation code in the HTML to fall back to the ordinary collapsible ones.
@@ -928,16 +929,15 @@ inductive Mode where | single | multi
 /--
 Extra steps to be performed after building the manual.
 
-`ExtraStep` is short for `Mode → (String → IO Unit) → Config → TraverseState → Part Manual → IO Unit`.
+`ExtraStep` is short for `Mode → Config → TraverseState → Part Manual → BuildLogT IO Unit`.
 
 The parameters are:
  * A mode, which is whether the HTML was generated in one or multiple files
- * An error logger
  * The configuration, as determined from the initial value passed to `manualMain` and modified via the command line
  * The final state of the traversal pass
  * The final text, post-traversal
 -/
-abbrev ExtraStep := Mode → (String → IO Unit) → Config → TraverseState → Part Manual → IO Unit
+abbrev ExtraStep := Mode → Config → TraverseState → Part Manual → BuildLogT IO Unit
 
 
 open Verso.CLI
@@ -951,7 +951,7 @@ def manualMain (text : Part Manual)
 
 where
 
-  opts (cfg : RenderConfig) : List String → ReaderT ExtensionImpls IO RenderConfig
+  opts (cfg : RenderConfig) : List String → IO RenderConfig
     | ("--output"::dir::more) => opts { cfg with destination := dir } more
     | ("--depth"::n::more) => opts { cfg with htmlDepth := n.toNat! } more
 
@@ -998,34 +998,27 @@ where
   fixBase (base : String) : String :=
     if base.endsWith "/" then base else base ++ "/"
 
-  go : ReaderT ExtensionImpls IO UInt32 := do
-    let errorCount : IO.Ref Nat ← IO.mkRef 0
-    let logError msg := do errorCount.modify (· + 1); IO.eprintln msg
+  go (extensionImpls : ExtensionImpls) : IO UInt32 := do
     let cfg ← opts config options
+    runWithLogger <| flip ReaderT.run extensionImpls do
+      if cfg.emitTeX then
+        if cfg.verbose then
+          IO.println s!"Saving TeX"
+        emitTeX cfg.toConfig text
 
-    if cfg.emitTeX then
-      if cfg.verbose then
-        IO.println s!"Saving TeX"
-      emitTeX logError cfg.toConfig text
+      emitHtml cfg.emitHtmlSingle .single cfg text traverseHtmlSingle emitHtmlSingle
+      emitHtml cfg.emitHtmlMulti .multi cfg text traverseHtmlMulti emitHtmlMulti
 
-    emitHtml cfg.emitHtmlSingle .single logError cfg text traverseHtmlSingle emitHtmlSingle
-    emitHtml cfg.emitHtmlMulti .multi logError cfg text traverseHtmlMulti emitHtmlMulti
-
-    if let some wcFile := cfg.wordCount then
-      if cfg.verbose then
-        IO.println s!"Saving word counts to {wcFile}"
-      wordCount wcFile logError cfg.toConfig text
-
-    match ← errorCount.get with
-    | 0 => return 0
-    | 1 => IO.eprintln "An error was encountered!"; return 1
-    | n => IO.eprintln s!"{n} errors were encountered!"; return 1
+      if let some wcFile := cfg.wordCount then
+        if cfg.verbose then
+          IO.println s!"Saving word counts to {wcFile}"
+        wordCount wcFile cfg.toConfig text
 
   emitHtml
-      (how : EmitHtml) (mode : Mode) (logError : String → IO Unit) (cfg : RenderConfig) (text : Part Manual)
-      (traverse : (String → IO Unit) → RenderConfig → Part Manual → ReaderT ExtensionImpls IO (Part Manual × TraverseState))
-      (emit : (String → IO Unit) → RenderConfig → Part Manual → TraverseState → ReaderT ExtensionImpls IO Unit) :
-      ReaderT ExtensionImpls IO Unit := do
+      (how : EmitHtml) (mode : Mode) (cfg : RenderConfig) (text : Part Manual)
+      (traverse : RenderConfig → Part Manual → EmitM (Part Manual × TraverseState))
+      (emit : RenderConfig → Part Manual → TraverseState → EmitM Unit) :
+      EmitM Unit := do
     let outDir :=
       match mode with | .single => "html-single" | .multi => "html-multi"
     match how with
@@ -1033,17 +1026,17 @@ where
     | .immediately =>
       if cfg.verbose then
         IO.println s!"Saving {match mode with | .single => "single" | .multi => "multi"}-page HTML"
-      let (text', traverseState) ← traverse logError cfg text
+      let (text', traverseState) ← traverse cfg text
       emitXrefsJson (cfg.destination / outDir) traverseState
-      emit logError cfg text' traverseState
+      emit cfg text' traverseState
       for step in extraSteps do
-        step mode logError cfg.toConfig traverseState text'
+        step mode cfg.toConfig traverseState text'
     | .delay f =>
-      let (text', traverseState) ← traverse logError cfg text
+      let (text', traverseState) ← traverse cfg text
       emitXrefsJson (cfg.destination / outDir) traverseState
       SavedState.mk text' traverseState |>.save f
     | .resumeFrom f =>
       let {text, traverseState} ← SavedState.load f
-      emit logError cfg text traverseState
+      emit cfg text traverseState
       for step in extraSteps do
-        step .single logError cfg.toConfig traverseState text
+        step .single cfg.toConfig traverseState text

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -645,14 +645,12 @@ structure TraverseContext where
   blockContext : Array BlockContext := #[]
   /-- Whether the current build is a draft (used for hiding TODOs, etc from public builds) -/
   draft : Bool := false
-  logError : String → IO Unit
-
 def TraverseContext.inFile (self : TraverseContext) (file : String) : TraverseContext :=
   {self with path := self.path.push file}
 
 abbrev BlockTraversal genre :=
   InternalId → Json → Array (Doc.Block genre) →
-  ReaderT TraverseContext (StateT TraverseState IO) (Option (Doc.Block genre))
+  ReaderT TraverseContext (StateT TraverseState (BuildLogT IO)) (Option (Doc.Block genre))
 
 abbrev BlockToHtml (genre : Genre) (m) :=
   (Doc.Inline genre → Html.HtmlT genre m Output.Html) →
@@ -666,7 +664,7 @@ abbrev BlockToTeX (genre : Genre) (m) :=
 
 abbrev InlineTraversal genre :=
   InternalId → Json → Array (Doc.Inline genre) →
-  ReaderT TraverseContext (StateT TraverseState IO) (Option (Doc.Inline genre))
+  ReaderT TraverseContext (StateT TraverseState (BuildLogT IO)) (Option (Doc.Inline genre))
 
 abbrev InlineToHtml (genre : Genre) (m) :=
   (Doc.Inline genre → Html.HtmlT genre m Output.Html) →
@@ -761,7 +759,7 @@ structure InlineDescr extends HtmlAssets where
   /--
   How to generate HTML. If {name}`none`, generating HTML from a document that contains this inline will fail.
   -/
-  toHtml : Option (InlineToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls IO)))
+  toHtml : Option (InlineToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))))
 
   /--
   Should this inline be an entry in the page-local ToC? If so, how should it be represented?
@@ -780,7 +778,7 @@ structure InlineDescr extends HtmlAssets where
   How to generate TeX. If {name}`none`, generating TeX from a document that contains this inline
   will fail.
   -/
-  toTeX : Option (InlineToTeX Manual (ReaderT ExtensionImpls IO))
+  toTeX : Option (InlineToTeX Manual (ReaderT ExtensionImpls (BuildLogT IO)))
   /-- Required TeX `\usepackage` lines -/
   usePackages : List String := {}
   /-- Required items in the TeX preamble -/
@@ -804,7 +802,7 @@ structure BlockDescr extends HtmlAssets where
   How to generate HTML. If {name}`none`, generating HTML from a document that contains this block
   will fail.
   -/
-  toHtml : Option (BlockToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls IO)))
+  toHtml : Option (BlockToHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))))
 
   /--
   Should this block be an entry in the page-local ToC? If so, how should it be represented?
@@ -824,7 +822,7 @@ structure BlockDescr extends HtmlAssets where
   How to generate TeX. If {name}`none`, generating TeX from a document that contains this block
   will fail.
   -/
-  toTeX : Option (BlockToTeX Manual (ReaderT ExtensionImpls IO))
+  toTeX : Option (BlockToTeX Manual (ReaderT ExtensionImpls (BuildLogT IO)))
   /-- Required TeX `\usepackage` lines -/
   usePackages : List String := {}
   /-- Required items in the TeX preamble -/
@@ -1013,13 +1011,13 @@ def ExtensionImpls.fromLists (inlineImpls : List (Name × InlineDescr)) (blockIm
 open Lean Elab Term in
 elab "extension_impls%" : term => do elabTerm (← ``(ExtensionImpls.fromLists inline_extensions% block_extensions%)) none
 
-abbrev TraverseM := ReaderT ExtensionImpls (ReaderT Manual.TraverseContext (StateT Manual.TraverseState IO))
+abbrev TraverseM := ReaderT ExtensionImpls (ReaderT Manual.TraverseContext (StateT Manual.TraverseState (BuildLogT IO)))
 
 def TraverseM.run
     (impls : ExtensionImpls)
     (ctxt : Manual.TraverseContext)
     (state : Manual.TraverseState)
-    (act : TraverseM α) : IO (α × Manual.TraverseState) :=
+    (act : TraverseM α) : BuildLogT IO (α × Manual.TraverseState) :=
   act impls ctxt state
 
 instance : MonadReader Manual.TraverseContext TraverseM where
@@ -1028,8 +1026,9 @@ instance : MonadReader Manual.TraverseContext TraverseM where
 instance : MonadWithReader Manual.TraverseContext TraverseM where
   withReader := withTheReader Manual.TraverseContext
 
-def logError [Monad m] [MonadLiftT IO m] [MonadReaderOf Manual.TraverseContext m] (err : String) : m Unit := do
-  (← readThe Manual.TraverseContext).logError err
+@[deprecated "Use `Verso.reportError` instead." (since := "2026-05-29")]
+def logError [MonadBuildLog m] (err : String) : m Unit :=
+  Verso.reportError err
 
 def isDraft [Functor m] [MonadReaderOf Manual.TraverseContext m] : m Bool :=
   (·.draft) <$> (readThe Manual.TraverseContext)
@@ -1395,7 +1394,7 @@ def tagPart
     (saveXref : Slug → InternalId → Lean.Doc.Part Manual.Inline Manual.Block m → TraverseM Unit) :
     TraverseM Tag := do
   let some id := getId metadata
-    | logError "No internal ID assigned while tagging part"; return default
+    | reportError "No internal ID assigned while tagging part"; return default
   match getTag metadata with
   | none =>
     -- Assign an internal tag - the next round will make it external. This is done in two rounds to
@@ -1407,7 +1406,7 @@ def tagPart
     -- Ensure uniqueness
     if let some id' := (← get).tags[t]? then
       if id != id' then
-        logError s!"Duplicate tag '{t}'"
+        reportError s!"Duplicate tag '{t}'"
     else
       modify fun st => {st with tags := st.tags.insert t id}
     let path := (← readThe TraverseContext).path
@@ -1425,7 +1424,7 @@ def tagPart
       let external := Tag.external slug
 
       let t ← if let some id' := (← get).tags[external]? then
-        if id != id' then logError s!"Duplicate tag '{t}'"
+        if id != id' then reportError s!"Duplicate tag '{t}'"
           pure t
         else
           modify fun st => { st with
@@ -1487,7 +1486,7 @@ instance : Traverse Manual TraverseM where
 
           impl.traverse id data content
         else
-          logError s!"No block traversal implementation found for {name}"
+          reportError s!"No block traversal implementation found for {name}"
           pure none
       else
         -- Assign a fresh ID if there is none. It can then be used on the next traversal pass.
@@ -1505,7 +1504,7 @@ instance : Traverse Manual TraverseM where
 
           impl.traverse id data content
         else
-          logError s!"No inline traversal implementation found for {name}"
+          reportError s!"No inline traversal implementation found for {name}"
           pure none
       else
         -- Assign a fresh ID if there is none. It can then be used on the next traversal pass.
@@ -1513,7 +1512,7 @@ instance : Traverse Manual TraverseM where
         pure <| some <| Inline.other ⟨name, some id, data⟩ content
 
 open Verso.Output.TeX in
-instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
+instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls (BuildLogT IO)) where
   part go metadata txt := do
     let st ← TeX.state
     let label? := do
@@ -1527,7 +1526,7 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getBlock? b.name
       | panic! s!"Unknown block {b.name} while rendering.\n\nKnown blocks: {(← readThe ExtensionImpls).blockDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | TeX.logError s!"Block {b.name} doesn't support TeX"
+      | reportError s!"Block {b.name} doesn't support TeX"
         return .empty
     impl goI goB id b.data content
   inline go i content := do
@@ -1536,7 +1535,7 @@ instance : TeX.GenreTeX Manual (ReaderT ExtensionImpls IO) where
     let some descr := (← readThe ExtensionImpls).getInline? i.name
       | panic! s!"Unknown inline {i.name} while rendering.\n\nKnown inlines: {(← readThe ExtensionImpls).inlineDescrs.toArray |>.map (·.fst) |>.qsort (·.toString < ·.toString)}"
     let some impl := descr.toTeX
-      | TeX.logError s!"Inline {i.name} doesn't support TeX"
+      | reportError s!"Inline {i.name} doesn't support TeX"
         return .empty
     impl go id i.data content
 
@@ -1575,7 +1574,7 @@ def permalink (id : InternalId) (st : TraverseState) (inline : Bool := true) : H
 
 
 open Verso.Output.Html in
-instance : Html.GenreHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls IO)) where
+instance : Html.GenreHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) where
   part go «meta» txt := do
     let st ← Verso.Doc.Html.HtmlT.state
     let attrs := meta.id.map (st.htmlId) |>.getD #[]

--- a/src/verso-manual/VersoManual/Bibliography.lean
+++ b/src/verso-manual/VersoManual/Bibliography.lean
@@ -205,7 +205,7 @@ where
 
 open Verso.Doc.TeX in
 open Verso.Output.TeX in
-def Citable.bibTeX (go : Doc.Inline Genre.Manual → TeXT Manual (ReaderT ExtensionImpls IO) TeX) (c : Citable) : TeXT Manual (ReaderT ExtensionImpls IO) TeX :=   wrap <$> open TeX in do
+def Citable.bibTeX (go : Doc.Inline Genre.Manual → TeXT Manual (ReaderT ExtensionImpls (BuildLogT IO)) TeX) (c : Citable) : TeXT Manual (ReaderT ExtensionImpls (BuildLogT IO)) TeX :=   wrap <$> open TeX in do
   match c with
   | .inProceedings p =>
     let authors ← andListTeX <$> p.authors.mapM go
@@ -288,10 +288,10 @@ where
 
 open Verso.Doc.TeX in
 def Citable.inlineTeX
-    (go : Doc.Inline Genre.Manual → TeXT Manual (ReaderT ExtensionImpls IO) Output.TeX)
+    (go : Doc.Inline Genre.Manual → TeXT Manual (ReaderT ExtensionImpls (BuildLogT IO)) Output.TeX)
     (ps : List Citable)
     (fmt : Style) :
-    TeXT Manual (ReaderT ExtensionImpls IO) TeX := open TeX in do
+    TeXT Manual (ReaderT ExtensionImpls (BuildLogT IO)) TeX := open TeX in do
   match fmt with
   | .textual =>
     let out : Array TeX ← ps.toArray.mapM fun p => do
@@ -357,13 +357,13 @@ inline_extension Inline.cite (citations : List Citable) (style : Style := .paren
   data := ToJson.toJson (ToJson.toJson citations, style)
   traverse _ data _ := do
     match FromJson.fromJson? data with
-    | .error e => logError s!"Failed to deserialize citation: {e}"; return none
+    | .error e => reportError s!"Failed to deserialize citation: {e}"; return none
     | .ok (v : Json × Style) =>
       let cited : Option (Except String (Array Json)) := (← get).get? `Manual.Bibliography
       match cited with
       | .none =>
         modify (·.set `Manual.Bibliography (Json.arr #[v.1]))
-      | .some (.error e) => logError e
+      | .some (.error e) => reportError e
       | .some (.ok citedSet) =>
         if citedSet.binSearchContains v.1 (cmpCite · · == .lt) then pure ()
         else modify (·.set `Manual.Bibliography <| citedSet.binInsert (cmpCite · · == .lt) v.1)
@@ -372,10 +372,10 @@ inline_extension Inline.cite (citations : List Citable) (style : Style := .paren
     open Verso.Output.TeX in
     some <| fun go _ data _content => do -- TODO repurpose "content" for e.g. "page 5"
       match FromJson.fromJson? data with
-      | .error e => TeX.logError s!"Failed to deserialize citation/style: {e}"; return .empty
+      | .error e => reportError s!"Failed to deserialize citation/style: {e}"; return .empty
       | .ok (v : Json × Style) =>
         match FromJson.fromJson? v.1 with
-        | .error e => TeX.logError s!"Failed to deserialize citation: {e}"; return .empty
+        | .error e => reportError s!"Failed to deserialize citation: {e}"; return .empty
         | .ok (v' : List Citable) =>
           Citable.inlineTeX go v' v.2
   extraCss := [Marginalia.css]
@@ -383,10 +383,10 @@ inline_extension Inline.cite (citations : List Citable) (style : Style := .paren
     open Verso.Output.Html in
     some <| fun go _ data _content => do -- TODO repurpose "content" for e.g. "page 5"
       match FromJson.fromJson? data with
-      | .error e => HtmlT.logError s!"Failed to deserialize citation/style: {e}"; return {{""}}
+      | .error e => reportError s!"Failed to deserialize citation/style: {e}"; return {{""}}
       | .ok (v : Json × Style) =>
         match FromJson.fromJson? v.1 with
-        | .error e => HtmlT.logError s!"Failed to deserialize citation: {e}"; return {{""}}
+        | .error e => reportError s!"Failed to deserialize citation: {e}"; return {{""}}
         | .ok (v' : List Citable) =>
           Citable.inlineHtml go v' v.2
 

--- a/src/verso-manual/VersoManual/Diagrams.lean
+++ b/src/verso-manual/VersoManual/Diagrams.lean
@@ -85,7 +85,7 @@ block_extension Block.diagram
     open Verso.Output.Html in
     some <| fun _ _ _ data _ => do
       let .arr #[.str svgStr, .str css, .str _tex, .bool isInline] := data
-        | HtmlT.logError "Expected four-element JSON for diagram" *> pure .empty
+        | reportError "Expected four-element JSON for diagram" *> pure .empty
       let style :=
         ";".intercalate <|
           s!"width: {css}" ::
@@ -99,7 +99,7 @@ block_extension Block.diagram
   toTeX :=
     some <| fun _ _ _ data _ => do
       let .arr #[.str svgStr, .str _css, .str tex, .bool isInline] := data
-        | TeX.logError "Expected four-element JSON for diagram" *> pure .empty
+        | reportError "Expected four-element JSON for diagram" *> pure .empty
       let filename ← modifyGet fun s =>
         let fn := extraFileName s.extraFiles s!"diagram-{svgStr.hash}" "svg" svgStr
         (fn, { s with extraFiles := s.extraFiles.insert fn svgStr })

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -525,13 +525,13 @@ def docstringSection.descr : BlockDescr where
   toTeX := some fun _goI goB _id info contents =>
     open Verso.Output.TeX in do
     let .ok header := FromJson.fromJson? (α := String) info
-      | Verso.Doc.TeX.logError "Failed to deserialize docstring section data while generating TeX"; return .empty
+      | reportError "Failed to deserialize docstring section data while generating TeX"; return .empty
     pure \TeX{\par\noindent\textbf{\Lean{header}}\par " " \Lean{.seq (← contents.mapM goB)}}
   toHtml := some fun _goI goB _id info contents =>
     open Verso.Doc.Html HtmlT in
     open Verso.Output Html in do
       let .ok header := FromJson.fromJson? (α := String) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring section data while generating HTML"; pure .empty
+        | do reportError "Failed to deserialize docstring section data while generating HTML"; pure .empty
       return {{
         <h1>{{header}}</h1>
         {{← contents.mapM goB}}
@@ -543,7 +543,7 @@ def internalSignature.descr : BlockDescr where
   toTeX := some fun _goI goB _id info contents =>
     open Verso.Output.TeX in do
     let .ok (name, signature) := FromJson.fromJson? (α := Highlighted × Option Highlighted) info
-      | Verso.Doc.TeX.logError "Failed to deserialize docstring section data while generating TeX"; return .empty
+      | reportError "Failed to deserialize docstring section data while generating TeX"; return .empty
     let signatureTeX ← do
       if let some sig := signature then
         pure \TeX{ " : " \Lean{ (← sig.toTeX) } }
@@ -553,7 +553,7 @@ def internalSignature.descr : BlockDescr where
     open Verso.Doc.Html HtmlT in
     open Verso.Output Html in do
       let .ok (name, signature) := FromJson.fromJson? (α := Highlighted × Option Highlighted) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring section data while generating HTML"; pure .empty
+        | do reportError "Failed to deserialize docstring section data while generating HTML"; pure .empty
       return {{
         <section class="subdocs">
           <pre class="name-and-type hl lean">
@@ -576,13 +576,13 @@ def inheritance.descr : BlockDescr where
   toTeX := some fun _goI goB _id info contents =>
     open Verso.Output.TeX in do
     let .ok (name, _parents) := FromJson.fromJson? (α := Name × Array Block.Docstring.ParentInfo) info
-      | Verso.Doc.TeX.logError "Failed to deserialize docstring section data while generating TeX"; return .empty
+      | reportError "Failed to deserialize docstring section data while generating TeX"; return .empty
     return \TeX{\Lean{s!"{name}"} \Lean{.seq (← contents.mapM goB)}}
   toHtml := some fun _goI _goB _id info _contents =>
     open Verso.Doc.Html HtmlT in
     open Verso.Output Html in do
       let .ok (name, parents) := FromJson.fromJson? (α := Name × Array Block.Docstring.ParentInfo) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring structure inheritance data while generating HTML"; pure .empty
+        | do reportError "Failed to deserialize docstring structure inheritance data while generating HTML"; pure .empty
       let parentRow ← do
         if parents.isEmpty then pure .empty
         else pure {{
@@ -605,7 +605,7 @@ def fieldSignature.descr : BlockDescr where
   toTeX := some fun _goI goB _id info contents =>
     open Verso.Output.TeX in do
     let .ok (visibility, name, signature, inheritedFrom, parents) := FromJson.fromJson? (α := Visibility × Highlighted × Highlighted × Option Nat × Array Highlighted) info
-      | Verso.Doc.TeX.logError "Failed to deserialize docstring section data while generating TeX"; return .empty
+      | reportError "Failed to deserialize docstring section data while generating TeX"; return .empty
     let visibility : Verso.Output.TeX :=
       match visibility with
       | .public => .empty
@@ -621,7 +621,7 @@ def fieldSignature.descr : BlockDescr where
     open Verso.Doc.Html HtmlT in
     open Verso.Output Html in do
       let .ok (visibility, name, signature, inheritedFrom, parents) := FromJson.fromJson? (α := Visibility × Highlighted × Highlighted × Option Nat × Array Highlighted) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring section data while generating HTML"; pure .empty
+        | do reportError "Failed to deserialize docstring section data while generating HTML"; pure .empty
       let inheritedAttr : Array (String × String) :=
         inheritedFrom.map (fun i => #[("data-inherited-from", toString i)]) |>.getD #[]
       let visibility : Html :=
@@ -657,7 +657,7 @@ def constructorSignature.descr : BlockDescr where
   toTeX := some fun _goI goB _id info contents =>
     open Verso.Output.TeX in do
       let .ok signature := FromJson.fromJson? (α := Highlighted) info
-        | Verso.Doc.TeX.logError "Failed to deserialize docstring section data while generating TeX"; pure .empty
+        | reportError "Failed to deserialize docstring section data while generating TeX"; pure .empty
       let signat ← signature.toTeX
       pure \TeX{ \Lean{.raw "\\begin{list}{$|$}{\\leftmargin=1em\\topsep=0pt \\partopsep=0pt}\\item "}
                  \Lean{signat}
@@ -669,7 +669,7 @@ def constructorSignature.descr : BlockDescr where
     open Verso.Doc.Html HtmlT in
     open Verso.Output Html in do
       let .ok signature := FromJson.fromJson? (α := Highlighted) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring section data while generating HTML"; pure .empty
+        | do reportError "Failed to deserialize docstring section data while generating HTML"; pure .empty
 
       return {{
         <div class="constructor">
@@ -737,7 +737,7 @@ def docstring.descr : BlockDescr := withHighlighting {
   traverse id info _ := do
     let .ok (name, declType, _signature, _customLabel, altNames) :=
       FromJson.fromJson? (α := Name × Block.Docstring.DeclType × Signature × Option String × Array Name) info
-      | do logError "Failed to deserialize docstring data"; pure none
+      | do reportError "Failed to deserialize docstring data"; pure none
 
     match declType with
     | .structure true ctor? fields fieldInfos _parents _ancestors =>
@@ -763,7 +763,7 @@ def docstring.descr : BlockDescr := withHighlighting {
 
     -- Save a backreference
     match (← get).get? `Verso.Genre.Manual.docstring with
-    | some (.error e) => logError e
+    | some (.error e) => reportError e
     | some (.ok (v : Json)) =>
       let found : HashSet InternalId := (v.getObjVal? name.toString).bind fromJson? |>.toOption |>.getD {}
       modify (·.set `Verso.Genre.Manual.docstring <|  v.setObjVal! name.toString (toJson (found.insert id)))
@@ -789,7 +789,7 @@ def docstring.descr : BlockDescr := withHighlighting {
     open Verso.Doc.Html HtmlT in
     open Verso.Output Html in do
       let .ok (name, declType, signature, customLabel, _) := FromJson.fromJson? (α := Name × Block.Docstring.DeclType × Signature × Option String × Array Name) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring data while generating HTML"; pure .empty
+        | do reportError "Failed to deserialize docstring data while generating HTML"; pure .empty
       let sig : Html ← signature.toHtml
 
       let xref ← state
@@ -798,7 +798,7 @@ def docstring.descr : BlockDescr := withHighlighting {
       let label := customLabel.getD declType.label
 
       if label == "" then
-        Doc.Html.HtmlT.logError s!"Missing label for '{name}': supply one with 'label := \"LABEL\"'"
+        reportError s!"Missing label for '{name}': supply one with 'label := \"LABEL\"'"
 
       return {{
         <div class="namedocs" {{idAttr}}>
@@ -820,11 +820,11 @@ def docstring.descr : BlockDescr := withHighlighting {
   toTeX := some <| fun _goI goB _id info contents =>
     open Verso.Output.TeX in do
       let .ok (name, declType, signature, customLabel, _) := FromJson.fromJson? (α := Name × Block.Docstring.DeclType × Signature × Option String × Array Name) info
-        | Verso.Doc.TeX.logError "Failed to deserialize docstring data while generating TeX"; return .empty
+        | reportError "Failed to deserialize docstring data while generating TeX"; return .empty
 
       let label := customLabel.getD declType.label
       if label == "" then
-        Verso.Doc.TeX.logError s!"Missing label for '{name}': supply one with 'label := \"LABEL\"'"
+        reportError s!"Missing label for '{name}': supply one with 'label := \"LABEL\"'"
       pure \TeX{\begin{docstringBox}{\Lean{label}} \Lean{← signature.toTeX} \tcblower " " \Lean{← contents.mapM goB} \end{docstringBox}}
 
   extraCss := [docstringStyle]
@@ -834,7 +834,7 @@ where
       (id : InternalId) (name : Name)
       (subterm : Option (Doc.Inline Manual))
       (showName : Option String := none) :
-      ReaderT TraverseContext (StateT TraverseState IO) Unit := do
+      ReaderT TraverseContext (StateT TraverseState (BuildLogT IO)) Unit := do
     let path ← (·.path) <$> read
     let _ ← Verso.Genre.Manual.externalTag id path name.toString
     Index.addEntry id {
@@ -866,7 +866,7 @@ def leanFromMarkdown.inlinedescr : InlineDescr := withHighlighting {
     some <| fun _ _ data _ => do
       match FromJson.fromJson? (α := Highlighted) data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.inlineHtml (g := Manual) "docstring-examples"
@@ -885,7 +885,7 @@ def leanFromMarkdown.blockdescr : BlockDescr := withHighlighting {
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? (α := Highlighted) data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.blockHtml (g := Manual) "docstring-examples"
@@ -1559,7 +1559,7 @@ def optionDocs.descr : BlockDescr := withHighlighting {
 
   traverse id info _ := do
     let .ok (name, _defaultValue) := FromJson.fromJson? (α := Name × Highlighted) info
-      | do logError "Failed to deserialize docstring data while traversing an option"; pure none
+      | do reportError "Failed to deserialize docstring data while traversing an option"; pure none
 
     let path ← (·.path) <$> read
     let _ ← Verso.Genre.Manual.externalTag id path name.toString
@@ -1574,7 +1574,7 @@ def optionDocs.descr : BlockDescr := withHighlighting {
     open Verso.Doc.Html in
     open Verso.Output Html in do
       let .ok (name, defaultValue) := FromJson.fromJson? (α := Name × Highlighted) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize docstring data while generating HTML for an option"; pure .empty
+        | do reportError "Failed to deserialize docstring data while generating HTML for an option"; pure .empty
       let x : Html := Html.text true <| Name.toString name
 
       let xref ← HtmlT.state
@@ -1730,7 +1730,7 @@ def tactic.descr : BlockDescr := withHighlighting {
 
   traverse id info _ := do
     let .ok (tactic, «show») := FromJson.fromJson? (α := TacticDoc × Option String) info
-      | do logError "Failed to deserialize docstring data while traversing a tactic"; pure none
+      | do reportError "Failed to deserialize docstring data while traversing a tactic"; pure none
     let path ← (·.path) <$> read
     let _ ← Verso.Genre.Manual.externalTag id path <| show.getD tactic.userName
     Index.addEntry id {term := Doc.Inline.code <| show.getD tactic.userName}
@@ -1745,7 +1745,7 @@ def tactic.descr : BlockDescr := withHighlighting {
     open Verso.Doc.Html in
     open Verso.Output Html in do
       let .ok (tactic, «show») := FromJson.fromJson? (α := TacticDoc × Option String) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize tactic data while generating HTML for a tactic"; pure .empty
+        | do reportError "Failed to deserialize tactic data while generating HTML for a tactic"; pure .empty
       let x : Highlighted := .token ⟨.keyword tactic.internalName none tactic.docString, show.getD tactic.userName⟩
 
       let xref ← HtmlT.state
@@ -1816,7 +1816,7 @@ def tacticInline.descr : InlineDescr := withHighlighting {
     some <| fun _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean tactic code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean tactic code while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.inlineHtml (g := Manual) "examples"
@@ -1884,7 +1884,7 @@ def conv.descr : BlockDescr := withHighlighting {
 
   traverse id info _ := do
     let .ok (name, «show», _docs?) := FromJson.fromJson? (α := Name × String × Option String) info
-      | do logError "Failed to deserialize conv docstring data"; pure none
+      | do reportError "Failed to deserialize conv docstring data"; pure none
     let path ← (·.path) <$> read
     let _ ← Verso.Genre.Manual.externalTag id path <| name.toString
     Index.addEntry id {term := Doc.Inline.code <| «show»}
@@ -1897,7 +1897,7 @@ def conv.descr : BlockDescr := withHighlighting {
     open Verso.Doc.Html in
     open Verso.Output Html in do
       let .ok (name, «show», docs?) := FromJson.fromJson? (α := Name × String × Option String) info
-        | do Verso.Doc.Html.HtmlT.logError "Failed to deserialize conv tactic data"; pure .empty
+        | do reportError "Failed to deserialize conv tactic data"; pure .empty
       let x : Highlighted := .token ⟨.keyword (some name) none docs?, «show»⟩
 
       let xref ← HtmlT.state
@@ -1934,7 +1934,7 @@ inline_extension Inline.conv (hl : Highlighted) via withHighlighting where
     some <| fun _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize conv tactic code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize conv tactic code while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.inlineHtml (g := Manual) "examples"

--- a/src/verso-manual/VersoManual/Docstring/Progress.lean
+++ b/src/verso-manual/VersoManual/Docstring/Progress.lean
@@ -119,7 +119,7 @@ public def progress.descr : BlockDescr where
   toHtml := some fun _ _ _ info _blocks => open Output.Html in do
     let documented ← match ((← Doc.Html.HtmlT.state).get? `Verso.Genre.Manual.docstring).getD (pure <| .mkObj []) >>= Json.getObj? with
       | .error e =>
-        Doc.Html.HtmlT.logError e
+        reportError e
         pure {}
       | .ok v =>
         pure v

--- a/src/verso-manual/VersoManual/ExternalLean.lean
+++ b/src/verso-manual/VersoManual/ExternalLean.lean
@@ -34,16 +34,16 @@ block_extension Block.lean (hls : Highlighted) (cfg : CodeConfig) via withHighli
     Json.arr #[ToJson.toJson cfg, ToJson.toJson hls, ToJson.toJson defined]
   traverse id data _ := do
     let .arr #[cfgJson, _hlJson, definesJson] := data
-      | logError s!"Expected array for Lean block, got {data.compress}"; return none
+      | reportError s!"Expected array for Lean block, got {data.compress}"; return none
     match FromJson.fromJson? cfgJson with
     | .error err =>
-      logError <| "Failed to deserialize code config during traversal:" ++ err
+      reportError <| "Failed to deserialize code config during traversal:" ++ err
       return none
     | .ok (cfg : CodeConfig) =>
       if cfg.defSite.isEqSome false then return none
       match FromJson.fromJson? definesJson with
       | .error err =>
-        logError <| "Failed to deserialize code config during traversal:" ++ err
+        reportError <| "Failed to deserialize code config during traversal:" ++ err
         return none
       | .ok (defines : Array (Name × String)) =>
         saveExampleDefs id defines
@@ -70,16 +70,16 @@ block_extension Block.lean (hls : Highlighted) (cfg : CodeConfig) via withHighli
     open Verso.Output.Html in
     some <| fun _ _ _ data _ => do
       let .arr #[cfgJson, hlJson, _definesJson] := data
-        | HtmlT.logError "Expected four-element JSON for Lean code"
+        | reportError "Expected four-element JSON for Lean code"
           pure .empty
       match FromJson.fromJson? hlJson with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code block while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code block while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         match FromJson.fromJson? cfgJson with
         | .error err =>
-          HtmlT.logError <| "Couldn't deserialize Lean code block config while rendering HTML: " ++ err
+          reportError <| "Couldn't deserialize Lean code block config while rendering HTML: " ++ err
           pure .empty
         | .ok (cfg : CodeConfig) =>
           let i := hl.indentation
@@ -93,16 +93,16 @@ inline_extension Inline.lean (hls : Highlighted) (cfg : CodeConfig) via withHigh
     Json.arr #[ToJson.toJson cfg, ToJson.toJson hls, ToJson.toJson defined]
   traverse id data _ := do
     let .arr #[cfgJson, _hlJson, definesJson] := data
-      | logError s!"Expected array for Lean block, got {data.compress}"; return none
+      | reportError s!"Expected array for Lean block, got {data.compress}"; return none
     match FromJson.fromJson? cfgJson with
     | .error err =>
-      logError <| "Failed to deserialize code config during traversal:" ++ err
+      reportError <| "Failed to deserialize code config during traversal:" ++ err
       return none
     | .ok (cfg : CodeConfig) =>
       unless cfg.defSite.isEqSome true do return none
       match FromJson.fromJson? definesJson with
       | .error err =>
-        logError <| "Failed to deserialize code config during traversal:" ++ err
+        reportError <| "Failed to deserialize code config during traversal:" ++ err
         return none
       | .ok (defines : Array (Name × String)) =>
         saveExampleDefs id defines
@@ -129,16 +129,16 @@ inline_extension Inline.lean (hls : Highlighted) (cfg : CodeConfig) via withHigh
     open Verso.Output.Html in
     some <| fun _ _ data _ => do
       let .arr #[cfgJson, hlJson, _] := data
-        | HtmlT.logError "Expected four-element JSON for Lean code"
+        | reportError "Expected four-element JSON for Lean code"
           pure .empty
       match FromJson.fromJson? hlJson with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code block while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code block while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         match FromJson.fromJson? cfgJson with
         | .error err =>
-          HtmlT.logError <| "Couldn't deserialize Lean code block config while rendering HTML: " ++ err
+          reportError <| "Couldn't deserialize Lean code block config while rendering HTML: " ++ err
           pure .empty
         | .ok (cfg : CodeConfig) =>
           let i := hl.indentation
@@ -160,7 +160,7 @@ block_extension Block.leanOutput
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        TeX.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
         pure .empty
       | .ok ((msg, _summarize, _expandTraces) : Highlighted.Message × Bool × List Name) =>
         msg.toTeX
@@ -169,7 +169,7 @@ block_extension Block.leanOutput
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
         pure .empty
       | .ok ((msg, summarize, expandTraces) : Highlighted.Message × Bool × List Name) =>
         msg.blockHtml summarize expandTraces (g := Manual)
@@ -186,7 +186,7 @@ inline_extension Inline.leanOutput
     some <| fun _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        TeX.logError <| "Couldn't deserialize Lean code while rendering TeX: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering TeX: " ++ err
         pure .empty
       | .ok ((txt, plain, expandTraces) : Highlighted.Message × Bool × List Name) =>
         if plain then
@@ -198,7 +198,7 @@ inline_extension Inline.leanOutput
     some <| fun _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
         pure .empty
       | .ok ((txt, plain, expandTraces) : Highlighted.Message × Bool × List Name) =>
         if plain then pure {{<code>{{txt.toString}}</code>}}

--- a/src/verso-manual/VersoManual/Glossary.lean
+++ b/src/verso-manual/VersoManual/Glossary.lean
@@ -92,12 +92,12 @@ public meta def deftech : RoleExpanderOf DefTechArgs
 
 
 /-- Adds an internal identifier as a target for a given glossary entry -/
-def Glossary.addEntry [Monad m] [MonadState TraverseState m] [MonadLiftT IO m] [MonadReaderOf TraverseContext m]
+def Glossary.addEntry [Monad m] [MonadState TraverseState m] [MonadLiftT IO m] [MonadReaderOf TraverseContext m] [MonadBuildLog m]
     (id : InternalId) (key : String) : m Unit := do
   match (← get).get? glossaryState with
   | none =>
     modify (TraverseState.set · glossaryState <| Lean.Json.mkObj [(key, ToJson.toJson id)])
-  | some (.error err) => logError err
+  | some (.error err) => reportError err
   | some (.ok (v : Json)) =>
     modify (TraverseState.set · glossaryState <| v.setObjVal! key (ToJson.toJson id))
 
@@ -127,7 +127,7 @@ public def deftech.descr : InlineDescr where
     let path ← (·.path) <$> read
     match FromJson.fromJson? data with
     | .error err =>
-      logError err
+      reportError err
       return none
     | .ok ((key, term) : (String × String) ) =>
       let termSlug := term.sluggify.toString
@@ -181,15 +181,16 @@ public meta def tech : RoleExpanderOf TechArgs
       (kind := .key)
 
     let filename ← getFileName
-    let line := (← getFileMap).utf8PosToLspPos <$> (← getRef).getPos?
-    let loc : String := filename ++ (line.map (fun ⟨line, col⟩ => s!":{line}:{col}")).getD ""
+    let pos? := (← getFileMap).utf8PosToLspPos <$> (← getRef).getPos?
 
     let content ← content.mapM elabInline
 
 
     `(let content : Array (Doc.Inline Verso.Genre.Manual) := #[$content,*]
       let k := ($(quote key) : Option String).getD (techString (Doc.Inline.concat content))
-      Doc.Inline.other {Inline.tech with data := Json.arr #[Json.str (if $(quote normalize) then normString k else k), Json.str $(quote loc), $(quote remote).map Json.str |>.getD Json.null]} content)
+      let loc : Verso.SourceLoc :=
+        { file := $(quote filename), span := ($(quote pos?) : Option Lean.Lsp.Position) }
+      Doc.Inline.other {Inline.tech with data := Json.arr #[Json.str (if $(quote normalize) then normString k else k), Lean.toJson loc, $(quote remote).map Json.str |>.getD Json.null]} content)
 
 open Verso.Output Html in
 private def techLink (addr : String) (content : Html) (remote? : Option String := none) :=
@@ -207,14 +208,15 @@ public def tech.descr : InlineDescr where
     open Verso.Output.Html in
     open Doc.Html in
     some <| fun go _id info content => do
-      let Json.arr #[.str key, .str loc, remote] := info
-        | HtmlT.logError s!"Failed to decode glossary key and location from {info}"
+      let Json.arr #[.str key, locJson, remote] := info
+        | reportError s!"Failed to decode glossary key and location from {info}"
           content.mapM go
+      let loc : Option Verso.SourceLoc := (Lean.fromJson? (α := Verso.SourceLoc) locJson).toOption
       let remote ←
         match remote with
         | .null => pure none
         | .str s => pure (some s)
-        | other => HtmlT.logError s!"Failed to decode optional remote from {other}"; pure none
+        | other => reportError s!"Failed to decode optional remote from {other}"; pure none
 
       match remote with
       | none =>
@@ -224,17 +226,17 @@ public def tech.descr : InlineDescr where
             if let some link := (← HtmlT.state).resolveId ids[0] then
               return techLink link.relativeLink (← content.mapM go)
             else
-              HtmlT.logError s!"{loc}: No link target saved for internal ID of term \"{key}\""
+              reportError s!"No link target saved for internal ID of term \"{key}\"" loc
               content.mapM go
           else
             let st ← HtmlT.state
             let potentialTargets := ids.map st.resolveId |>.map (·.map (·.link))
             let potentialTargets := potentialTargets.map fun tgt? =>
               s!" * {tgt?.getD "<no link>"}"
-            HtmlT.logError s!"{loc}: Ambiguous term def with key \"{key}\". Targets:\n{"\n".intercalate potentialTargets.toList}"
+            reportError s!"Ambiguous term def with key \"{key}\". Targets:\n{"\n".intercalate potentialTargets.toList}" loc
             content.mapM go
         else
-          HtmlT.logError s!"{loc}: No term def with key \"{key}\""
+          reportError s!"No term def with key \"{key}\"" loc
           content.mapM go
       | some r =>
         if let some remote := (← readThe AllRemotes)[r]? then
@@ -242,17 +244,17 @@ public def tech.descr : InlineDescr where
             if h : objs.size = 1 then
               return techLink objs[0].link.link (← content.mapM go)
             else
-              HtmlT.logError s!"{loc}: Ambiguous term def with key \"{key}\" in remote {r.quote} - {objs.map (·.link.link)} found"
+              reportError s!"Ambiguous term def with key \"{key}\" in remote {r.quote} - {objs.map (·.link.link)} found" loc
               content.mapM go
           else
             let keys := remote.domains[technicalTermDomain]?
               |>.map (·.contents.keysArray.qsortOrd.toList |> ", ".intercalate)
               |>.map ("Keys are: " ++ ·)
               |>.getD "Technical term domain not found."
-            HtmlT.logError s!"{loc}: No term def with key \"{key}\" in remote {r.quote}. {keys}"
+            reportError s!"No term def with key \"{key}\" in remote {r.quote}. {keys}" loc
             content.mapM go
         else
-          HtmlT.logError s!"{loc}: Remote {r.quote} not found in {(← readThe AllRemotes).allRemotes.keys}"
+          reportError s!"Remote {r.quote} not found in {(← readThe AllRemotes).allRemotes.keys}" loc
           content.mapM go
 
   extraCss := [

--- a/src/verso-manual/VersoManual/Index.lean
+++ b/src/verso-manual/VersoManual/Index.lean
@@ -123,19 +123,19 @@ public def index (args : Array (Doc.Inline Manual)) (subterm : Option String := 
   Doc.Inline.other {Inline.index with data := ToJson.toJson entry} #[]
 
 /-- Adds an internal identifier as a target for a given index entry -/
-public def Index.addEntry [Monad m] [MonadState TraverseState m] [MonadLiftT IO m] [MonadReaderOf TraverseContext m]
+public def Index.addEntry [Monad m] [MonadState TraverseState m] [MonadLiftT IO m] [MonadReaderOf TraverseContext m] [MonadBuildLog m]
     (id : InternalId) (entry : Index.Entry) : m Unit := do
   let ist : Option (Except String Lean.Json) := (← get).get? indexState
   -- This function works directly with the JSON serialization of the index. Otherwise, there's a
   -- quadratic overhead from serialization/deserialization with each entry.
   match ist with
-  | some (.error err) => logError err
+  | some (.error err) => reportError err
   | some (.ok v) =>
     match v.getArr? with
-    | .error err => logError err
+    | .error err => reportError err
     | .ok xs =>
       let #[.arr entries, see] := xs
-        | logError "Expected two elements for index state with first being an array"
+        | reportError "Expected two elements for index state with first being an array"
       let entries' := entries.binInsert cmpEntry (.arr #[ToJson.toJson entry, ToJson.toJson id])
       modify fun i =>
         i.set indexState (Lean.Json.arr #[.arr entries', see]) (by clear entries'; grind)
@@ -157,7 +157,7 @@ def index.descr : InlineDescr where
     let _ ← Verso.Genre.Manual.externalTag id path ("--index-" ++ Index.sortingKey (.concat contents))
     match FromJson.fromJson? data with
     | .error err =>
-      logError err
+      reportError err
       return none
     | .ok (entry : Index.Entry) =>
       Index.addEntry id entry
@@ -189,12 +189,12 @@ def see.descr : InlineDescr where
   traverse _id data _contents := do
     match FromJson.fromJson? data with
     | .error err =>
-      logError err
+      reportError err
       return none
     | .ok (see : Index.See) =>
       let ist : Option (Except String Index) := (← get).get? indexState
       match ist with
-      | some (.error err) => logError err; return none
+      | some (.error err) => reportError err; return none
       | some (.ok v) => modify (·.set indexState {v with see := v.see.binInsert (· < ·) see})
       | none => modify (·.set indexState {entries := {}, see := #[see] : Index})
       pure none
@@ -225,7 +225,8 @@ structure RenderedEntry where
 deriving ToJson
 
 open Verso.Output Html in
-def RenderedEntry.toHtml [Monad m] (inlineHtml : Doc.Inline Manual → Doc.Html.HtmlT Manual m Html) (entry : RenderedEntry) : Doc.Html.HtmlT Manual m Html := do
+def RenderedEntry.toHtml [Monad m] [MonadLiftT IO m] [MonadBuildLog (Doc.Html.HtmlT Manual m)]
+    (inlineHtml : Doc.Inline Manual → Doc.Html.HtmlT Manual m Html) (entry : RenderedEntry) : Doc.Html.HtmlT Manual m Html := do
   let termPart ← oneTerm entry.id entry.term entry.links
   let subPart ←
     if entry.subterms.size != 0 || entry.see.size != 0 then
@@ -255,7 +256,7 @@ where
         let addr := dest.link
         pure {{<a href={{addr}}>{{termHtml}}</a>}}
       else
-        HtmlT.logError s!"No external tag for {id.toString}"
+        reportError s!"No external tag for {id.toString}"
         pure .empty
     | _ =>
       let links ← links.mapIdxM fun i id => do
@@ -263,7 +264,7 @@ where
           let addr := dest.link
           pure {{" " <a href={{addr}}> s!"({i})" </a>}}
         else
-          HtmlT.logError s!"No external tag for {id}"
+          reportError s!"No external tag for {id}"
           pure .empty
 
       pure {{ {{termHtml}} {{links}} }}
@@ -400,10 +401,10 @@ def theIndex.descr : BlockDescr where
       let ist : Option (Except String Index) := (← state).get? indexState
       match ist with
       | some (.error err) =>
-        Verso.Doc.Html.HtmlT.logError err
+        reportError err
         return .empty
       | none =>
-        Verso.Doc.Html.HtmlT.logError "Index data not found"
+        reportError "Index data not found"
         return .empty
       | some (.ok v) =>
         let r := v.render

--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -42,10 +42,10 @@ inline_extension Inline.lean (hls : Highlighted) via withHighlighting where
 
   traverse id data _ := do
     let .arr #[_, defined] := data
-      | logError "Expected two-element JSON for Lean code" *> pure none
+      | reportError "Expected two-element JSON for Lean code" *> pure none
     match FromJson.fromJson? defined with
     | .error err =>
-      logError <| "Couldn't deserialize Lean code while traversing inline example: " ++ err
+      reportError <| "Couldn't deserialize Lean code while traversing inline example: " ++ err
       pure none
     | .ok (defs : Array (Name × String)) =>
       saveExampleDefs id defs
@@ -53,21 +53,21 @@ inline_extension Inline.lean (hls : Highlighted) via withHighlighting where
   toTeX :=
     some <| fun _ _ data _ => do
       let .arr #[hlJson, _] := data
-        | TeX.logError "Expected two-element JSON for Lean code" *> pure .empty
+        | reportError "Expected two-element JSON for Lean code" *> pure .empty
       match FromJson.fromJson? hlJson with
       | .error err =>
-        TeX.logError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
-        hl.toTeX (g := Manual) (m := ReaderT ExtensionImpls IO)
+        hl.toTeX (g := Manual) (m := ReaderT ExtensionImpls (BuildLogT IO))
   toHtml :=
     open Verso.Output.Html in
     some <| fun _ _ data _ => do
       let .arr #[hlJson, _] := data
-        | HtmlT.logError "Expected two-element JSON for Lean code" *> pure .empty
+        | reportError "Expected two-element JSON for Lean code" *> pure .empty
       match FromJson.fromJson? hlJson with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering inline HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.inlineHtml (g := Manual) "examples"
@@ -626,7 +626,7 @@ block_extension Block.leanOutput via withHighlighting where
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        TeX.logError <| "Couldn't deserialize Lean output while rendering TeX: " ++ err ++ "\n" ++ toString data
+        reportError <| "Couldn't deserialize Lean output while rendering TeX: " ++ err ++ "\n" ++ toString data
         pure .empty
       | .ok ((msg, _summarize, expandTraces) : Highlighted.Message × Bool × List Name) =>
         msg.toTeX (expandTraces := expandTraces) (g := Manual)
@@ -635,7 +635,7 @@ block_extension Block.leanOutput via withHighlighting where
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean output while rendering HTML: " ++ err ++ "\n" ++ toString data
+        reportError <| "Couldn't deserialize Lean output while rendering HTML: " ++ err ++ "\n" ++ toString data
         pure .empty
       | .ok ((msg, summarize, expandTraces) : Highlighted.Message × Bool × List Name) =>
         msg.blockHtml summarize (expandTraces := expandTraces) (g := Manual)
@@ -800,7 +800,7 @@ inline_extension Inline.name via withHighlighting where
     some <| fun _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.inlineHtml (g := Manual) "examples"

--- a/src/verso-manual/VersoManual/InlineLean/Block.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Block.lean
@@ -30,10 +30,10 @@ block_extension Block.lean
 
   traverse id data _ := do
     let .arr #[_, defined, _, _] := data
-      | logError "Expected two-element JSON for Lean code" *> pure none
+      | reportError "Expected two-element JSON for Lean code" *> pure none
     match FromJson.fromJson? defined with
     | .error err =>
-      logError <| "Couldn't deserialize Lean code while traversing block example: " ++ err
+      reportError <| "Couldn't deserialize Lean code while traversing block example: " ++ err
       pure none
     | .ok (defs : Array (Name × String)) =>
       saveExampleDefs id defs
@@ -41,21 +41,21 @@ block_extension Block.lean
   toTeX :=
     some <| fun _ _ _ data _ => do
       let .arr #[hlJson, _ds, _, _] := data
-        | TeX.logError "Expected four-element JSON for Lean code" *> pure .empty
+        | reportError "Expected four-element JSON for Lean code" *> pure .empty
       match FromJson.fromJson? hlJson with
       | .error err =>
-        TeX.logError <| "Couldn't deserialize Lean code block while rendering TeX: " ++ err
+        reportError <| "Couldn't deserialize Lean code block while rendering TeX: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
-        hl.toTeX (g := Manual) (m := ReaderT ExtensionImpls IO)
+        hl.toTeX (g := Manual) (m := ReaderT ExtensionImpls (BuildLogT IO))
   toHtml :=
     open Verso.Output.Html in
     some <| fun _ _ _ data _ => do
       let .arr #[hlJson, _ds, _, _] := data
-        | HtmlT.logError "Expected four-element JSON for Lean code" *> pure .empty
+        | reportError "Expected four-element JSON for Lean code" *> pure .empty
       match FromJson.fromJson? hlJson with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code block while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code block while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
 

--- a/src/verso-manual/VersoManual/InlineLean/IO.lean
+++ b/src/verso-manual/VersoManual/InlineLean/IO.lean
@@ -185,7 +185,7 @@ block_extension Block.exampleLeanFile (filename : String) where
   open Verso.Output.TeX in
   some <| fun _ goB _ data blocks => do
     let .str filename := data
-      | Verso.Doc.TeX.logError "Failed to deserialize filename from {data.compress} (expected a string)"
+      | reportError "Failed to deserialize filename from {data.compress} (expected a string)"
         return .empty
     let descr := \TeX{\texttt{\Lean{"File: " ++ filename} } }
     pure <| .seq #[.raw "\\begin{FileVerbatim}[label={", descr, .raw "}]\n",
@@ -195,7 +195,7 @@ block_extension Block.exampleLeanFile (filename : String) where
   toHtml := open Verso.Output Html in
     some <| fun _ goB _ data blocks => do
       let .str filename := data
-        | HtmlT.logError "Failed to deserialize filename from {data.compress} (expected a string)"
+        | reportError "Failed to deserialize filename from {data.compress} (expected a string)"
           return .empty
       let descr := {{<code>{{filename}}</code>}}
       return exampleFileHtmlWrapper descr (← blocks.mapM goB)
@@ -237,14 +237,14 @@ def Block.exampleFile.descr : BlockDescr := withHighlighting {
     some <| fun _ _ _ data blocks => do
       match FromJson.fromJson? (α := FileType) data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize file metadata while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize file metadata while rendering HTML: " ++ err
         pure .empty
       | .ok type =>
         let str ←
           match blocks with
           | #[.code s] => pure s
           | other =>
-            HtmlT.logError <| s!"Expected a single code block in an example file, but got {other.size} blocks"
+            reportError <| s!"Expected a single code block in an example file, but got {other.size} blocks"
             return .empty
         let descr : Html :=
           match type with

--- a/src/verso-manual/VersoManual/InlineLean/Option.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Option.lean
@@ -48,7 +48,7 @@ def option.descr : InlineDescr := withHighlighting {
     some <| fun _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean option code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean option code while rendering HTML: " ++ err
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.inlineHtml (g := Manual) "examples"

--- a/src/verso-manual/VersoManual/InlineLean/Signature.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Signature.lean
@@ -32,7 +32,7 @@ block_extension Block.signature via withHighlighting where
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML signature: " ++ err ++ "\n" ++ toString data
+        reportError <| "Couldn't deserialize Lean code while rendering HTML signature: " ++ err ++ "\n" ++ toString data
         pure .empty
       | .ok (hl : Highlighted) =>
         hl.blockHtml (g := Manual) "examples"

--- a/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
+++ b/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
@@ -76,7 +76,7 @@ block_extension Block.syntaxError via withHighlighting where
     some <| fun _ _ _ data _ => do
       match FromJson.fromJson? data with
       | .error err =>
-        HtmlT.logError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
+        reportError <| "Couldn't deserialize Lean code while rendering HTML: " ++ err
         pure .empty
       | .ok (str, (msgs : (Array SyntaxError))) =>
         let mut pos : String.Pos.Raw := ⟨0⟩

--- a/src/verso-manual/VersoManual/Literate.lean
+++ b/src/verso-manual/VersoManual/Literate.lean
@@ -29,17 +29,17 @@ block_extension Block.literateDocstringPart (level : Nat) where
   traverse _ _ _ _ := pure none
   toHtml := some fun goI goB _id data contents => do
     let .ok (level : Nat) := FromJson.fromJson? data
-      | HtmlT.logError s!"Couldn't decode nesting level from {data.compress}"
+      | reportError s!"Couldn't decode nesting level from {data.compress}"
         pure .empty
     let title : Html ←
       if let some title := contents[0]? then
         if let .para xs := title then
           xs.mapM goI
         else
-          HtmlT.logError s!"Expected a paragraph at the beginning of a docstring section"
+          reportError s!"Expected a paragraph at the beginning of a docstring section"
           pure .empty
       else
-        HtmlT.logError s!"Expected a block at the beginning of a docstring section"
+        reportError s!"Expected a block at the beginning of a docstring section"
         pure .empty
     let contents := contents.extract 1
     pure {{
@@ -51,17 +51,17 @@ block_extension Block.literateDocstringPart (level : Nat) where
   toTeX := some fun goI goB _id data contents =>
     open Verso.Output.TeX in do
       let .ok (level : Nat) := FromJson.fromJson? data
-        | Verso.Doc.TeX.logError s!"Couldn't decode nesting level from {data.compress}"
+        | reportError s!"Couldn't decode nesting level from {data.compress}"
           pure .empty
       let title : TeX ←
         if let some title := contents[0]? then
           if let .para xs := title then
             xs.mapM goI
           else
-            Verso.Doc.TeX.logError s!"Expected a paragraph at the beginning of a docstring section"
+            reportError s!"Expected a paragraph at the beginning of a docstring section"
             pure .empty
         else
-          Verso.Doc.TeX.logError s!"Expected a block at the beginning of a docstring section"
+          reportError s!"Expected a block at the beginning of a docstring section"
           pure .empty
       let contents := contents.extract 1
       let sectionHeader ← Doc.TeX.headerLevel title level none

--- a/src/verso-manual/VersoManual/LocalContents.lean
+++ b/src/verso-manual/VersoManual/LocalContents.lean
@@ -223,8 +223,8 @@ def SubpartSpec.decr : SubpartSpec → SubpartSpec
 instance : LT SubpartSpec := Ord.toLT inferInstance
 instance : LE SubpartSpec := Ord.toLE inferInstance
 
-partial def localContentsCore [Monad m] [ToHtml Manual m (Doc.Inline Manual)] [MonadReaderOf ExtensionImpls m]
-    (opts : Html.Options m) (ctxt : TraverseContext) (xref : TraverseState)
+partial def localContentsCore [Monad m] [MonadLiftT IO m] [ToHtml Manual m (Doc.Inline Manual)] [MonadReaderOf ExtensionImpls m]
+    (opts : Html.Options) (ctxt : TraverseContext) (xref : TraverseState)
     (p : Part Manual) (sectionNumPrefix : Option String)
     (includeTitle : Bool) (includeSubparts : SubpartSpec) (fromLevel : Nat) :
     StateT LocalItemState (StateT (Code.Hover.State Html) m) Unit := do
@@ -236,7 +236,7 @@ partial def localContentsCore [Monad m] [ToHtml Manual m (Doc.Inline Manual)] [M
       if let some title := shortTitle then
         pure (Html.ofString title)
       else
-        let (html, _) ← p.title.mapM (Manual.toHtml opts ctxt xref {} {} {} ·) |>.run {}
+        let (html, _) ← p.title.mapM (Manual.toHtml (m := m) opts ctxt xref {} {} {} ·) |>.run {}
         pure html
 
     let partDest : Option LocalContentItem := do
@@ -259,8 +259,8 @@ where
   withoutPrefix (str : String) (prefix? : Option String) : String :=
     prefix?.bind (str.dropPrefix? · |>.map String.Slice.copy) |>.getD str
 
-def localContents [Monad m] [ToHtml Manual m (Doc.Inline Manual)] [MonadReaderOf ExtensionImpls m]
-    (opts : Html.Options m) (ctxt : TraverseContext) (xref : TraverseState)
+def localContents [Monad m] [MonadLiftT IO m] [ToHtml Manual m (Doc.Inline Manual)] [MonadReaderOf ExtensionImpls m]
+    (opts : Html.Options) (ctxt : TraverseContext) (xref : TraverseState)
     (p : Part Manual)
     (sectionNumPrefix : Option String := none)
     (includeTitle : Bool := true) (includeSubparts : SubpartSpec := .all) (fromLevel : Nat := 0) :

--- a/src/verso-manual/VersoManual/Row.lean
+++ b/src/verso-manual/VersoManual/Row.lean
@@ -22,7 +22,7 @@ block_extension Block.row (alignItems : String) where
     open Verso.Output.Html in
     some <| fun _ blockHtml _ data content => do
       let .str ai := data
-        | HtmlT.logError "Expected string JSON for row" *> pure .empty
+        | reportError "Expected string JSON for row" *> pure .empty
       let style := s!"display: flex; flex-wrap: wrap; align-items: {ai}; gap: 1em;"
       pure {{
         <div class="verso-row" style={{style}}>

--- a/src/verso-manual/VersoManual/Table.lean
+++ b/src/verso-manual/VersoManual/Table.lean
@@ -54,7 +54,7 @@ block_extension Block.table (columns : Nat) (header : Bool) (tag : Option String
 
   traverse id data contents := do
     match FromJson.fromJson? data (α := Nat × Bool × Option String × Option Tag × Option TableConfig.Alignment) with
-    | .error e => logError s!"Error deserializing table data: {e}"; pure none
+    | .error e => reportError s!"Error deserializing table data: {e}"; pure none
     | .ok (_, _, none, _) => pure none
     | .ok (c, hdr, some x, none, align) =>
       let path ← (·.path) <$> read
@@ -76,7 +76,7 @@ block_extension Block.table (columns : Nat) (header : Bool) (tag : Option String
           rows := rows.push (items.take columns |>.map (·.contents))
           items := items.extract columns items.size
 
-        let rowsOut : TeX.TeXT Manual (ReaderT ExtensionImpls IO) (Array Output.TeX) := do
+        let rowsOut : TeX.TeXT Manual (ReaderT ExtensionImpls (BuildLogT IO)) (Array Output.TeX) := do
           rows.mapIdxM fun i r => do
             let cols ← r.mapM fun c => do
               let cell : Output.TeX ← Array.mapM goB c
@@ -97,7 +97,7 @@ block_extension Block.table (columns : Nat) (header : Bool) (tag : Option String
     some <| fun _goI goB id data blocks => do
       match FromJson.fromJson? data (α := Nat × Bool × Option String × Option Tag × Option TableConfig.Alignment) with
       | .error e =>
-        HtmlT.logError s!"Error deserializing table data: {e}"
+        reportError s!"Error deserializing table data: {e}"
         return .empty
       | .ok (columns, header, _, _, align) =>
       if let #[.ul items] := blocks then
@@ -128,7 +128,7 @@ block_extension Block.table (columns : Nat) (header : Bool) (tag : Option String
         }}
 
       else
-        HtmlT.logError "Malformed table"
+        reportError "Malformed table"
         return .empty
 
   extraCss := [

--- a/src/verso-tutorial/VersoTutorial.lean
+++ b/src/verso-tutorial/VersoTutorial.lean
@@ -650,7 +650,7 @@ def tutorialsMain (tutorials : Tutorials) (args : List String)
   ReaderT.run go extensionImpls
 
 where
-  go : ReaderT ExtensionImpls IO UInt32 := Verso.withLogger fun logger => do
+  go : ReaderT ExtensionImpls IO UInt32 := withLogger fun logger => do
     let config ← opts config args
 
     IO.FS.createDirAll config.destination
@@ -669,7 +669,8 @@ where
         SavedState.mk tutorials state |>.save f
         let json := xrefJson state.domains state.externalTags
         IO.FS.writeFile (config.destination / "xref.json") <| toString json
-        -- No HTML is emitted in this mode; fall through so logged errors still set the exit code.
+        -- No HTML is emitted in this mode; returning early here causes the exit code to be derived
+        -- from the surrounding `withLogger` based on whether errors were logged.
         return
       | .resumeFrom f =>
           try

--- a/src/verso-tutorial/VersoTutorial.lean
+++ b/src/verso-tutorial/VersoTutorial.lean
@@ -162,22 +162,21 @@ open Verso.Genre.Blog.Template in
 structure EmitContext where
   components : Blog.Components
   config : Manual.Config
-  logError : String → IO Unit
   theme : Blog.Theme
   remoteContent : AllRemotes
 
 def EmitContext.toBlogContext (ctxt : EmitContext) : Blog.TraverseContext where
-  config := { logError := ctxt.logError }
+  config := {}
   components := ctxt.components
 
 abbrev EmitM :=
   ReaderT EmitContext <|
   ReaderT Manual.TraverseState <|
   ReaderT ExtensionImpls <|
-  StateRefT Blog.Component.State (StateRefT (Code.Hover.State Html) IO)
+  StateRefT Blog.Component.State (StateRefT (Code.Hover.State Html) (BuildLogT IO))
 
 def EmitM.run
-    (config : Manual.Config) (logError : String → IO Unit)
+    (config : Manual.Config) (logger : Verso.Logger IO)
     (state : Manual.TraverseState) (extensionImpls : ExtensionImpls)
     (componentState : Blog.Component.State)
     (hoverState : Code.Hover.State Html)
@@ -186,21 +185,16 @@ def EmitM.run
     (remoteContent : AllRemotes)
     (act : EmitM α) : IO (α × Blog.Component.State × Code.Hover.State Html) := do
   let ((v, st), st') ←
-    ReaderT.run act { config, logError, components, theme, remoteContent }
+    ReaderT.run act { config, components, theme, remoteContent }
       |>.run state
       |>.run extensionImpls
       |>.run componentState
       |>.run hoverState
+      |>.run logger
   return (v, st, st')
 
 def EmitM.config : EmitM Manual.Config := do
   return (← readThe EmitContext).config
-
-def EmitM.logError : EmitM ((message : String) → IO Unit) := do
-  return (← readThe EmitContext).logError
-
-def EmitM.htmlOptions [MonadLiftT IO m] : EmitM (Html.Options m) := do
-  return { logError := ((← EmitM.logError) ·) }
 
 def EmitM.writeFile (path : System.FilePath) (content : String) : EmitM Unit := do
   if (← readThe EmitContext).config.verbose then
@@ -268,8 +262,8 @@ partial def inlineToPage (i : Inline Tutorial) : EmitM (Inline Blog.Page) := do
   | .other .. =>
     let hoverSt ← getThe (Code.Hover.State Html)
     let (html, hoverSt) ←
-      Tutorial.toHtml (m := ReaderT AllRemotes (ReaderT ExtensionImpls IO)) (← EmitM.htmlOptions)
-        { logError := (← read).logError }
+      Tutorial.toHtml (m := ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) {}
+        {}
         (← readThe Manual.TraverseState)
         {} {} {} i
         |>.run hoverSt
@@ -290,8 +284,8 @@ partial def blockToPage (b : Block Tutorial) : EmitM (Block Blog.Page) := do
   | .other .. =>
     let hoverSt ← getThe (Code.Hover.State Html)
     let (html, hoverSt) ←
-      Tutorial.toHtml (m := ReaderT AllRemotes (ReaderT ExtensionImpls IO)) (← EmitM.htmlOptions)
-        { logError := (← read).logError }
+      Tutorial.toHtml (m := ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) {}
+        {}
         (← readThe Manual.TraverseState)
         {} {} {} b
         |>.run hoverSt
@@ -478,7 +472,7 @@ def toSite (tuts : Tutorials) : EmitM Blog.Site := do
   return .page `tutorials { tuts.content with subParts := topicParts } contentPages
 
 def EmitM.blogConfig : EmitM Blog.Config := do
-  return { logError := (← read).logError, verbose := (← EmitM.config).verbose }
+  return { verbose := (← EmitM.config).verbose }
 
 def liftGenerate (act : Blog.GenerateM α) (site : Blog.Site) (state : Blog.TraverseState) (extraParams : Path → Blog.Template.Params:= fun _ => {}) : EmitM α := do
   let st ← getThe (Code.Hover.State _)
@@ -656,10 +650,8 @@ def tutorialsMain (tutorials : Tutorials) (args : List String)
   ReaderT.run go extensionImpls
 
 where
-  go : ReaderT ExtensionImpls IO UInt32 := do
+  go : ReaderT ExtensionImpls IO UInt32 := Verso.withLogger fun logger => do
     let config ← opts config args
-    let errorCount : IO.Ref Nat ← IO.mkRef 0
-    let logError msg := do errorCount.modify (· + 1); IO.eprintln msg
 
     IO.FS.createDirAll config.destination
 
@@ -667,35 +659,31 @@ where
     let (tutorials, state) ←
       match config.emit with
       | .immediately =>
-        let (tutorials, state) ← traverse logError tutorials config.toConfig
+        let (tutorials, state) ← traverse logger tutorials config.toConfig
         let json := xrefJson state.domains state.externalTags
 
         IO.FS.writeFile (config.destination / "xref.json") <| toString json
         pure (tutorials, state)
       | .delay f =>
-        let (tutorials, state) ← traverse logError tutorials config.toConfig
+        let (tutorials, state) ← traverse logger tutorials config.toConfig
         SavedState.mk tutorials state |>.save f
         let json := xrefJson state.domains state.externalTags
         IO.FS.writeFile (config.destination / "xref.json") <| toString json
-        return 0
+        -- No HTML is emitted in this mode; fall through so logged errors still set the exit code.
+        return
       | .resumeFrom f =>
           try
             let ⟨tutorials, state⟩ ← SavedState.load f
             pure (tutorials, state)
           catch
-            | .userError e => logError e; return (1 : UInt32)
+            | .userError e => logger.reportError e; return
             | other => throw other
 
     if config.verbose then IO.println "Updating remote data"
     let remoteContent ← updateRemotes false config.remoteConfigFile (if config.verbose then IO.println else fun _ => pure ())
 
     -- Emit HTML
-    let ((), _) ← (emit tutorials navSite).run config.toConfig logError state extensionImpls {} {} components theme remoteContent
-
-    match ← errorCount.get with
-    | 0 => return 0
-    | 1 => IO.eprintln "An error was encountered!"; return 1
-    | n => IO.eprintln s!"{n} errors were encountered!"; return 1
+    let ((), _) ← (emit tutorials navSite).run config.toConfig logger state extensionImpls {} {} components theme remoteContent
 
   opts (cfg : Config) : List String → ReaderT ExtensionImpls IO Config
     | ("--output"::dir::more) => opts { cfg with destination := dir } more

--- a/src/verso-tutorial/VersoTutorial/Basic.lean
+++ b/src/verso-tutorial/VersoTutorial/Basic.lean
@@ -241,8 +241,8 @@ open Manual in
 Performs the traversal pass for tutorials until a fixed point is reached or `config.maxTraversals`
 passes have been run.
 -/
-def traverse (logError : String → IO Unit) (tutorials : Tutorials) (config : Manual.Config) : ReaderT ExtensionImpls IO (Tutorials × Manual.TraverseState) := do
-  let topCtxt : Manual.TraverseContext := {logError, draft := config.draft}
+def traverse (logger : Verso.Logger IO) (tutorials : Tutorials) (config : Manual.Config) : ReaderT ExtensionImpls IO (Tutorials × Manual.TraverseState) := do
+  let topCtxt : Manual.TraverseContext := { draft := config.draft }
   let mut state : Manual.TraverseState := .ofConfig ({ config with features := {} }).toHtmlConfig
   let mut tutorials := tutorials
   if config.verbose then
@@ -262,7 +262,7 @@ def traverse (logError : String → IO Unit) (tutorials : Tutorials) (config : M
     if config.verbose then
       IO.println s!"Traversal pass {i}"
     let startTime ← IO.monoMsNow
-    let (tutorials', state') ← tutorials.traverse1 (Genre.traverse Tutorial) |>.run extensionImpls topCtxt state
+    let (tutorials', state') ← tutorials.traverse1 (Genre.traverse Tutorial) |>.run extensionImpls topCtxt state logger
 
     let endTime ← IO.monoMsNow
     if config.verbose then

--- a/src/verso/Verso/BuildLog.lean
+++ b/src/verso/Verso/BuildLog.lean
@@ -122,7 +122,7 @@ public structure Logger (m : Type → Type) where
   /-- The warnings logged so far. -/
   warnings : m (Array LogMessage)
 
-instance [Applicative m] : Inhabited (Logger m) where
+public instance [Applicative m] : Inhabited (Logger m) where
   default.log _ _ _ := pure ()
   default.errors := pure default
   default.warnings := pure default

--- a/src/verso/Verso/BuildLog.lean
+++ b/src/verso/Verso/BuildLog.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+
+public import Lean.Data.Lsp.Basic
+import Lean.Message
+
+set_option doc.verso true
+set_option linter.missingDocs true
+
+/-!
+A small logging abstraction for error reporting while generating readable output from a Verso
+document.
+
+Errors are non-fatal: the build runs to completion, but the process exit code reflects whether any
+error was logged. Warnings never affect the exit code.
+-/
+
+namespace Verso
+
+/--
+The severity of a logged build message.
+-/
+public inductive Severity where
+  | error
+  | warning
+deriving DecidableEq, Repr, Inhabited, Lean.ToJson, Lean.FromJson
+
+/--
+A source location attached to a logged message.
+-/
+public inductive SourceSpan where
+  | none
+  | pos (p : Lean.Lsp.Position)
+  | range (r : Lean.Lsp.Range)
+deriving Lean.ToJson, Lean.FromJson
+
+public instance : Coe Lean.Lsp.Position SourceSpan := ⟨.pos⟩
+public instance : Coe Lean.Lsp.Range SourceSpan := ⟨.range⟩
+
+/--
+An optional position or range coerces to a {name}`SourceSpan`, with {name}`none` becoming
+{name}`SourceSpan.none`. This lets a call site assign an {lean}`Option Lean.Lsp.Position` directly
+to a {name}`SourceSpan` field.
+-/
+public instance [Coe α SourceSpan] : Coe (Option α) SourceSpan where
+  coe
+    | none => .none
+    | some x => x
+
+/--
+A resolved source location: a filename together with an optional source position.
+-/
+public structure SourceLoc where
+  file : String
+  span : SourceSpan := .none
+deriving Lean.ToJson, Lean.FromJson
+
+/-- Converts an LSP position (0-based) to a {name}`Lean.Position` (1-based line, 0-based column). -/
+def SourceLoc.toLeanPosition (p : Lean.Lsp.Position) : Lean.Position :=
+  ⟨p.line + 1, p.character⟩
+
+/--
+A logged build message.
+-/
+public structure LogMessage where
+  severity : Severity
+  text : String
+  loc : Option SourceLoc
+
+/--
+Formats a {name}`LogMessage` for printing to stderr.
+-/
+public def LogMessage.format (msg : LogMessage) : String :=
+  match msg.loc with
+  | none => msg.text
+  | some loc =>
+    match loc.span with
+    | .pos p =>
+      Lean.mkErrorStringWithPos loc.file (SourceLoc.toLeanPosition p) msg.text
+    | .range r =>
+      Lean.mkErrorStringWithPos loc.file (SourceLoc.toLeanPosition r.start) msg.text
+        (endPos := some (SourceLoc.toLeanPosition r.end))
+    | .none => s!"{loc.file}: {msg.text}"
+
+/--
+Monads that can emit build log messages.
+-/
+public class MonadBuildLog (m : Type → Type) where
+  log : Severity → String → (loc : Option SourceLoc := none) → m Unit
+
+/--
+Reports a build message of the given severity.
+-/
+public def report [MonadBuildLog m] (severity : Severity) (text : String) (loc : Option SourceLoc := none) : m Unit :=
+  MonadBuildLog.log severity text loc
+
+/--
+Reports an error. Errors do not abort the build, but they cause a non-zero exit code.
+-/
+public def reportError [MonadBuildLog m] (text : String) (loc : Option SourceLoc := none) : m Unit :=
+  MonadBuildLog.log .error text loc
+
+/--
+Reports a warning. Warnings do not affect the exit code.
+-/
+public def reportWarning [MonadBuildLog m] (text : String) (loc : Option SourceLoc := none) : m Unit :=
+  MonadBuildLog.log .warning text loc
+
+/--
+A logger is a structure that both emits messages (typically to stderr) and tracks them for later
+summarization.
+-/
+public structure Logger (m : Type → Type) where
+  /-- Records a message of the given severity at the given optional source location. -/
+  log : Severity → String → Option SourceLoc → m Unit
+  /-- The errors logged so far. -/
+  errors : m (Array LogMessage)
+  /-- The warnings logged so far. -/
+  warnings : m (Array LogMessage)
+
+instance [Applicative m] : Inhabited (Logger m) where
+  default.log _ _ _ := pure ()
+  default.errors := pure default
+  default.warnings := pure default
+
+/--
+Creates a fresh {name}`Logger` that accumulates messages in {name}`IO.Ref`s in addition to printing
+them to the current stderr (resolved at log time, rather than captured when {name}`Logger.new` is
+called).
+-/
+public def Logger.new : IO (Logger IO) := do
+  let errorsRef ← IO.mkRef #[]
+  let warningsRef ← IO.mkRef #[]
+  return {
+    log severity text loc := do
+      let msg : LogMessage := { severity, text, loc }
+      match severity with
+      | .error => errorsRef.modify (·.push msg)
+      | .warning => warningsRef.modify (·.push msg)
+      IO.eprintln msg.format
+    errors := errorsRef.get
+    warnings := warningsRef.get
+  }
+
+/--
+Lifts a logger into a more powerful monad.
+-/
+public def Logger.lift [MonadLiftT m m'] (logger : Logger m) : Logger m' where
+  log severity text loc := liftM (logger.log severity text loc)
+  errors := liftM logger.errors
+  warnings := liftM logger.warnings
+
+public instance [MonadLiftT IO m] : Coe (Logger IO) (Logger m) := ⟨Logger.lift⟩
+
+/--
+Reports an error directly through a {name}`Logger` value. Most callers should use
+{name}`Verso.reportError` instead.
+-/
+public def Logger.reportError (logger : Logger m) (text : String) (loc : Option SourceLoc := none) : m Unit :=
+  logger.log .error text loc
+
+/--
+Reports a warning directly through a {name}`Logger` value. Most callers should use
+{name}`Verso.reportWarning` instead.
+-/
+public def Logger.reportWarning (logger : Logger m) (text : String) (loc : Option SourceLoc := none) : m Unit :=
+  logger.log .warning text loc
+
+/--
+Whether any error has been logged.
+-/
+public def Logger.hasErrors [Functor m] (logger : Logger m) : m Bool :=
+  (!·.isEmpty) <$> logger.errors
+
+/--
+Whether any warning has been logged.
+-/
+public def Logger.hasWarnings [Functor m] (logger : Logger m) : m Bool :=
+  (!·.isEmpty) <$> logger.warnings
+
+/--
+The process exit code implied by the logged messages: non-zero if and only if an error was logged.
+-/
+public def Logger.exitCode [Monad m] (logger : Logger m) : m UInt32 := do
+  return if (← logger.hasErrors) then 1 else 0
+
+/--
+Prints a summary of the logged errors and returns the implied exit code, leaving the process to
+decide whether to propagate it.
+-/
+public def Logger.failIfErrors [Monad m] [MonadLiftT IO m] (logger : Logger m) : m UInt32 := do
+  match (← logger.errors).size with
+  | 0 => return 0
+  | 1 => liftM (IO.eprintln "An error was encountered!"); return 1
+  | n => liftM (IO.eprintln s!"{n} errors were encountered!"); return 1
+
+/--
+Runs a build's main action with a fresh {lean}`Logger IO`, then returns the exit code implied by the
+messages it logged (see {name}`Logger.failIfErrors`).
+-/
+public def withLogger [Monad m] [MonadLiftT IO m] (act : Logger IO → m Unit) : m UInt32 := do
+  let logger ← Logger.new
+  act logger
+  logger.failIfErrors
+
+/--
+Equips a monad with a {name}`Logger`, and thus a {name}`MonadBuildLog` instance.
+-/
+public abbrev BuildLogT (m : Type → Type) : Type → Type := ReaderT (Logger m) m
+
+/--
+Runs a {name}`BuildLogT` action with a fresh {lean}`Logger IO`, then returns the exit code implied
+by the messages it logged.
+
+This is the {lean}`BuildLogT IO` specialization of {name}`withLogger`, and it can simplify the
+syntax of call sites.
+-/
+public def runWithLogger (act : BuildLogT IO Unit) : IO UInt32 := do
+  withLogger (act.run ·)
+
+public instance {m m' : Type → Type}
+    [MonadReaderOf (Logger m') m] [Monad m] [MonadLiftT m' m] :
+    MonadBuildLog m where
+  log severity text loc := do
+    let logger : Logger m' ← readThe (Logger m')
+    liftM (logger.log severity text loc)
+
+-- These instances can't be merged because it would leave one of the semiOutParams of MonadLiftT
+-- underdetermined
+
+public instance {m m' : Type → Type} [MonadLiftT m' m] :
+    MonadLift (ReaderT (Logger m) m) (ReaderT (Logger m') m) where
+  monadLift act := fun logger => act logger.lift
+
+public instance {m' m n : Type → Type} [MonadLift m n] :
+    MonadLift (ReaderT (Logger m') m) (ReaderT (Logger m') n) where
+  monadLift act := fun logger => MonadLift.monadLift (act logger)

--- a/src/verso/Verso/Doc/Html.lean
+++ b/src/verso/Verso/Doc/Html.lean
@@ -8,26 +8,20 @@ public import Verso.Doc
 import Verso.Output.Html
 import Verso.Method
 public import Verso.Code.Highlighted
+public import Verso.BuildLog
 
 namespace Verso.Doc.Html
 
 open Verso Output Doc Html
+open Verso (Severity SourceSpan MonadBuildLog Logger)
 open Verso.Code (HighlightHtmlM)
 
-public structure Options  (m : Type → Type) where
+public structure Options where
   /-- The level of the top-level headers -/
   headerLevel : Nat := 1
-  logError : String → m Unit
 
-public def Options.reinterpret (lift : {α : _} → m α → m' α) (opts : Options m) : Options m' :=
-  {opts with
-    logError := fun msg => lift <| opts.logError msg}
-
-public def Options.lift [MonadLiftT m m'] (opts : Options m) : Options m' :=
-  opts.reinterpret MonadLiftT.monadLift
-
-public structure HtmlT.Context (genre : Genre) (m : Type → Type) where
-  options : Options m
+public structure HtmlT.Context (genre : Genre) where
+  options : Options
   traverseContext : genre.TraverseContext
   traverseState : genre.TraverseState
   /--
@@ -38,24 +32,17 @@ public structure HtmlT.Context (genre : Genre) (m : Type → Type) where
   linkTargets : Code.LinkTargets genre.TraverseContext
   codeOptions : Code.HighlightHtmlM.Options
 
-public def HtmlT.Context.reinterpret (lift : {α : _} → m α → m' α) (ctx : HtmlT.Context g m) : HtmlT.Context g m' :=
-  {ctx with
-    options := ctx.options.reinterpret lift}
-
-public def HtmlT.Context.lift [MonadLiftT m m'] (ctx : HtmlT.Context g m) : HtmlT.Context g m' :=
-  ctx.reinterpret monadLift
-
 public def HtmlT.Context.cast {g1 g2 : Genre}
-    (ctx : HtmlT.Context g1 m)
+    (ctx : HtmlT.Context g1)
     (context_eq : g1.TraverseContext = g2.TraverseContext := by trivial)
-    (state_eq : g1.TraverseState = g2.TraverseState := by trivial) : HtmlT.Context g2 m :=
+    (state_eq : g1.TraverseState = g2.TraverseState := by trivial) : HtmlT.Context g2 :=
   { ctx with
     traverseContext := context_eq ▸ ctx.traverseContext,
     traverseState := state_eq ▸ ctx.traverseState,
     linkTargets := context_eq ▸ ctx.linkTargets }
 
 public abbrev HtmlT (genre : Genre) (m : Type → Type) : Type → Type :=
-  ReaderT (HtmlT.Context genre m) (StateT (Verso.Code.Hover.State Html) m)
+  ReaderT (HtmlT.Context genre) (StateT (Verso.Code.Hover.State Html) m)
 
 public def HtmlT.cast {g1 g2 : Genre} (act : HtmlT g1 m α)
     (context_eq : g1.TraverseContext = g2.TraverseContext := by trivial)
@@ -64,10 +51,10 @@ public def HtmlT.cast {g1 g2 : Genre} (act : HtmlT g1 m α)
   fun ρ σ =>
     act (ρ.cast context_eq.symm state_eq.symm) σ
 
-public def HtmlT.options [Monad m] : HtmlT genre m (Options m) := do
+public def HtmlT.options [Monad m] : HtmlT genre m Options := do
   return (← read).options
 
-public def HtmlT.withOptions (opts : Options m → Options m) (act : HtmlT g m α) : HtmlT g m α :=
+public def HtmlT.withOptions (opts : Options → Options) (act : HtmlT g m α) : HtmlT g m α :=
   withReader (fun ctxt => {ctxt with options := opts ctxt.options}) act
 
 public def HtmlT.context [Monad m] : HtmlT genre m genre.TraverseContext := do
@@ -85,7 +72,9 @@ public def HtmlT.linkTargets [Monad m] : HtmlT genre m (Code.LinkTargets genre.T
 public def HtmlT.codeOptions [Monad m] : HtmlT genre m Code.HighlightHtmlM.Options := do
   return (← read).codeOptions
 
-public def HtmlT.logError [Monad m] (message : String) : HtmlT genre m Unit := do (← options).logError message
+@[deprecated "Use `Verso.reportError` instead." (since := "2026-05-29")]
+public def HtmlT.logError [Monad m] [MonadBuildLog (HtmlT genre m)] (message : String) : HtmlT genre m Unit :=
+  Verso.reportError message
 
 public instance [Monad m] : MonadLift (HighlightHtmlM genre) (HtmlT genre m) where
   monadLift act := do modifyGet (act ⟨← HtmlT.linkTargets, ← HtmlT.context, ← HtmlT.definitionIds, ← HtmlT.codeOptions⟩)
@@ -196,13 +185,13 @@ partial def Part.toHtml [Monad m] [GenreHtml g m] [TraversePart g] [TraverseBloc
 public instance [Monad m] [GenreHtml g m] [TraversePart g] [TraverseBlock g] : ToHtml g m (Part g) where
   toHtml p := private Part.toHtml p
 
-public instance : GenreHtml .none m where
+public instance : GenreHtml .none Id where
   part _ m := nomatch m
   block _ _ x := nomatch x
   inline _ x := nomatch x
 
 public defmethod Genre.toHtml (g : Genre) [ToHtml g m α]
-    (options : Options m) (context : g.TraverseContext) (state : g.TraverseState)
+    (options : Options) (context : g.TraverseContext) (state : g.TraverseState)
     (definitionIds : Lean.NameMap String)
     (linkTargets : Code.LinkTargets g.TraverseContext) (codeOptions : Code.HighlightHtmlM.Options)
     (x : α) : StateT (Verso.Code.Hover.State Html) m Html :=

--- a/src/verso/Verso/Doc/TeX.lean
+++ b/src/verso/Verso/Doc/TeX.lean
@@ -8,16 +8,17 @@ public import Std.Data.HashMap
 public import Verso.Doc
 import Verso.Method
 public import Verso.Output.TeX
+public import Verso.BuildLog
 
 namespace Verso.Doc.TeX
 
+open Verso (Severity SourceSpan MonadBuildLog Logger reportError reportWarning)
 open Verso.Output TeX
 
-public structure Options (g : Genre) (m : Type → Type) where
+public structure Options (g : Genre) where
   headerLevels : Array String := #["chapter", "section", "subsection", "subsubsection", "paragraph"]
   /-- The level of the top-level headers -/
   headerLevel : Option (Fin headerLevels.size)
-  logError : String → m Unit
 
 public structure TeXContext where
   /--
@@ -26,66 +27,64 @@ public structure TeXContext where
   -/
   inFragile : Bool := false
 
-public def Options.reinterpret (lift : {α : _} → m α → m' α) (opts : Options g m) : Options g m' :=
-  {opts with
-    logError := fun msg => lift <| opts.logError msg}
-
-public def Options.lift [MonadLiftT m m'] (opts : Options g m) : Options g m' :=
-  opts.reinterpret MonadLiftT.monadLift
-
 public structure OutputState where
   extraFiles : Std.HashMap String String := {}
 
 public abbrev TeXT (genre : Genre) (m : Type → Type) : Type → Type :=
-  ReaderT (Options genre m × genre.TraverseContext × genre.TraverseState × TeXContext) <|
+  ReaderT (Options genre × genre.TraverseContext × genre.TraverseState × TeXContext) <|
   StateT OutputState <|
   m
 
 public instance [Monad m] [Inhabited α] : Inhabited (TeXT g m α) := ⟨pure default⟩
 
-public def options [Monad m] : TeXT g m (Options g m) := do
+public def options [Monad m] : TeXT g m (Options g) := do
   pure (← read).fst
 
 public def state [Monad m] : TeXT g m g.TraverseState := do
   pure (← read).2.2.1
 
-public def logError [Monad m] (message : String) : TeXT g m Unit := do
-  (← options).logError message
+@[deprecated "Use `Verso.reportError` instead." (since := "2026-05-29")]
+public def logError [Monad m] [MonadBuildLog (TeXT g m)] (message : String) : TeXT g m Unit :=
+  reportError message
 
 public def texContext [Monad m] : TeXT g m TeXContext := do
   let ⟨_, _, _, ctx⟩ ← read
   pure ctx
 
-private def mkHeader [Monad m] (opts : Options g m)
+section
+variable [Monad m] [MonadBuildLog (TeXT g m)]
+
+private def mkHeader (opts : Options g)
     (level : Option (Fin opts.headerLevels.size)) (name : TeX) (label : Option String) : TeXT g m TeX := do
   let some i := level
-    | logError s!"No more header nesting available at {name.asString}"; return \TeX{\textbf{\Lean{name}}}
+    | reportError s!"No more header nesting available at {name.asString}"; return \TeX{\textbf{\Lean{name}}}
   let label := label.map (\TeX{\label{\Lean{.raw ·}}}) |>.getD .empty
   pure <| .raw (s!"\\{opts.headerLevels[i]}" ++ "{") ++ name ++ .raw "}" ++ label
 
-public def headerLevel [Monad m] (name : TeX) (level : Nat) (label : Option String) : TeXT g m TeX := do
+public def headerLevel (name : TeX) (level : Nat) (label : Option String) : TeXT g m TeX := do
   let opts ← options
   let lev := if h : level < opts.headerLevels.size then some ⟨level, h⟩ else none
   mkHeader opts lev name label
 
-public def header [Monad m] (name : TeX) (label : Option String) : TeXT g m TeX := do
+public def header (name : TeX) (label : Option String) : TeXT g m TeX := do
   let opts ← options
   mkHeader opts opts.headerLevel name label
 
-public def inFragile [Monad m] (act : TeXT g m α) : TeXT g m α :=
+public def inFragile (act : TeXT g m α) : TeXT g m α :=
   withReader (fun (opts, st, st', tctx) => (opts, st, st', { tctx with inFragile := true })) act
 
-public def inHeader [Monad m] (act : TeXT g m α) : TeXT g m α :=
+public def inHeader (act : TeXT g m α) : TeXT g m α :=
   withReader (fun (opts, st, st', tctx) => (bumpHeader opts, st, st', tctx)) act
 where
-  bumpHeader opts :=
+  bumpHeader (opts : Options g) : Options g :=
     if let some i := opts.headerLevel then
       if h : i.val + 1 < opts.headerLevels.size then
         {opts with headerLevel := some ⟨i.val + 1, h⟩}
       else {opts with headerLevel := none}
     else opts
+end
 
-public class GenreTeX (genre : Genre) (m : Type → Type) where
+public class GenreTeX (genre : Genre) (m : outParam (Type → Type)) where
   part
     (partTeX : Part genre → (label : Option String) → TeXT genre m TeX)
     (metadata : genre.PartMetadata) (contents : Part genre) : TeXT genre m TeX
@@ -184,7 +183,10 @@ public def verbatimInline [Monad m] [GenreTeX g m] (t : TeX) : TeXT g m Verso.Ou
 public def makeLink (url : String) (content : TeX) : TeX :=
   \TeX{\href{\Lean{.raw (escapeForTexHref url)}}{\Lean{content}}}
 
-public partial defmethod Inline.toTeX [Monad m] [GenreTeX g m] : Inline g → TeXT g m TeX
+section
+variable [Monad m] [MonadBuildLog (TeXT g m)] [GenreTeX g m]
+
+public partial defmethod Inline.toTeX : Inline g → TeXT g m TeX
   | .text str => pure <| .text str
   | .link content dest => do
     pure <| makeLink dest (← content.mapM Inline.toTeX)
@@ -203,7 +205,7 @@ public partial defmethod Inline.toTeX [Monad m] [GenreTeX g m] : Inline g → Te
   | .concat inlines => inlines.mapM toTeX
   | .other container content => GenreTeX.inline Inline.toTeX container content
 
-public partial defmethod Block.toTeX [Monad m] [GenreTeX g m] : Block g → TeXT g m TeX
+public partial defmethod Block.toTeX : Block g → TeXT g m TeX
   | .para xs => do
     pure <| (← xs.mapM Inline.toTeX)
   | .blockquote bs => do
@@ -220,7 +222,7 @@ public partial defmethod Block.toTeX [Monad m] [GenreTeX g m] : Block g → TeXT
   | .other container content => GenreTeX.block Inline.toTeX Block.toTeX container content
 
 
-public partial defmethod Part.toTeX [Monad m] [GenreTeX g m] (p : Part g) (label : Option String) : TeXT g m TeX :=
+public partial defmethod Part.toTeX (p : Part g) (label : Option String) : TeXT g m TeX :=
   match p.metadata with
   | .none => do
     pure \TeX{
@@ -232,3 +234,5 @@ public partial defmethod Part.toTeX [Monad m] [GenreTeX g m] (p : Part g) (label
     }
   | some m =>
     GenreTeX.part Part.toTeX m p.withoutMetadata
+
+end

--- a/src/verso/Verso/FS.lean
+++ b/src/verso/Verso/FS.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 module
+public import Verso.BuildLog
 set_option doc.verso true
 
 namespace Verso.FS
@@ -21,18 +22,20 @@ public def ensureDir (dir : System.FilePath) : IO Unit := do
     throw (↑ s!"Not a directory: {dir}")
 
 /--
-Recursively copies a directory of files from {name}`src` to {name}`tgt`. Any errors are logged using
-{name}`logError`, and paths that don't satisfy {name}`copyFile` are skipped.
+Recursively copies a directory of files from {name}`src` to {name}`tgt`. Any errors are reported via
+{name}`MonadBuildLog`, and paths that don't satisfy {name}`copyFile` are skipped.
 -/
-public partial def copyRecursively (logError : String → IO Unit) (src tgt : System.FilePath)
-    (copyFile : System.FilePath → IO Bool := fun _ => pure true) : IO Unit := do
-  unless (← copyFile src) do return
-  if (← src.metadata).type == .symlink then
-    logError s!"Can't copy '{src}' - symlinks not currently supported"
-  if ← src.isDir then
-    ensureDir tgt
-    for d in ← src.readDir do
-      copyRecursively logError d.path (tgt / d.fileName) (copyFile := copyFile)
+public partial def copyRecursively
+    [Monad m] [MonadLiftT IO m] [MonadBuildLog m]
+    (src tgt : System.FilePath) (copyFile : System.FilePath → IO Bool := fun _ => pure true) :
+    m Unit := do
+  unless ← (copyFile src : IO _) do return
+  if (← (src.metadata : IO _)).type == .symlink then
+    Verso.reportError s!"Can't copy '{src}' - symlinks not currently supported"
+  if ← (src.isDir : IO _) then
+    (ensureDir tgt : IO _)
+    for d in ← (src.readDir : IO _) do
+      copyRecursively d.path (tgt / d.fileName) (copyFile := copyFile)
   else
     withFile src .read fun h =>
       withFile tgt .write fun h' => do

--- a/test-projects/custom-genre/SimplePage.lean
+++ b/test-projects/custom-genre/SimplePage.lean
@@ -192,7 +192,7 @@ datatypes, but they require instances of `GenreHtml` or `GenreTeX` to render gen
 
 open Verso.Output Html
 
-instance : GenreHtml SimplePage IO where
+instance : GenreHtml SimplePage (BuildLogT IO) where
   -- When rendering a part to HTMl, extract the incoming links from the final traversal state and
   -- insert back-references
   part recur metadata | (.mk title titleString _ content subParts) => do
@@ -216,7 +216,7 @@ instance : GenreHtml SimplePage IO where
       pure <| renderDate d m y
     -- If no ID was assigned, log an error
     | .inr ⟨dest, none⟩, contents => do
-      HtmlT.logError s!"No ID assigned to section link of {dest}"
+      reportError s!"No ID assigned to section link of {dest}"
       pure {{<a href=s!"#{dest}"> {{← contents.mapM recur}} </a>}}
     -- Otherwise emit the right ID
     | .inr ⟨dest, some t⟩, contents => do
@@ -244,35 +244,25 @@ def render (doc : Part SimplePage) : IO UInt32 := do
     iterations := iterations + 1
   IO.println s!"Traversal completed after {iterations} iterations"
 
-  -- Render the resulting document to HTML. This requires a way to log errors.
-  let hadError ← IO.mkRef false
-  let logError str := do
-    hadError.set true
-    IO.eprintln str
+  -- Render the resulting document to HTML. This requires a logger to record errors and warnings.
+  Verso.withLogger fun logger => do
+    IO.println "Rendering HTML"
+    -- toHtml returns both deduplicated hover contents and the actual content.
+    -- Since we're not rendering Lean code, we can ignore the hover contents.
+    let (content, _) ← SimplePage.toHtml (m := BuildLogT IO) {} context state {} {} {} doc .empty |>.run logger
+    let html := {{
+      <html>
+        <head>
+          <title>{{doc.titleString}}</title>
+          <meta charset="utf-8"/>
+        </head>
+        <body>{{ content }}</body>
+      </html>
+    }}
 
-  IO.println "Rendering HTML"
-  -- toHtml returns both deduplicated hover contents and the actual content.
-  -- Since we're not rendering Lean code, we can ignore the hover contents.
-  let (content, _) ← SimplePage.toHtml {logError} context state {} {} {} doc .empty
-  let html := {{
-    <html>
-      <head>
-        <title>{{doc.titleString}}</title>
-        <meta charset="utf-8"/>
-      </head>
-      <body>{{ content }}</body>
-    </html>
-  }}
-
-  IO.println "Writing to index.html"
-  IO.FS.withFile "index.html" .write fun h => do
-    h.putStrLn html.asString
-
-  if (← hadError.get) then
-    IO.eprintln "Errors occurred while rendering"
-    pure 1
-  else
-    pure 0
+    IO.println "Writing to index.html"
+    IO.FS.withFile "index.html" .write fun h => do
+      h.putStrLn html.asString
 
 end SimplePage
 

--- a/test-projects/textbook/DemoTextbookMain.lean
+++ b/test-projects/textbook/DemoTextbookMain.lean
@@ -25,56 +25,59 @@ open Lean Elab Term Command in
 /--
 Extract the marked exercises and example code.
 -/
-partial def buildExercises (mode : Mode) (logError : String → IO Unit) (cfg : Config) (_state : TraverseState) (text : Part Manual) : IO Unit := do
+partial def buildExercises (mode : Mode) (cfg : Config) (_state : TraverseState) (text : Part Manual) : BuildLogT IO Unit := do
   let .multi := mode
     | pure ()
-  let code := (← part text |>.run {}).snd
-  let dest := cfg.destination / "example-code"
-  let some mainDir := mainFileName.parent
-    | throw <| IO.userError "Can't find directory of `DemoTextbookMain.lean`"
-
-  IO.FS.createDirAll <| dest
-  for ⟨fn, f⟩ in code do
-    -- Make sure the path is relative to that of this one
-    if let some fn' := fn.dropPrefix? mainDir.toString then
-      let fn' := fn'.toString.dropWhile (· ∈ System.FilePath.pathSeparators : Char → Bool)
-      let fn := dest / fn'.copy
-      fn.parent.forM IO.FS.createDirAll
-      if (← fn.pathExists) then IO.FS.removeFile fn
-      IO.FS.writeFile fn f
-    else
-      logError s!"Couldn't save example code. The path '{fn}' is not underneath '{mainDir}'."
+  let logger ← readThe (Logger IO)
+  saveExampleCode logger cfg text
 
 where
-  part : Part Manual → StateT (HashMap String String) IO Unit
+  saveExampleCode (logger : Verso.Logger IO) (cfg : Config) (text : Part Manual) : IO Unit := do
+    let code := (← part logger text |>.run {}).snd
+    let dest := cfg.destination / "example-code"
+    let some mainDir := mainFileName.parent
+      | throw <| IO.userError "Can't find directory of `DemoTextbookMain.lean`"
+
+    IO.FS.createDirAll <| dest
+    for ⟨fn, f⟩ in code do
+      -- Make sure the path is relative to that of this one
+      if let some fn' := fn.dropPrefix? mainDir.toString then
+        let fn' := fn'.toString.dropWhile (· ∈ System.FilePath.pathSeparators : Char → Bool)
+        let fn := dest / fn'.copy
+        fn.parent.forM IO.FS.createDirAll
+        if (← fn.pathExists) then IO.FS.removeFile fn
+        IO.FS.writeFile fn f
+      else
+        logger.reportError s!"Couldn't save example code. The path '{fn}' is not underneath '{mainDir}'."
+  part (logger : Verso.Logger IO) : Part Manual → StateT (HashMap String String) IO Unit
     | .mk _ _ _ intro subParts => do
-      for b in intro do block b
-      for p in subParts do part p
-  block : Block Manual → StateT (HashMap String String) IO Unit
+      for b in intro do block logger b
+      for p in subParts do part logger p
+  block (logger : Verso.Logger IO) : Block Manual → StateT (HashMap String String) IO Unit
     | .other which contents => do
       if which.name == ``Block.savedLean then
         let .arr #[.str fn, .str code] := which.data
-          | logError s!"Failed to deserialize saved Lean data {which.data}"
+          | logger.reportError s!"Failed to deserialize saved Lean data {which.data}"
         modify fun saved =>
           let prior := saved[fn]?.getD ""
           saved.insert fn (prior ++ code ++ "\n")
 
       if which.name == ``Block.savedImport then
         let .arr #[.str fn, .str code] := which.data
-          | logError s!"Failed to deserialize saved Lean import data {which.data}"
+          | logger.reportError s!"Failed to deserialize saved Lean import data {which.data}"
         modify fun saved =>
           let prior := saved[fn]?.getD ""
           saved.insert fn (code.trimAsciiEnd.copy ++ "\n" ++ prior)
 
-      for b in contents do block b
+      for b in contents do block logger b
     | .concat bs | .blockquote bs =>
-      for b in bs do block b
+      for b in bs do block logger b
     | .ol _ lis | .ul lis =>
       for li in lis do
-        for b in li.contents do block b
+        for b in li.contents do block logger b
     | .dl dis =>
       for di in dis do
-        for b in di.desc do block b
+        for b in di.desc do block logger b
     | .para .. | .code .. => pure ()
 
 

--- a/test-projects/website/DemoSite/About.lean
+++ b/test-projects/website/DemoSite/About.lean
@@ -38,7 +38,7 @@ block_component gallery where
 block_component image where
   toHtml id data _goI goB contents := do
     let .arr #[.str alt, .str url] := data
-      | HtmlT.logError s!"Failed to deserialize {data}"
+      | reportError s!"Failed to deserialize {data}"
         pure .empty
     pure {{
       <div class="image-item" id={{id}}>


### PR DESCRIPTION
Before, most Verso monads and functions threaded IO actions for logging errors, and each monad had a bespoke error reporting function. These grew organically, and were largely a set of IO actions attached to various reader contexts.

Now, they're all unified with a single logging type class, a single canonical monad transformer, as well as a single way to actually print the error report to the console when finished. Many type parameters on contexts could be removed. This makes it much easier to work on Verso.

Additionally, warning logs were added in order to prepare for an upcoming feature.