### PR TITLE
fix: parse decoded string literals with accurate decoded positions

### DIFF
--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -13,6 +13,7 @@ import Tests.DocTerm
 import Tests.HighlightedToTeX
 import Tests.Html
 import Tests.HtmlEntities
+import Tests.InlineStringPositions
 import Tests.Integration
 import Tests.Integration.SampleDoc
 import Tests.Integration.CodeContent

--- a/src/tests/Tests/InlineStringPositions.lean
+++ b/src/tests/Tests/InlineStringPositions.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2023-2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import Verso
+import Verso.Doc.Concrete.InlineString
+
+open Lean
+open Verso.Doc
+open Verso.SyntaxUtils
+
+set_option pp.rawOnError true
+
+/--
+info: Inline.concat #[Inline.text "Hello, ", Inline.emph #[Inline.bold #[Inline.text "emph"]]] : Inline Genre.none
+-/
+#guard_msgs in
+#check (inlines!"Hello, _*emph*_" : Inline .none)
+
+/--
+info: Block.concat #[Block.para #[Inline.text "Hello, ", Inline.emph #[Inline.bold #[Inline.text "emph"]]]] : Block Genre.none
+-/
+#guard_msgs in
+#check (blocks!"Hello, _*emph*_" : Block .none)
+
+/--
+Decodes `src` with `decode` (over the whole string) and checks the decoded contents, then that each
+`(lo, hi, text)` span re-extracts from the source to `text`. Comparing extracted *source* text keeps
+the checks independent of where the test sits in the file: each decoded byte range `[lo, hi)` must
+map back to the bytes that produced it.
+-/
+def checkDecode
+    (decode : String → String.Pos.Raw → String.Pos.Raw → String × Std.TreeMap String.Pos.Raw String.Pos.Raw)
+    (src expected : String) (spans : List (Nat × Nat × String)) : Bool :=
+  let (decoded, m) := decode src ⟨0⟩ src.rawEndPos
+  decoded == expected &&
+  spans.all fun ⟨lo, hi, text⟩ =>
+    (mapDecodedPos m ⟨lo⟩).extract src (mapDecodedPos m ⟨hi⟩) == text
+
+-- A markup delimiter after an escape maps past the multi-byte source of the escape, not by a
+-- constant shift: in `"a\n*b*"` the `*` is decoded byte 2 but source byte 4.
+#guard checkDecode decodeStrLitWithMap "\"a\\n*b*\"" "a\n*b*" [(1, 2, "\\n"), (2, 3, "*")]
+
+-- A unicode escape decodes to a multi-byte character whose source span is the whole `\uHHHH`.
+#guard checkDecode decodeStrLitWithMap "\"\\u00e9x\"" "éx" [(0, 2, "\\u00e9"), (2, 3, "x")]
+
+-- A string gap decodes to nothing; the character after it maps past the whole gap to source byte 6.
+#guard checkDecode decodeStrLitWithMap "\"a\\\n  b\"" "ab" [(1, 2, "b")]
+
+-- Raw string literals are not escape-decoded: `\n` stays two characters.
+#guard checkDecode decodeStrLitWithMap "r\"a\\n*\"" "a\\n*" [(3, 4, "*")]
+
+-- Every character a unicode escape: each decoded character maps to its whole six-byte `\uHHHH`.
+#guard checkDecode decodeStrLitWithMap "\"\\u002A\\u0062\\u002A\"" "*b*"
+  [(0, 1, "\\u002A"), (1, 2, "\\u0062"), (2, 3, "\\u002A")]
+
+-- A bare content region (no surrounding quotes) decodes the same way; this drives re-parsing escaped
+-- code spans as Lean.
+#guard checkDecode decodeContentWithMap "\\u004E\\u0061\\u0074" "Nat"
+  [(0, 1, "\\u004E"), (1, 2, "\\u0061"), (2, 3, "\\u0074")]
+
+-- Remapping reanchors a token's leading and trailing whitespace into the source string, so the
+-- syntax round-trips, and the token's positions become absolute.
+#guard
+  let src := "\"a\\n*b*\""
+  let (_, m) := decodeStrLitWithMap src ⟨0⟩ src.rawEndPos
+  let leading : Substring.Raw := { str := "a\n*b*", startPos := ⟨2⟩, stopPos := ⟨2⟩ }
+  let trailing : Substring.Raw := { str := "a\n*b*", startPos := ⟨3⟩, stopPos := ⟨3⟩ }
+  let remapped := remapSyntaxPos src (mapDecodedPos m) (Syntax.atom (.original leading ⟨2⟩ trailing ⟨3⟩) "*")
+  remapped.getPos? == some ⟨4⟩ &&
+  remapped.getTailPos? == some ⟨5⟩ &&
+  (remapped.getHeadInfo.getTrailing?.map (·.str)) == some src
+
+/--
+info: Inline.concat
+  #[Inline.text "a", Inline.linebreak "\n", Inline.text "b ",
+    Inline.emph #[Inline.bold #[Inline.text "c"]]] : Inline Genre.none
+-/
+#guard_msgs in
+#check (inlines!"a\nb _*c*_" : Inline .none)

--- a/src/tests/interactive/test-cases/title_escape_hover.lean
+++ b/src/tests/interactive/test-cases/title_escape_hover.lean
@@ -4,6 +4,7 @@ import VersoManual
 open Verso Genre Manual InlineLean
 
 #doc (Manual) "T \" {lean}`Nat`" =>
+                         --^ sync
                          --^ textDocument/hover
 
 Body paragraph.

--- a/src/tests/interactive/test-cases/title_escape_hover.lean
+++ b/src/tests/interactive/test-cases/title_escape_hover.lean
@@ -1,0 +1,9 @@
+import Verso
+import VersoManual
+
+open Verso Genre Manual InlineLean
+
+#doc (Manual) "T \" {lean}`Nat`" =>
+                         --^ textDocument/hover
+
+Body paragraph.

--- a/src/tests/interactive/test-cases/title_escape_hover.lean.expected.out
+++ b/src/tests/interactive/test-cases/title_escape_hover.lean.expected.out
@@ -1,0 +1,9 @@
+{"textDocument":
+ {"uri": "file:///src/tests/interactive/test-cases/title_escape_hover.lean"},
+ "position": {"line": 5, "character": 27}}
+{"range":
+ {"start": {"line": 5, "character": 27}, "end": {"line": 5, "character": 30}},
+ "contents":
+ {"value":
+  "```lean\nNat : Type\n```\n***\nThe natural numbers, starting at zero.\n\nThis type is special-cased by both the kernel and the compiler, and overridden with an efficient\nimplementation. Both use a fast arbitrary-precision arithmetic library (usually\n[GMP](https://gmplib.org/)); at runtime, `Nat` values that are sufficiently small are unboxed.\n\n***\n*import Init.Prelude*",
+  "kind": "markdown"}}

--- a/src/tests/interactive/test-cases/title_unicode_escape_hover.lean
+++ b/src/tests/interactive/test-cases/title_unicode_escape_hover.lean
@@ -1,0 +1,8 @@
+import Verso
+import VersoManual
+open Verso Genre Manual InlineLean
+
+#doc (Manual) "\u007B\u006C\u0065\u0061\u006E\u007D\u0060\u004E\u0061\u0074\u0060" =>
+                                                          --^ textDocument/hover
+
+Body.

--- a/src/tests/interactive/test-cases/title_unicode_escape_hover.lean
+++ b/src/tests/interactive/test-cases/title_unicode_escape_hover.lean
@@ -3,6 +3,7 @@ import VersoManual
 open Verso Genre Manual InlineLean
 
 #doc (Manual) "\u007B\u006C\u0065\u0061\u006E\u007D\u0060\u004E\u0061\u0074\u0060" =>
+                                                          --^ sync
                                                           --^ textDocument/hover
 
 Body.

--- a/src/tests/interactive/test-cases/title_unicode_escape_hover.lean.expected.out
+++ b/src/tests/interactive/test-cases/title_unicode_escape_hover.lean.expected.out
@@ -1,0 +1,10 @@
+{"textDocument":
+ {"uri":
+  "file:///src/tests/interactive/test-cases/title_unicode_escape_hover.lean"},
+ "position": {"line": 4, "character": 60}}
+{"range":
+ {"start": {"line": 4, "character": 57}, "end": {"line": 4, "character": 75}},
+ "contents":
+ {"value":
+  "```lean\nNat : Type\n```\n***\nThe natural numbers, starting at zero.\n\nThis type is special-cased by both the kernel and the compiler, and overridden with an efficient\nimplementation. Both use a fast arbitrary-precision arithmetic library (usually\n[GMP](https://gmplib.org/)); at runtime, `Nat` values that are sufficiently small are unboxed.\n\n***\n*import Init.Prelude*",
+  "kind": "markdown"}}

--- a/src/verso/Verso/Doc/ArgParse.lean
+++ b/src/verso/Verso/Doc/ArgParse.lean
@@ -692,35 +692,18 @@ def ValDesc.nat : ValDesc m Nat where
 instance : FromArgVal Nat m where
   fromArgVal := .nat
 
-open Lean.Parser in
+open Verso.SyntaxUtils in
+open Verso.Parser in
 /--
-Parses a sequence of Verso inline elements from a string literal. Returns a FileMap within which
-they can be related to their original source.
+Parses a sequence of Verso inline elements from a string literal. The resulting syntax is adjusted
+so that escapes in the string literal are accounted for in source positions.
 -/
-def ValDesc.inlinesString [MonadFileMap m] : ValDesc m (FileMap × TSyntaxArray `inline) where
+def ValDesc.inlinesString [MonadFileMap m] : ValDesc m (TSyntaxArray `inline) where
   description := doc!"a string that contains a sequence of inline elements"
   signature := .String
   get
-    | .str s => open Lean.Parser in do
-      let text ← getFileMap
-      let input := s.getString
-      let ictxt := mkInputContext input s!"string literal on line {s.raw.getPos?.map ((s!" on line {text.toPosition · |>.line}")) |>.getD ""}"
-      let env ← getEnv
-      let pmctx : ParserModuleContext := {env, options := {}}
-      let p := Verso.Parser.textLine -- TODO use upstreamed once public
-      let s' := p.run ictxt pmctx (getTokenTable env) (mkParserState input)
-      if s'.allErrors.isEmpty then
-        if s'.stxStack.size = 1 then
-          match s'.stxStack.back with
-          | .node _ _ contents => Pure.pure (FileMap.ofString input, contents.map (⟨·⟩))
-          | other => throwError "Unexpected syntax from Verso parser. Expected a node, got {other}"
-        else throwError "Unexpected internal stack size from Verso parser. Expected 1, got {s'.stxStack.size}"
-      else
-        let mut msg := "Failed to parse:"
-        for (p, _, e) in s'.allErrors do
-          let {line, column} := text.toPosition p
-          msg := msg ++ s!"  {line}:{column}: {toString e}\n    {repr <| p.extract input input.rawEndPos}\n"
-        throwError msg
+    | .str s => do
+      return (← parseMarkupStrLit textLine s).getArgs.map (⟨·⟩)
     | other => throwError "Expected string, got {repr other}"
 
 def ValDesc.messageSeverity : ValDesc m MessageSeverity where

--- a/src/verso/Verso/Doc/Concrete/InlineString.lean
+++ b/src/verso/Verso/Doc/Concrete/InlineString.lean
@@ -47,18 +47,3 @@ elab_rules : term <= ty
       { highlightDeduplicationTable := .none }
       (.init tk tk) <| inls.mapM (elabBlock ⟨·⟩)
     elabTerm (← ``(Block.concat #[ $[$tms],* ] )) ty
-
-
-set_option pp.rawOnError true
-
-/--
-info: Inline.concat #[Inline.text "Hello, ", Inline.emph #[Inline.bold #[Inline.text "emph"]]] : Inline Genre.none
--/
-#guard_msgs in
-#check (inlines!"Hello, _*emph*_" : Inline .none)
-
-/--
-info: Block.concat #[Block.para #[Inline.text "Hello, ", Inline.emph #[Inline.bold #[Inline.text "emph"]]]] : Block Genre.none
--/
-#guard_msgs in
-#check (blocks!"Hello, _*emph*_" : Block .none)

--- a/src/verso/Verso/Instances.lean
+++ b/src/verso/Verso/Instances.lean
@@ -26,6 +26,8 @@ instance : Quote String (k := ``docComment) where
 
 deriving instance Quote for String.Pos.Raw
 
+deriving instance Ord for String.Pos.Raw
+
 deriving instance Quote for SourceInfo
 
 deriving instance Quote for Position

--- a/src/verso/Verso/Parser.lean
+++ b/src/verso/Verso/Parser.lean
@@ -983,15 +983,16 @@ end Verso.Parser
 
 namespace Verso.Doc.Concrete
 open Verso.Parser
+open Verso.SyntaxUtils
 open Lean Elab Term
 
-public def stringToInlines [Monad m] [MonadError m] [MonadEnv m] [MonadQuotation m] (s : StrLit) : m (Array Syntax) :=
+public def stringToInlines [Monad m] [MonadFileMap m] [MonadError m] [MonadEnv m] [MonadQuotation m] (s : StrLit) : m (Array Syntax) :=
   withRef s do
-    return (← textLine.parseString s.getString).getArgs
+    return (← parseMarkupStrLit textLine s).getArgs
 
 open Lean Elab Term in
-public def stringToBlocks [Monad m] [MonadError m] [MonadEnv m] [MonadQuotation m] (s : StrLit) : m (Array Syntax) :=
+public def stringToBlocks [Monad m] [MonadFileMap m] [MonadError m] [MonadEnv m] [MonadQuotation m] (s : StrLit) : m (Array Syntax) :=
   withRef s do
-    return (← (blocks {}).parseString s.getString).getArgs
+    return (← parseMarkupStrLit (blocks {}) s).getArgs
 
 end Verso.Doc.Concrete

--- a/src/verso/Verso/SyntaxUtils.lean
+++ b/src/verso/Verso/SyntaxUtils.lean
@@ -5,6 +5,7 @@ Author: David Thrane Christiansen
 -/
 module
 public import Lean.Parser.Types
+public import Std.Data.TreeMap
 public meta import Verso.Instances
 import Verso.Instances
 import Verso.Method
@@ -236,15 +237,117 @@ public defmethod ParserFn.parseString [Monad m] [MonadError m] [MonadEnv m] (p :
   else
     pure stk[0]
 
+open Lean.Syntax in
+/--
+Decodes the region of `source` between `startPos` and `stopPos`, which holds the bare contents of a
+string literal (no surrounding quotes), applying escape sequences. Returns the decoded string and a
+map from decoded byte positions to absolute source positions.
+
+The map records, for each decoded character, the position where its source representation begins,
+followed by a final entry pairing the end of the decoded string with `stopPos`.
+-/
+public def decodeContentWithMap (source : String) (startPos stopPos : String.Pos.Raw) :
+    String × Std.TreeMap String.Pos.Raw String.Pos.Raw := Id.run do
+  let mut i := startPos
+  let mut decoded := ""
+  let mut map : Std.TreeMap String.Pos.Raw String.Pos.Raw := {}
+  while i.byteIdx < stopPos.byteIdx do
+    let c := i.get source
+    if c == '\\' then
+      if let some (ch, i') := decodeQuotedChar source (i.next source) then
+        map := map.insert decoded.rawEndPos i
+        decoded := decoded.push ch
+        i := i'
+      else if let some i' := decodeStringGap source (i.next source) then
+        i := i'
+      else
+        break
+    else
+      map := map.insert decoded.rawEndPos i
+      decoded := decoded.push c
+      i := i.next source
+  return (decoded, map.insert decoded.rawEndPos i)
+
+/--
+Decodes the contents of a string literal, returning the decoded string together with a map from byte
+positions in the decoded string to absolute byte positions in `source`. `startPos` and `stopPos`
+delimit the literal, including its quotes, within `source`.
+-/
+public def decodeStrLitWithMap (source : String) (startPos stopPos : String.Pos.Raw) :
+    String × Std.TreeMap String.Pos.Raw String.Pos.Raw :=
+  if startPos.get source == 'r' then Id.run do
+    -- Raw string literals are not escape-decoded.
+    let mut i := startPos.next source
+    let mut num := 0
+    while i.get source == '#' do
+      num := num + 1
+      i := i.next source
+    let contentStart := i.next source
+    let contentClose : String.Pos.Raw := ⟨stopPos.byteIdx - (num + 1)⟩
+    let decoded := contentStart.extract source contentClose
+    return (decoded, Std.TreeMap.empty.insert ⟨0⟩ contentStart |>.insert decoded.rawEndPos contentClose)
+  else
+    -- The contents lie between the opening and closing quotes.
+    decodeContentWithMap source (startPos.next source) ⟨stopPos.byteIdx - 1⟩
+
+/--
+Maps a byte position in a decoded string to the corresponding absolute source position, using a map
+produced by `decodeStrLitWithMap`.
+-/
+public def mapDecodedPos (map : Std.TreeMap String.Pos.Raw String.Pos.Raw) (p : String.Pos.Raw) :
+    String.Pos.Raw :=
+  match map.getEntryLE? p with
+  | some (decodedPos, sourcePos) => ⟨sourcePos.byteIdx + (p.byteIdx - decodedPos.byteIdx)⟩
+  | none => p
+
+private def remapSubstring (source : String) (mapPos : String.Pos.Raw → String.Pos.Raw)
+    (w : Substring.Raw) : Substring.Raw :=
+  { str := source, startPos := mapPos w.startPos, stopPos := mapPos w.stopPos }
+
+private def remapSourceInfo (source : String) (mapPos : String.Pos.Raw → String.Pos.Raw) :
+    SourceInfo → SourceInfo
+  | .original leading pos trailing endPos =>
+    .original
+      (remapSubstring source mapPos leading) (mapPos pos)
+      (remapSubstring source mapPos trailing) (mapPos endPos)
+  | .synthetic pos endPos canonical =>
+    .synthetic (mapPos pos) (mapPos endPos) canonical
+  | .none => .none
+
+/--
+Rewrites every source position in `stx`, mapping positions in a decoded string back to absolute
+positions in `source`. The leading and trailing whitespace of original tokens is reanchored to
+`source`, so the syntax round-trips back to the original text.
+-/
+public partial def remapSyntaxPos (source : String) (mapPos : String.Pos.Raw → String.Pos.Raw) :
+    Syntax → Syntax
+  | .node info kind args =>
+    .node (remapSourceInfo source mapPos info) kind (args.map (remapSyntaxPos source mapPos))
+  | .atom info val =>
+    .atom (remapSourceInfo source mapPos info) val
+  | .ident info rawVal val preresolved =>
+    .ident (remapSourceInfo source mapPos info) rawVal val preresolved
+  | .missing => .missing
+
 /--
 Parses an original string literal.
 
 The provided string literal is used only for source positions; the `FileMap` is used to acquire the
-actual string contents.
+actual string contents. When the literal's source text differs from its contents because of escape
+sequences, the decoded contents are parsed and the resulting positions are mapped back to the
+source.
 -/
 public def parseStrLitWith [Monad m] [MonadLog m] [MonadEnv m] [MonadOptions m] [MonadError m] [AddMessageContext m] (p : ParserFn) (input : StrLit) : m Syntax := do
-  let (ictx, startPos) ← strLitInputContext input.raw (← getFileName)
   let text ← getFileMap
+  if let some startPos := input.raw.getPos? then
+    let endPos := input.raw.getTailPos?.getD startPos
+    let stopPos := if endPos > text.source.rawEndPos then text.source.rawEndPos else endPos
+    if startPos.extract text.source stopPos != input.getString then
+      let (decoded, posMap) := decodeContentWithMap text.source startPos stopPos
+      if decoded == input.getString then
+        return ← parseDecoded p decoded (mapDecodedPos posMap) text
+  -- The contents appear verbatim in the source: parse it directly for exact source positions.
+  let (ictx, startPos) ← strLitInputContext input.raw (← getFileName)
   let s := { mkParserState text.source with pos := startPos }
   let env ← getEnv
   let s := p.run ictx { env, options := ← getOptions } (getTokenTable env) s
@@ -260,6 +363,20 @@ public def parseStrLitWith [Monad m] [MonadLog m] [MonadEnv m] [MonadOptions m] 
     return s.stxStack.back
   else
     throwErrorAt input "Unparsed input: `{s.pos.extract text.source ictx.endPos}`"
+where
+  parseDecoded (p : ParserFn) (decoded : String) (mapPos : String.Pos.Raw → String.Pos.Raw) (text : FileMap) : m Syntax := do
+    let env ← getEnv
+    let ictx := mkInputContext decoded (← getFileName)
+    let s := p.run ictx { env, options := ← getOptions } (getTokenTable env) (mkParserState decoded)
+    if !s.allErrors.isEmpty then
+      for (pos, stk, err) in s.allErrors do
+        let serr := mkSyntaxError ictx pos stk err
+        logErrorAt (Syntax.atom (.synthetic (mapPos pos) (mapPos pos)) "") serr.text
+      return .missing
+    else if ictx.atEnd s.pos then
+      return remapSyntaxPos text.source mapPos s.stxStack.back
+    else
+      throwErrorAt input "Unparsed input: `{s.pos.extract decoded ictx.endPos}`"
 
 /--
 Parses an original string literal as part of a syntax category.
@@ -269,6 +386,43 @@ actual string contents.
 -/
 public def parseStrLitAsCategory [Monad m] [MonadLog m] [MonadEnv m] [MonadOptions m] [MonadError m] [AddMessageContext m] (catName : Name) (input : StrLit) : m Syntax :=
   parseStrLitWith (andthenFn whitespace (categoryParserFnImpl catName)) input
+
+/--
+Parses the contents of a string literal as Verso markup using `p`, producing syntax whose source
+positions are absolute positions in the enclosing file. Escape sequences are decoded before parsing,
+and the resulting positions are mapped back to the original source.
+
+When the literal has no source position (for example, one synthesized by a macro), the contents are
+parsed directly and positions refer to the decoded string.
+-/
+public def parseMarkupStrLit [Monad m] [MonadFileMap m] [MonadEnv m] [MonadError m]
+    (p : ParserFn) (s : StrLit) : m Syntax := do
+  let text ← getFileMap
+  let env ← getEnv
+  let pmctx : ParserModuleContext := { env, options := {} }
+  let (input, mapPos, remap) :=
+    match s.raw.getPos?, s.raw.getTailPos? with
+    | some startPos, some stopPos =>
+      let (input, posMap) := decodeStrLitWithMap text.source startPos stopPos
+      if input == s.getString then
+        let mapPos := mapDecodedPos posMap
+        (input, mapPos, remapSyntaxPos text.source mapPos)
+      else
+        (s.getString, id, id)
+    | _, _ => (s.getString, id, id)
+  let st := p.run (mkInputContext input "<string literal>") pmctx (getTokenTable env) (mkParserState input)
+  if st.allErrors.isEmpty then
+    if st.stxStack.size = 1 then
+      return remap st.stxStack.back
+    else
+      throwError "Unexpected syntax from Verso parser: expected a single node, got {st.stxStack.size}"
+  else
+    let mut msg := "Failed to parse Verso markup:"
+    for (errPos, _, e) in st.allErrors do
+      let pos := text.toPosition (mapPos errPos)
+      msg := msg ++ s!"\n  {pos.line}:{pos.column}: {toString e}"
+    let blamePos := mapPos (((st.allErrors[0]?).map (·.1)).getD ⟨0⟩)
+    throwErrorAt (Syntax.atom (.synthetic blamePos blamePos) "") msg
 
 open Lean.Parser in
 /--


### PR DESCRIPTION
This fixes an issue where syntax resulting from parsed string literals would have bogus position information, which got in the way of some LSP features. Even worse, if this syntax was used in a point of interest, it panicked (after the merge of #771).