### PR TITLE
chore: migrate to module system

### DIFF
--- a/doc/UsersGuide/Manuals.lean
+++ b/doc/UsersGuide/Manuals.lean
@@ -174,6 +174,9 @@ results in
 
 {docstring List.forM}
 
+When using the module system, docstrings from imported modules are not available by default when building from the command line.
+To include these docstrings in a document, use `import all` to import them.
+
 The {name}`docstring` command takes a positional parameter which is the documented name.
 It also accepts the following optional named parameters:
 

--- a/src/cli/VersoMain.lean
+++ b/src/cli/VersoMain.lean
@@ -4,12 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Lean.Data.Json
-import Lean.Data.NameMap
-import Std.Data.HashMap
-import Std.Time.DateTime
+module
+public import Lean.Data.Json
+public import Lean.Data.NameMap
+public import Std.Data.HashMap
+public import Std.Time.DateTime
 
-import MultiVerso
+public import MultiVerso
+
+public section
 
 open Lean (Json NameMap)
 open Verso.Multi

--- a/src/multi-verso/MultiVerso.lean
+++ b/src/multi-verso/MultiVerso.lean
@@ -281,7 +281,7 @@ public structure RefDomain where
   contents : HashMap String (Array RefObject)
 deriving Inhabited, Repr
 
-instance : GetElem? RefDomain String (Array RefObject) fun dom name => name ∈ dom.contents where
+public instance : GetElem? RefDomain String (Array RefObject) fun dom name => name ∈ dom.contents where
   getElem dom name ok := dom.contents[name]'ok
   getElem? dom name := dom.contents[name]?
 
@@ -478,10 +478,10 @@ private def RemoteInfo.structBEq (x y : RemoteInfo) : Bool :=
 private unsafe def RemoteInfo.fastBEq (x y : RemoteInfo) : Bool :=
   if ptrEq x y then true else RemoteInfo.structBEq x y
 
-instance : Membership Name RemoteInfo where
+public instance : Membership Name RemoteInfo where
   mem ri dom := dom ∈ ri.domains
 
-instance : GetElem? RemoteInfo Name RefDomain (fun ri d => d ∈ ri) where
+public instance : GetElem? RemoteInfo Name RefDomain (fun ri d => d ∈ ri) where
   getElem xs x ok := xs.domains[x]'ok
   getElem? xs x := xs.domains[x]?
 

--- a/src/multi-verso/MultiVerso/Path.lean
+++ b/src/multi-verso/MultiVerso/Path.lean
@@ -32,7 +32,7 @@ Adds {lean}`component` to the end of {name}`path`.
 public def Path.join (path : Path) (component : String) : Path :=
   Array.push path component
 
-instance : HDiv Path String Path := ⟨Path.join⟩
+public instance : HDiv Path String Path := ⟨Path.join⟩
 
 /--
 Retrieves a string that can be used as a link.

--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -10,7 +10,11 @@ import Tests.Golden
 import Tests.CommentSkipping
 import Tests.DocElabExtensions.Use
 import Tests.DocTerm
+import Tests.DocstringMissing
+import Tests.DocstringMissingLegacy
 import Tests.HighlightedToTeX
+import Tests.ExpanderSignatures
+import Tests.ExpanderSignaturesLegacy
 import Tests.Html
 import Tests.HtmlEntities
 import Tests.InlineStringPositions

--- a/src/tests/Tests/Basic.lean
+++ b/src/tests/Tests/Basic.lean
@@ -3,7 +3,10 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
+module
+public import Verso
+public meta import Verso
+public section
 namespace Verso.BasicTest
 set_option guard_msgs.diff true
 set_option pp.rawOnError true

--- a/src/tests/Tests/CommentSkipping.lean
+++ b/src/tests/Tests/CommentSkipping.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Tests.CommentSkipping.Doc
-import Tests.CommentSkipping.Doc2
+module
+public meta import Tests.CommentSkipping.Doc
+public meta import Tests.CommentSkipping.Doc2
+public section
 
 /-!
 This test ensures that Lean's parser doesn't skip Lean comment syntax while parsing Verso blocks as

--- a/src/tests/Tests/CommentSkipping/Doc.lean
+++ b/src/tests/Tests/CommentSkipping/Doc.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-
-import Verso
+module
+public import Verso
+public meta import Verso
+public section
 
 /-!
 This test ensures that Lean's parser doesn't skip Lean comment syntax while parsing Verso blocks as

--- a/src/tests/Tests/CommentSkipping/Doc2.lean
+++ b/src/tests/Tests/CommentSkipping/Doc2.lean
@@ -3,8 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-
-import Verso
+module
+public import Verso
+public meta import Verso
+public section
 
 /-!
 This test checks a regression that happened where syntax that contained trailing null nodes wouldn't

--- a/src/tests/Tests/DocElabExtensions/Define.lean
+++ b/src/tests/Tests/DocElabExtensions/Define.lean
@@ -3,8 +3,13 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio Jesus Gallego Arias
 -/
-import Tests.DocElabExtensions.LocalExtension
-import VersoManual
+module
+public import Tests.DocElabExtensions.LocalExtension
+public meta import Tests.DocElabExtensions.LocalExtension
+public import VersoManual
+public meta import VersoManual
+
+public section
 
 namespace Verso.Tests.DocElabExtensions
 
@@ -22,19 +27,19 @@ open Lean
 #register_inherited_test_local_entry
 
 @[role]
-def inheritedRole : RoleExpanderOf Unit
+meta def inheritedRole : RoleExpanderOf Unit
   | (), _contents => ``(Doc.Inline.text "inherited role")
 
 @[code_block]
-def inheritedCode : CodeBlockExpanderOf Unit
+meta def inheritedCode : CodeBlockExpanderOf Unit
   | (), str => ``(Doc.Block.code $(quote str.getString))
 
 @[directive]
-def inheritedDirective : DirectiveExpanderOf Unit
+meta def inheritedDirective : DirectiveExpanderOf Unit
   | (), blocks => do
     let blocks ← blocks.mapM elabBlock
     ``(Doc.Block.concat #[$blocks,*])
 
 @[block_command]
-def inheritedCommand : BlockCommandOf Unit
+meta def inheritedCommand : BlockCommandOf Unit
   | () => ``(Doc.Block.para #[Doc.Inline.text "inherited command"])

--- a/src/tests/Tests/DocElabExtensions/LocalExtension.lean
+++ b/src/tests/Tests/DocElabExtensions/LocalExtension.lean
@@ -3,8 +3,13 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio Jesus Gallego Arias
 -/
-import Lean.Elab.Command
-import Verso.EnvExtension
+module
+public import Lean.Elab.Command
+public meta import Lean.Elab.Command
+public import Verso.EnvExtension
+public meta import Verso.EnvExtension
+
+public section
 
 namespace Verso.Tests.DocElabExtensions
 
@@ -17,14 +22,14 @@ extension are empty.
 
 open Lean Elab Command
 
-private def addTestEntry (entries : Lean.NameMap (Array Name)) (key value : Name) :
+meta def addTestEntry (entries : Lean.NameMap (Array Name)) (key value : Name) :
     Lean.NameMap (Array Name) :=
   entries.insert key <| (entries.find? key |>.getD #[]).push value
 
-private abbrev TestLocalExtension :=
+abbrev TestLocalExtension :=
   LocalPersistentEnvExtension (Name × Array Name) (Name × Name) (Lean.NameMap (Array Name))
 
-initialize testLocalExt : TestLocalExtension ←
+public meta initialize testLocalExt : TestLocalExtension ←
   LocalPersistentEnvExtension.register {
     name := `Verso.Tests.DocElabExtensions.testLocalExt
     mkInitialState := pure {}
@@ -39,10 +44,10 @@ initialize testLocalExt : TestLocalExtension ←
       .uniform entries.toArray
   }
 
-def testLocalExtensionEntries (env : Environment) (key : Name) : Array Name :=
+meta def testLocalExtensionEntries (env : Environment) (key : Name) : Array Name :=
   testLocalExt.getState env |>.find? key |>.getD #[]
 
-def testLocalExtensionModuleEntries (env : Environment) (moduleIdx : ModuleIdx) :
+meta def testLocalExtensionModuleEntries (env : Environment) (moduleIdx : ModuleIdx) :
     Array (Name × Array Name) :=
   testLocalExt.getModuleEntries env moduleIdx
 

--- a/src/tests/Tests/DocElabExtensions/Middle.lean
+++ b/src/tests/Tests/DocElabExtensions/Middle.lean
@@ -3,7 +3,10 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio Jesus Gallego Arias
 -/
-import Tests.DocElabExtensions.Define
+module
+public import Tests.DocElabExtensions.Define
+
+public section
 
 namespace Verso.Tests.DocElabExtensions
 

--- a/src/tests/Tests/DocElabExtensions/Use.lean
+++ b/src/tests/Tests/DocElabExtensions/Use.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio Jesus Gallego Arias
 -/
-import Tests.DocElabExtensions.Middle
+module
+public import Tests.DocElabExtensions.Middle
+public meta import Tests.DocElabExtensions.Middle
+
+public section
 
 namespace Verso.Tests.DocElabExtensions
 

--- a/src/tests/Tests/DocTerm.lean
+++ b/src/tests/Tests/DocTerm.lean
@@ -3,8 +3,12 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
+module
 
-import Verso
+public import Verso
+public meta import Verso
+
+public section
 
 def docTermSmoke : Verso.Doc.VersoDoc .none := #doc (.none) "Term doc" =>
 # Term heading

--- a/src/tests/Tests/DocstringMissing.lean
+++ b/src/tests/Tests/DocstringMissing.lean
@@ -1,0 +1,30 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import VersoManual
+
+open Lean Elab Command
+open Verso.Genre.Manual
+
+set_option guard_msgs.diff true
+
+/-!
+When a docstring is missing in a module document, the error
+message names the declaration's module and suggests `import all` so
+the docstrings load in batch mode. `Signature.mk` is an imported,
+undocumented constructor, so it exercises this hint.
+-/
+
+/--
+error: 'Verso.Genre.Manual.Signature.mk' is not documented.
+
+Hint: If `Signature.mk` is documented, add `import all VersoManual.Docstring.Basic` to import docstrings from `VersoManual.Docstring.Basic`.
+
+Set option 'verso.docstring.allowMissing' to 'true' to allow missing docstrings.
+-/
+#guard_msgs in
+run_cmd do
+  discard <| getDocString? (← getEnv) ``Verso.Genre.Manual.Signature.mk

--- a/src/tests/Tests/DocstringMissingLegacy.lean
+++ b/src/tests/Tests/DocstringMissingLegacy.lean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import VersoManual
+
+open Lean Elab Command
+open Verso.Genre.Manual
+
+set_option guard_msgs.diff true
+
+/-!
+The `import all` hint is specific to module documents, where a plain `import` does not load
+docstrings. A non-`module` document loads docstrings from a plain `import`, so the
+diagnostic omits the hint. This is the non-`module` counterpart of `Tests/DocstringMissing.lean`.
+-/
+
+/--
+error: 'Verso.Genre.Manual.Signature.mk' is not documented.
+
+Set option 'verso.docstring.allowMissing' to 'true' to allow missing docstrings.
+-/
+#guard_msgs in
+run_cmd do
+  discard <| getDocString? (← getEnv) ``Verso.Genre.Manual.Signature.mk

--- a/src/tests/Tests/Elab.lean
+++ b/src/tests/Tests/Elab.lean
@@ -3,8 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Rob Simmons
 -/
-import Verso
-import VersoManual
+module
+public import Verso
+public meta import Verso
+public import VersoManual
+public meta import VersoManual
+public section
 namespace Verso.BlocksTest
 open Genre Manual InlineLean
 
@@ -23,7 +27,7 @@ open Lean
 open Doc.Elab
 
 @[role]
-def insertSyntaxGivingRiseToMetavariables : RoleExpanderOf Unit
+meta def insertSyntaxGivingRiseToMetavariables : RoleExpanderOf Unit
   | (), _ => do
     ``(Doc.Inline.text s!"{4}")
 
@@ -33,7 +37,7 @@ I can {insertSyntaxGivingRiseToMetavariables}[]
 :::::::
 
 @[role]
-def totallyUndefined : RoleExpanderOf Unit
+meta def totallyUndefined : RoleExpanderOf Unit
   | (), _content => do
     `(_)
 

--- a/src/tests/Tests/ExpanderSignatures.lean
+++ b/src/tests/Tests/ExpanderSignatures.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+
+public section
+
+namespace Verso.ExpanderSignatureTest.Module
+set_option guard_msgs.diff true
+
+open Lean Elab Command
+open Verso Doc Elab ArgParse
+
+/-!
+The argument signature of every role/directive/code block is precomputed into a constant when the
+expander is defined. These tests pin down that the signature is computed correctly, and in
+particular that defining an expander whose parser is built from `.many`/`partial` combinators does
+not crash when the module holding the constant is loaded.
+
+This file defines the expanders in a `module`, so the parsers are `meta`. `Tests/ExpanderSignaturesLegacy.lean`
+checks the same thing for a non-`module` source file.
+-/
+
+structure ManyArgs where
+  tag : Name
+  attrs : Array (String × String)
+
+meta def manyAttrs : ArgParse DocElabM (Array (String × String)) := List.toArray <$> .many oneAttr
+where
+  oneAttr : ArgParse DocElabM (String × String) :=
+    (fun (k, v) => (k.getId.toString (escape := false), v)) <$> .anyNamed `attr .string
+
+meta instance : FromArgs ManyArgs DocElabM where
+  fromArgs := ManyArgs.mk <$> .positional `tag .name <*> manyAttrs
+
+@[directive]
+meta def manyDir : DirectiveExpanderOf ManyArgs
+  | _, _ => do ``(Verso.Doc.Block.concat #[])
+
+structure SimpleArgs where
+  tag : Name
+  title : Option String
+  loud : Bool
+
+meta instance : FromArgs SimpleArgs DocElabM where
+  fromArgs := SimpleArgs.mk <$> .positional `tag .name <*> .named `title .string true <*> .flag `loud false "Be loud?"
+
+@[directive]
+meta def simpleDir : DirectiveExpanderOf SimpleArgs
+  | _, _ => do ``(Verso.Doc.Block.concat #[])
+
+/--
+info: simpleDir: Positional: `tag : Ident — a name`
+
+Named: `title : String` (optional) — a string
+
+Flag* `loud` (default `false`) - Be loud?
+---
+info: manyDir: ```
+tag :
+Ident
+attr : String (key/value)*
+```
+-/
+#guard_msgs in
+run_cmd do
+  let report (label : String) (s : Option SigDoc) : CommandElabM Unit :=
+    match s with
+    | some sd => do logInfo m!"{label}: {← sd.toString}"
+    | none => logInfo m!"{label}: «no signature»"
+  report "simpleDir" (sig SimpleArgs)
+  report "manyDir" (sig ManyArgs)

--- a/src/tests/Tests/ExpanderSignaturesLegacy.lean
+++ b/src/tests/Tests/ExpanderSignaturesLegacy.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import Verso
+import VersoManual
+
+namespace Verso.ExpanderSignatureTest.Legacy
+set_option guard_msgs.diff true
+
+open Lean Elab Command
+open Verso Doc Elab ArgParse
+
+/-!
+The non-`module` counterpart of `Tests/ExpanderSignatures.lean`. The expanders are defined in a
+legacy source file, so the parsers are ordinary (non-`meta`) definitions and the generated
+signature constants are not marked `meta`. The signatures must still be computed correctly, and
+loading this file must not crash on the `.many` parser's constant.
+-/
+
+structure ManyArgs where
+  tag : Name
+  attrs : Array (String × String)
+
+def manyAttrs : ArgParse DocElabM (Array (String × String)) := List.toArray <$> .many oneAttr
+where
+  oneAttr : ArgParse DocElabM (String × String) :=
+    (fun (k, v) => (k.getId.toString (escape := false), v)) <$> .anyNamed `attr .string
+
+instance : FromArgs ManyArgs DocElabM where
+  fromArgs := ManyArgs.mk <$> .positional `tag .name <*> manyAttrs
+
+@[directive]
+def manyDir : DirectiveExpanderOf ManyArgs
+  | _, _ => do ``(Verso.Doc.Block.concat #[])
+
+structure SimpleArgs where
+  tag : Name
+  title : Option String
+  loud : Bool
+
+instance : FromArgs SimpleArgs DocElabM where
+  fromArgs := SimpleArgs.mk <$> .positional `tag .name <*> .named `title .string true <*> .flag `loud false "Be loud?"
+
+@[directive]
+def simpleDir : DirectiveExpanderOf SimpleArgs
+  | _, _ => do ``(Verso.Doc.Block.concat #[])
+
+/--
+info: simpleDir: Positional: `tag : Ident — a name`
+
+Named: `title : String` (optional) — a string
+
+Flag* `loud` (default `false`) - Be loud?
+---
+info: manyDir: ```
+tag :
+Ident
+attr : String (key/value)*
+```
+-/
+#guard_msgs in
+run_cmd do
+  let report (label : String) (s : Option SigDoc) : CommandElabM Unit :=
+    match s with
+    | some sd => do logInfo m!"{label}: {← sd.toString}"
+    | none => logInfo m!"{label}: «no signature»"
+  report "simpleDir" (sig SimpleArgs)
+  report "manyDir" (sig ManyArgs)

--- a/src/tests/Tests/ExtensionResolution.lean
+++ b/src/tests/Tests/ExtensionResolution.lean
@@ -3,7 +3,11 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Emilio J. Gallego Arias
 -/
-import Verso
+module
+public import Verso
+public meta import Verso
+
+public section
 
 namespace Verso.ExtensionResolutionTest
 set_option guard_msgs.diff true
@@ -22,7 +26,7 @@ Extension resolution has four relevant outcomes:
 namespace RoleCases
 
 @[role]
-def registered : RoleExpanderOf Unit
+meta def registered : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "registered-role")
 
@@ -36,7 +40,7 @@ def registered : RoleExpanderOf Unit
 #eval roleRegistered.toPart.content
 
 @[role_expander legacyRegistered]
-def legacyRegistered : RoleExpander
+meta def legacyRegistered : RoleExpander
   | _, _ => do
     pure #[← `(Verso.Doc.Inline.text "legacy-role")]
 
@@ -130,42 +134,42 @@ error: No registered role `q`.
 :::::::
 
 @[role]
-def r : RoleExpanderOf Unit
+meta def r : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "one-character-cutoff-role")
 
 @[role]
-def ab : RoleExpanderOf Unit
+meta def ab : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "short-distance-role")
 
 @[role]
-def vvv : RoleExpanderOf Unit
+meta def vvv : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "three-character-cutoff-role")
 
 @[role]
-def distanceRegistered : RoleExpanderOf Unit
+meta def distanceRegistered : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "distance-role")
 
 @[role]
-def yyyyy : RoleExpanderOf Unit
+meta def yyyyy : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "middle-cutoff-role")
 
 @[role]
-def zzzzzz : RoleExpanderOf Unit
+meta def zzzzzz : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "long-cutoff-role")
 
 @[role]
-def multiAlpha : RoleExpanderOf Unit
+meta def multiAlpha : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "multi-alpha-role")
 
 @[role]
-def multiAlphi : RoleExpanderOf Unit
+meta def multiAlphi : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "multi-alphi-role")
 
@@ -304,7 +308,7 @@ end DistanceCases
 namespace ShadowSource
 
 @[role]
-def shadowedRegistered : RoleExpanderOf Unit
+meta def shadowedRegistered : RoleExpanderOf Unit
   | (), _ => do
     `(Verso.Doc.Inline.text "shadowed-role")
 
@@ -348,7 +352,7 @@ end ShadowUse
 namespace CodeBlockCases
 
 @[code_block]
-def registeredBlock : CodeBlockExpanderOf Unit
+meta def registeredBlock : CodeBlockExpanderOf Unit
   | (), str => do
     `(Verso.Doc.Block.code $(quote str.getString))
 
@@ -406,7 +410,7 @@ end CodeBlockCases
 namespace DirectiveCases
 
 @[directive]
-def registeredDirective : DirectiveExpanderOf Unit
+meta def registeredDirective : DirectiveExpanderOf Unit
   | (), blocks => do
     let blocks ← blocks.mapM Verso.Doc.Elab.elabBlock
     `(Verso.Doc.Block.concat #[$blocks,*])
@@ -466,7 +470,7 @@ end DirectiveCases
 namespace BlockCommandCases
 
 @[block_command]
-def registeredCommand : BlockCommandOf Unit
+meta def registeredCommand : BlockCommandOf Unit
   | () => do
     `(Verso.Doc.Block.para #[Verso.Doc.Inline.text "registered-command"])
 

--- a/src/tests/Tests/GenericCode.lean
+++ b/src/tests/Tests/GenericCode.lean
@@ -3,7 +3,10 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
+module
+public import Verso
+public meta import Verso
+public section
 namespace Verso.GenericCodeTest
 set_option guard_msgs.diff true
 set_option pp.rawOnError true

--- a/src/tests/Tests/Golden.lean
+++ b/src/tests/Tests/Golden.lean
@@ -3,7 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Util.Diff
+module
+
+public import Lean.Util.Diff
+
+public section
 
 namespace Verso.GoldenTest
 

--- a/src/tests/Tests/HtmlEntities.lean
+++ b/src/tests/Tests/HtmlEntities.lean
@@ -3,7 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso.Output.Html.Entities
+module
+
+public import Verso.Output.Html.Entities
+public meta import Verso.Output.Html.Entities
+
+public section
 
 open Verso.Output.Html
 

--- a/src/tests/Tests/InlineStringPositions.lean
+++ b/src/tests/Tests/InlineStringPositions.lean
@@ -3,8 +3,13 @@ Copyright (c) 2023-2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import Verso.Doc.Concrete.InlineString
+module
+public import Verso
+public meta import Verso
+public import Verso.Doc.Concrete.InlineString
+public meta import Verso.Doc.Concrete.InlineString
+
+public section
 
 open Lean
 open Verso.Doc

--- a/src/tests/Tests/Integration.lean
+++ b/src/tests/Tests/Integration.lean
@@ -3,7 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jason Reed
 -/
-import Lean.Util.Diff
+module
+
+public import Lean.Util.Diff
+
+public section
 
 namespace Verso.Integration
 

--- a/src/tests/Tests/Integration/DiagramDoc.lean
+++ b/src/tests/Tests/Integration/DiagramDoc.lean
@@ -3,10 +3,14 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import VersoManual
-import Illuminate
-
+module
+public import Verso
+public import VersoManual
+public import Illuminate
+public meta import Verso
+public meta import VersoManual
+public meta import Illuminate
+public section
 namespace Verso.Integration.DiagramDoc
 
 open Verso Genre Manual

--- a/src/tests/Tests/Integration/ExtraFilesDoc.lean
+++ b/src/tests/Tests/Integration/ExtraFilesDoc.lean
@@ -3,9 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import VersoManual
-
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+public section
 namespace Verso.Integration.ExtraFilesDoc
 
 open Verso Genre Manual

--- a/src/tests/Tests/Integration/FrontMatter.lean
+++ b/src/tests/Tests/Integration/FrontMatter.lean
@@ -3,9 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import VersoManual
-
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+public section
 namespace Verso.Integration.FrontMatter
 
 open Verso Genre Manual

--- a/src/tests/Tests/Integration/InheritanceDoc.lean
+++ b/src/tests/Tests/Integration/InheritanceDoc.lean
@@ -3,9 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jason Reed
 -/
-import Verso
-import VersoManual
-
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+public section
 namespace Verso.Integration.InheritanceDoc
 
 open Verso Genre Manual

--- a/src/tests/Tests/Integration/LeanSection.lean
+++ b/src/tests/Tests/Integration/LeanSection.lean
@@ -2,9 +2,12 @@
 Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import Verso
-import VersoManual
-
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+public section
 namespace Verso.Integration.LeanSection
 
 open Verso Genre Manual InlineLean

--- a/src/tests/Tests/Integration/SampleDoc.lean
+++ b/src/tests/Tests/Integration/SampleDoc.lean
@@ -3,9 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jason Reed
 -/
-import Verso
-import VersoManual
-
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+public section
 namespace Verso.Integration.SampleDoc
 
 open Verso Genre Manual

--- a/src/tests/Tests/Linters.lean
+++ b/src/tests/Tests/Linters.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import VersoManual
+module
+public import Verso
+public import VersoManual
+
+public section
 
 namespace Verso.LinterTests
 

--- a/src/tests/Tests/LiterateConfig.lean
+++ b/src/tests/Tests/LiterateConfig.lean
@@ -3,7 +3,10 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoLiterate
+module
+public import VersoLiterate
+
+public section
 
 open Lean
 open VersoLiterate

--- a/src/tests/Tests/LiterateHtml.lean
+++ b/src/tests/Tests/LiterateHtml.lean
@@ -3,8 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoLiterate
-import VersoLiterateCode
+module
+public import VersoLiterate
+public import VersoLiterateCode
+
+public section
 
 set_option maxRecDepth 1024
 

--- a/src/tests/Tests/Method.lean
+++ b/src/tests/Tests/Method.lean
@@ -3,7 +3,12 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso.Method
+module
+
+public import Verso.Method
+public meta import Verso.Method
+
+public section
 
 /-! ## Tests for defmethod macro -/
 

--- a/src/tests/Tests/NestedTacticHtml.lean
+++ b/src/tests/Tests/NestedTacticHtml.lean
@@ -3,8 +3,13 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import SubVerso.Highlighting.Code
+module
+public import Verso
+public meta import Verso
+public import SubVerso.Highlighting.Code
+public import Lean.Elab.Frontend
+
+public section
 
 /-!
 Highlighting a proof that uses compound tactics such as `obtain` produces nested proof states: the

--- a/src/tests/Tests/ParserRegression.lean
+++ b/src/tests/Tests/ParserRegression.lean
@@ -3,8 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jason Reed
 -/
-import Verso
-import VersoManual
+module
+public import Verso
+public import VersoManual
+
+public section
 
 /-
 This is a test for https://github.com/leanprover/verso/issues/531

--- a/src/tests/Tests/Refs.lean
+++ b/src/tests/Tests/Refs.lean
@@ -3,7 +3,11 @@ Copyright (c) 2023 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Rob Simmons
 -/
-import Verso
+module
+public import Verso
+public meta import Verso
+meta import all Verso.Doc.Elab.Monad
+public section
 namespace Verso.RefsTest
 set_option guard_msgs.diff true
 

--- a/src/tests/Tests/TeX.lean
+++ b/src/tests/Tests/TeX.lean
@@ -3,8 +3,14 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso.Doc.TeX
-import Verso.Output.TeX
+module
+
+public import Verso.Doc.TeX
+public import Verso.Output.TeX
+public meta import Verso.Doc.TeX
+public meta import Verso.Output.TeX
+
+public section
 
 namespace Verso.Tests.TeX
 

--- a/src/tests/Tests/TexUnit.lean
+++ b/src/tests/Tests/TexUnit.lean
@@ -3,7 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jason Reed
 -/
-import Tests.TexUtil
+module
+public import Tests.TexUtil
+public meta import Tests.TexUtil
+
+public section
 
 /-!
 Unit tests covering TeX output given given concrete Verso structures.

--- a/src/tests/Tests/TexUtil.lean
+++ b/src/tests/Tests/TexUtil.lean
@@ -3,8 +3,27 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jason Reed
 -/
-import Lean.Elab.Command
-import VersoManual
+module
+public import Lean.Elab.Command
+public import VersoManual
+import all VersoManual
+import all VersoManual.Bibliography
+import all VersoManual.Diagrams
+import all VersoManual.Docstring
+import all VersoManual.Draft
+import all VersoManual.ExternalLean
+import all VersoManual.InlineLean
+import all VersoManual.InlineLean.Block
+import all VersoManual.InlineLean.IO
+import all VersoManual.InlineLean.Signature
+import all VersoManual.InlineLean.SyntaxError
+import all VersoManual.License
+import all VersoManual.Literate
+import all VersoManual.Marginalia
+import all VersoManual.Row
+import all VersoManual.Table
+
+public section
 
 /-!
 Support for writing unit tests covering TeX output.

--- a/src/tests/Tests/VersoBlog.lean
+++ b/src/tests/Tests/VersoBlog.lean
@@ -9,6 +9,7 @@ public import Plausible.ArbitraryFueled
 public import VersoBlog
 public meta import VersoBlog.Basic
 public import VersoBlog.LiterateLeanPage
+public import Tests.VersoBlog.LiterateLeanPage
 public import Tests.Arbitrary
 public meta import Tests.Arbitrary
 

--- a/src/tests/Tests/VersoBlog.lean
+++ b/src/tests/Tests/VersoBlog.lean
@@ -3,11 +3,16 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Plausible
-import Plausible.ArbitraryFueled
-import VersoBlog
-import VersoBlog.LiterateLeanPage
-import Tests.Arbitrary
+module
+public import Plausible
+public import Plausible.ArbitraryFueled
+public import VersoBlog
+public meta import VersoBlog.Basic
+public import VersoBlog.LiterateLeanPage
+public import Tests.Arbitrary
+public meta import Tests.Arbitrary
+
+public section
 
 open Lean
 open Verso Genre Blog
@@ -20,6 +25,8 @@ open Plausible Gen Arbitrary
 /-- info: #[(`a.b.c, 1), (`a.c, 4), (`b.c, 6), (`c, 3)] -/
 #guard_msgs in
 #eval NameSuffixMap.empty |>.insert `a.b.c 1 |>.insert `b.c 2 |>.insert `c 3 |>.insert `a.c 4 |>.insert `a.b 5 |>.insert `b.c 6 |>.get `c
+
+meta section
 
 def freshIdOk (hint : LetterString) (path : Path) (howMany : Nat) : Bool := Id.run do
   let mut st : TraverseState := { remoteContent := {} }
@@ -64,6 +71,8 @@ def runBlogTests : IO Nat := do
     unless res matches .success .. do
       failures := failures + 1
   return failures
+
+end
 
 -- Regression test for hidden blog Lean blocks.
 #doc (Post) "Hidden Lean Block Flags" =>

--- a/src/tests/Tests/VersoBlog/LiterateLeanPage.lean
+++ b/src/tests/Tests/VersoBlog/LiterateLeanPage.lean
@@ -1,0 +1,20 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+meta import all VersoBlog.LiterateLeanPage
+
+namespace Verso.Tests.VersoBlog.LiterateLeanPage
+
+open Verso.Genre.Blog.Literate.Internal
+
+/-! ## Tests for the `url_subst` URL-rewriting macros
+
+`url_subst` builds a function that matches a URL against a pattern and rewrites it from a template.
+-/
+
+/-- info: some (Except.ok "foo/foo/bar/baz/f.png") -/
+#guard_msgs in
+#eval (url_subst "xy/" z "/static/" pic ".jpg" => "foo/" z "/" pic ".png") "xy/foo/static/bar/baz/f.jpg"

--- a/src/tests/Tests/VersoManual.lean
+++ b/src/tests/Tests/VersoManual.lean
@@ -3,8 +3,10 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Tests.VersoManual.Html
-import Tests.VersoManual.Html.SoftHyphenate
-import Tests.VersoManual.License
-import Tests.VersoManual.Markdown
-import Tests.VersoManual.WordCount
+module
+public import Tests.VersoManual.Html
+public import Tests.VersoManual.Html.SoftHyphenate
+public import Tests.VersoManual.License
+public import Tests.VersoManual.Markdown
+public import Tests.VersoManual.WordCount
+public section

--- a/src/tests/Tests/VersoManual.lean
+++ b/src/tests/Tests/VersoManual.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 module
+public import Tests.VersoManual.Docstring
 public import Tests.VersoManual.Html
 public import Tests.VersoManual.Html.SoftHyphenate
 public import Tests.VersoManual.License

--- a/src/tests/Tests/VersoManual/Docstring.lean
+++ b/src/tests/Tests/VersoManual/Docstring.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+meta import all VersoManual.Docstring
+
+namespace Verso.Tests.VersoManual.Docstring
+
+open Verso.Genre.Manual
+
+/-! ## Tests for `indentColumn`
+
+`indentColumn` finds the smallest indentation of any nonblank line, which is the common indentation
+to strip when rendering a docstring's code block.
+-/
+
+/-- info: 0 -/
+#guard_msgs in
+#eval indentColumn ""
+/-- info: 0 -/
+#guard_msgs in
+#eval indentColumn "abc"
+/-- info: 3 -/
+#guard_msgs in
+#eval indentColumn "   abc"
+/-- info: 3 -/
+#guard_msgs in
+#eval indentColumn "   abc\n\n   def"
+/-- info: 2 -/
+#guard_msgs in
+#eval indentColumn "   abc\n\n  def"
+/-- info: 2 -/
+#guard_msgs in
+#eval indentColumn "   abc\n\n  def\n    a"

--- a/src/tests/Tests/VersoManual/Html.lean
+++ b/src/tests/Tests/VersoManual/Html.lean
@@ -3,7 +3,11 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoManual.Html
+module
+public import VersoManual.Html
+meta import all VersoManual.Html
+
+public section
 
 namespace Verso.Genre.Manual.Html
 

--- a/src/tests/Tests/VersoManual/Html/SoftHyphenate.lean
+++ b/src/tests/Tests/VersoManual/Html/SoftHyphenate.lean
@@ -3,8 +3,11 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
+meta import all VersoManual.Html.SoftHyphenate
 
-import VersoManual.Html.SoftHyphenate
+public section
+
 open Verso.Genre.Manual
 
 /-- info: "blahNotCode<code><a>foo&shy;Bar&shy;Baz</a></code>" -/

--- a/src/tests/Tests/VersoManual/Markdown.lean
+++ b/src/tests/Tests/VersoManual/Markdown.lean
@@ -3,9 +3,15 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoManual.Markdown
-import Verso.Doc.Elab.Monad
-import Lean.Elab.Term
+module
+public import VersoManual.Markdown
+public import Verso.Doc.Elab.Monad
+public import Lean.Elab.Term
+meta import all VersoManual.Markdown
+meta import all Verso.Doc.Elab.Monad
+meta import all Lean.Elab.Term
+
+public section
 
 open Verso Doc Elab
 open Verso.Genre Manual Markdown

--- a/src/tests/Tests/Z85.lean
+++ b/src/tests/Tests/Z85.lean
@@ -3,8 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import VersoUtil.BinFiles.Z85
+public import VersoUtil.BinFiles.Z85
+public meta import VersoUtil.BinFiles.Z85
+
+public section
 
 open Verso.BinFiles.Z85
 

--- a/src/tests/Tests/Zip.lean
+++ b/src/tests/Tests/Zip.lean
@@ -3,8 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import VersoUtil.Zip
+public import VersoUtil.Zip
+
+public section
 
 open Verso.Zip
 

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -3,24 +3,32 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import SubVerso.Highlighting
-import SubVerso.Examples
+public import SubVerso.Highlighting
+public import SubVerso.Examples
 
-import VersoBlog.Basic
-import VersoBlog.LiterateLeanPage
-import VersoBlog.LiterateModuleDocs
-import VersoBlog.Generate
-import VersoBlog.Site
-import VersoBlog.Site.Syntax
-import VersoBlog.Template
-import VersoBlog.Theme
-import VersoBlog.Traverse
-import Verso.Doc.ArgParse
-import Verso.Doc.Lsp
-import Verso.Doc.Suggestion
-import Verso.Hover
-import Verso.WithoutAsync
+public import VersoBlog.Basic
+public import VersoBlog.LiterateLeanPage
+public import VersoBlog.LiterateModuleDocs
+public import VersoBlog.Generate
+public import VersoBlog.Site
+public import VersoBlog.Site.Syntax
+public import VersoBlog.Template
+public import VersoBlog.Theme
+public import VersoBlog.Traverse
+public import Verso.Doc.ArgParse
+public import Verso.Doc.Lsp
+public import Verso.Doc.Suggestion
+public import Verso.Hover
+public import Verso.WithoutAsync
+public meta import Lean.Data.FuzzyMatching
+public meta import Lean.Elab.Frontend
+public meta import Lean.Elab.GuardMsgs
+public meta import SubVerso.Examples.Messages
+
+public section
+
 open Verso.Output Html
 
 namespace Verso.Genre.Blog
@@ -35,14 +43,14 @@ open SubVerso.Examples (loadExamples Example)
 open SubVerso.Examples.Messages (messagesMatch)
 open SubVerso.Module (ModuleItem)
 
-def classArgs : ArgParse DocElabM String := .named `«class» .string false
+meta def classArgs : ArgParse DocElabM String := .named `«class» .string false
 
 structure ClassArgs where
   «class» : String
 
 section
 variable [Monad m] [MonadError m]
-instance : FromArgs ClassArgs m where
+meta instance : FromArgs ClassArgs m where
   fromArgs := ClassArgs.mk <$> .named `«class» .string false
 end
 
@@ -50,7 +58,7 @@ end
 Wraps the contents in an HTML `<span>` element with the provided `class`.
 -/
 @[role]
-def htmlSpan : RoleExpanderOf ClassArgs
+meta def htmlSpan : RoleExpanderOf ClassArgs
   | {«class»}, stxs => do
     let contents ← stxs.mapM elabInline
     ``(Inline.other (Blog.InlineExt.htmlSpan $(quote «class»)) #[$contents,*])
@@ -60,27 +68,27 @@ def htmlSpan : RoleExpanderOf ClassArgs
 Wraps the contents in an HTML `<div>` element with the provided `class`.
 -/
 @[directive]
-def htmlDiv : DirectiveExpanderOf ClassArgs
+meta def htmlDiv : DirectiveExpanderOf ClassArgs
   | {«class»}, stxs => do
     let contents ← stxs.mapM elabBlock
     ``(Block.other (Blog.BlockExt.htmlDiv $(quote «class»)) #[ $contents,* ])
 
 
-private partial def attrs : ArgParse DocElabM (Array (String × String)) := List.toArray <$> .many attr
-where
-  attr : ArgParse DocElabM (String × String) :=
-    (fun (k, v) => (k.getId.toString (escape := false), v)) <$> .anyNamed `attribute .string
-
 structure HtmlArgs where
   name : Name
   attrs : Array (String × String)
 
-instance : FromArgs HtmlArgs DocElabM where
-  fromArgs := HtmlArgs.mk <$> .positional `name .name <*> attrs
-
+meta instance : FromArgs HtmlArgs DocElabM where
+  fromArgs :=
+    HtmlArgs.mk <$> .positional `name .name <*> attrs
+where
+  mkAttr k v := (k.getId.toString (escape := false), v)
+  attr : ArgParse DocElabM (String × String) :=
+    (fun (k, v) => mkAttr k v) <$> .anyNamed `attribute .string
+  attrs : ArgParse DocElabM (Array (String × String)) := List.toArray <$> .many attr
 
 @[directive]
-def html : DirectiveExpanderOf HtmlArgs
+meta def html : DirectiveExpanderOf HtmlArgs
   | {name, attrs}, stxs => do
     let tag := name.toString (escape := false)
     let contents ← stxs.mapM elabBlock
@@ -89,18 +97,18 @@ def html : DirectiveExpanderOf HtmlArgs
 structure BlobArgs where
   blobName : Ident
 
-instance : FromArgs BlobArgs DocElabM where
+meta instance : FromArgs BlobArgs DocElabM where
   fromArgs := BlobArgs.mk <$> .positional `blobName .ident
 
 @[directive]
-def blob : DirectiveExpanderOf BlobArgs
+meta def blob : DirectiveExpanderOf BlobArgs
   | {blobName}, stxs => do
     if h : stxs.size > 0 then logErrorAt stxs[0] "Expected no contents"
     let actualName ← realizeGlobalConstNoOverloadWithInfo blobName
     ``(Block.other (Blog.BlockExt.blob ($(mkIdentFrom blobName actualName) : Html)) #[])
 
 @[role blob]
-def inlineBlob : RoleExpanderOf BlobArgs
+meta def inlineBlob : RoleExpanderOf BlobArgs
   | {blobName}, stxs => do
     if h : stxs.size > 0 then logErrorAt stxs[0] "Expected no contents"
     let actualName ← realizeGlobalConstNoOverloadWithInfo blobName
@@ -109,17 +117,17 @@ def inlineBlob : RoleExpanderOf BlobArgs
 structure LabelArgs where
   label : Name
 
-instance : FromArgs LabelArgs DocElabM where
+meta instance : FromArgs LabelArgs DocElabM where
   fromArgs := LabelArgs.mk <$> .positional `blobName .name
 
 @[role]
-def label : RoleExpanderOf LabelArgs
+meta def label : RoleExpanderOf LabelArgs
   | {label}, stxs => do
     let args ← stxs.mapM elabInline
     ``(Inline.other (Blog.InlineExt.label $(quote label)) #[ $[ $args ],* ])
 
 @[role]
-def ref : RoleExpanderOf LabelArgs
+meta def ref : RoleExpanderOf LabelArgs
   | {label}, stxs => do
     let args ← stxs.mapM elabInline
     ``(Inline.other (Blog.InlineExt.ref $(quote label)) #[ $[ $args ],* ])
@@ -128,14 +136,14 @@ structure PageLinkArgs where
   page : Name
   id? : Option String
 
-instance : FromArgs PageLinkArgs DocElabM where
+meta instance : FromArgs PageLinkArgs DocElabM where
   fromArgs :=
     PageLinkArgs.mk <$>
       .positional `page .name <*>
       (some <$> .positional `id .string <|> pure none)
 
 @[role]
-def page_link : RoleExpanderOf PageLinkArgs
+meta def page_link : RoleExpanderOf PageLinkArgs
   | {page, id?}, stxs => do
     let inls ← stxs.mapM elabInline
     ``(Inline.other (Blog.InlineExt.pageref $(quote page) $(quote id?)) #[ $[ $inls ],* ])
@@ -143,13 +151,13 @@ def page_link : RoleExpanderOf PageLinkArgs
 
 -- The assumption here is that suffixes are _mostly_ unique, so the arrays will likely be very
 -- small.
-structure NameSuffixMap (α : Type) : Type where
+meta structure NameSuffixMap (α : Type) : Type where
   contents : Lean.NameMap (Array (Name × α)) := {}
 deriving Inhabited
 
-def NameSuffixMap.empty : NameSuffixMap α := {}
+meta def NameSuffixMap.empty : NameSuffixMap α := {}
 
-def NameSuffixMap.insert (map : NameSuffixMap α) (key : Name) (val : α) : NameSuffixMap α := Id.run do
+meta def NameSuffixMap.insert (map : NameSuffixMap α) (key : Name) (val : α) : NameSuffixMap α := Id.run do
   let some last := key.components.getLast?
     | map
   let mut arr := map.contents.find? last |>.getD #[]
@@ -159,15 +167,15 @@ def NameSuffixMap.insert (map : NameSuffixMap α) (key : Name) (val : α) : Name
       return {map with contents := map.contents.insert last (arr.set i (key, val))}
   return {map with contents := map.contents.insert last (arr.push (key, val))}
 
-def NameSuffixMap.toArray (map : NameSuffixMap α) : Array (Name × α) := Id.run do
+meta def NameSuffixMap.toArray (map : NameSuffixMap α) : Array (Name × α) := Id.run do
   let mut arr := #[]
   for (_, arr') in map.contents.toList do
     arr := arr ++ arr'
   arr.qsort (fun x y => x.fst.toString < y.fst.toString)
 
-def NameSuffixMap.toList (map : NameSuffixMap α) : List (Name × α) := map.toArray.toList
+meta def NameSuffixMap.toList (map : NameSuffixMap α) : List (Name × α) := map.toArray.toList
 
-def NameSuffixMap.get (map : NameSuffixMap α) (key : Name) : Array (Name × α) := Id.run do
+meta def NameSuffixMap.get (map : NameSuffixMap α) (key : Name) : Array (Name × α) := Id.run do
   let ks := key.componentsRev
   let some k' := ks.head?
     | #[]
@@ -195,35 +203,35 @@ where
 
 section
 
-inductive LeanExampleData where
+meta inductive LeanExampleData where
   | inline (commandState : Command.State) (parserState : Parser.ModuleParserState)
   | subproject (loaded : NameSuffixMap Example)
   | module (positioned : Array ModuleItem)
 deriving Inhabited
 
-structure ExampleContext where
+meta structure ExampleContext where
   contexts : Lean.NameMap LeanExampleData := {}
 deriving Inhabited
 
-initialize exampleContextExt : EnvExtension ExampleContext ← registerEnvExtension (pure {})
+meta initialize exampleContextExt : EnvExtension ExampleContext ← registerEnvExtension (pure {})
 
-structure ExampleMessages where
+meta structure ExampleMessages where
   messages : NameSuffixMap ((Environment × MessageLog) ⊕ List (MessageSeverity × String)) := {}
 deriving Inhabited
 
-initialize messageContextExt : EnvExtension ExampleMessages ← registerEnvExtension (pure {})
+meta initialize messageContextExt : EnvExtension ExampleMessages ← registerEnvExtension (pure {})
 
-initialize registerTraceClass `Elab.Verso.block.lean
+meta initialize registerTraceClass `Elab.Verso.block.lean
 
 
-def leanExampleProject.Args := Name × String
+@[expose] def leanExampleProject.Args := Name × String
 
-instance : FromArgs leanExampleProject.Args DocElabM :=
+meta instance : FromArgs leanExampleProject.Args DocElabM :=
   ⟨(·, ·) <$> .positional `name .name <*> .positional `projectDir .string⟩
 
 open System in
 @[block_command]
-def leanExampleProject : BlockCommandOf leanExampleProject.Args
+meta def leanExampleProject : BlockCommandOf leanExampleProject.Args
   | (name, projectDir) => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"Loading example project") <| do
     if exampleContextExt.getState (← getEnv) |>.contexts |>.contains name then
       throwError "Example context '{name}' already defined in this module"
@@ -244,13 +252,13 @@ def leanExampleProject : BlockCommandOf leanExampleProject.Args
     Verso.Hover.addCustomHover (← getRef) <| "Contains:\n" ++ String.join (savedExamples.toList.map (s!" * `{toString ·.fst}`\n"))
     ``(Block.concat #[])
 
-def leanExampleModule.Args := Name × String × Name
-instance : FromArgs leanExampleModule.Args DocElabM :=
+@[expose] def leanExampleModule.Args := Name × String × Name
+meta instance : FromArgs leanExampleModule.Args DocElabM :=
   ⟨(·, ·, ·) <$> .positional `name .name <*> .positional `projectDir .string <*> .positional `module .name⟩
 
 open System in
 @[block_command]
-def leanExampleModule : BlockCommandOf leanExampleModule.Args
+meta def leanExampleModule : BlockCommandOf leanExampleModule.Args
   | (name, projectDir, module) => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"Loading example project") <| do
     if exampleContextExt.getState (← getEnv) |>.contexts |>.contains name then
       throwError "Example context '{name}' already defined in this module"
@@ -265,7 +273,7 @@ def leanExampleModule : BlockCommandOf leanExampleModule.Args
     ``(Block.concat #[])
 
 
-private def getSubproject (project : Ident) : TermElabM (NameSuffixMap Example) := do
+private meta def getSubproject (project : Ident) : TermElabM (NameSuffixMap Example) := do
   let some ctxt := exampleContextExt.getState (← getEnv) |>.contexts |>.find? project.getId
     | throwErrorAt project "Subproject '{project}' not loaded"
   let .subproject projectExamples := ctxt
@@ -273,14 +281,14 @@ private def getSubproject (project : Ident) : TermElabM (NameSuffixMap Example) 
   Verso.Hover.addCustomHover project <| "Contains:\n" ++ String.join (projectExamples.toList.map (s!" * `{toString ·.fst}`\n"))
   pure projectExamples
 
-private def getModule (project : Ident) : TermElabM (Array ModuleItem) := do
+private meta def getModule (project : Ident) : TermElabM (Array ModuleItem) := do
   let some ctxt := exampleContextExt.getState (← getEnv) |>.contexts |>.find? project.getId
     | throwErrorAt project "Subproject '{project}' not loaded"
   let .module modExamples := ctxt
     | throwErrorAt project "'{project}' is not loaded as a subproject"
   pure modExamples
 
-def NameSuffixMap.getOrSuggest [Monad m] [MonadInfoTree m] [MonadError m]
+meta def NameSuffixMap.getOrSuggest [Monad m] [MonadInfoTree m] [MonadError m]
     (map : NameSuffixMap α) (key : Ident) : m (Name × α) := do
   match map.get key.getId with
   | #[(n', v)] =>
@@ -306,13 +314,13 @@ structure LeanCommandConfig where
 section
 variable [Monad m] [MonadError m] [MonadLiftT CoreM m]
 
-instance : FromArgs LeanCommandConfig m where
+meta instance : FromArgs LeanCommandConfig m where
   fromArgs :=
     LeanCommandConfig.mk <$> .positional `project .ident <*> .positional `exampleName .ident <*> .flag `showProofStates true
 end
 
 @[block_command]
-def leanCommand : BlockCommandOf LeanCommandConfig
+meta def leanCommand : BlockCommandOf LeanCommandConfig
   | { project, exampleName, showProofStates } => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"leanCommand") <| do
     let projectExamples ← getSubproject project
     let (_, {highlighted := hls, original := str, ..}) ← projectExamples.getOrSuggest exampleName
@@ -324,10 +332,10 @@ structure LeanCommandAtArgs where
   line : Nat
   endLine? : Option Nat
 
-instance [Monad m] [MonadError m] : FromArgs LeanCommandAtArgs m where
+meta instance [Monad m] [MonadError m] : FromArgs LeanCommandAtArgs m where
   fromArgs := LeanCommandAtArgs.mk <$> .positional `project .ident <*> .positional `line .nat <*> (some <$> .positional `endLine .nat <|> pure none)
 
-private def useRange (startLine : Nat) (endLine? : Option Nat) (range : Position × Position) : Bool :=
+private meta def useRange (startLine : Nat) (endLine? : Option Nat) (range : Position × Position) : Bool :=
   let startLine' := range.1.line
   let endLine' := range.2.line
   if let some endLine := endLine? then
@@ -336,7 +344,7 @@ private def useRange (startLine : Nat) (endLine? : Option Nat) (range : Position
     startLine ≥ startLine' && startLine ≤ endLine' -- point is in region
 
 @[block_command]
-def leanCommandAt : BlockCommandOf LeanCommandAtArgs
+meta def leanCommandAt : BlockCommandOf LeanCommandAtArgs
   | {project, line, endLine?} => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"leanCommand") <| do
     let projectExamples ← getModule project
 
@@ -359,11 +367,11 @@ def leanCommandAt : BlockCommandOf LeanCommandAtArgs
 
 structure NoArgs where
 
-instance : FromArgs NoArgs m where
+meta instance : FromArgs NoArgs m where
   fromArgs := pure ⟨⟩
 
 @[role]
-def leanKw : RoleExpanderOf NoArgs
+meta def leanKw : RoleExpanderOf NoArgs
   | ⟨⟩, #[arg] => do
     let `(inline|code( $kw:str )) := arg
       | throwErrorAt arg "Expected code literal with the keyword"
@@ -379,14 +387,14 @@ structure LeanTermArgs where
   project : Ident
   showProofStates : Bool
 
-instance : FromArgs LeanTermArgs DocElabM where
+meta instance : FromArgs LeanTermArgs DocElabM where
   fromArgs :=
     LeanTermArgs.mk <$>
       .positional `project .ident <*>
       .flag `showProofStates true
 
 @[role]
-def leanTerm : RoleExpanderOf LeanTermArgs
+meta def leanTerm : RoleExpanderOf LeanTermArgs
   | {project, showProofStates}, #[arg] => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"leanTerm") <| do
     let `(inline|code( $name:str )) := arg
       | throwErrorAt arg "Expected code literal with the example name"
@@ -411,7 +419,7 @@ structure LeanBlockConfig where
   /-- Whether to render proof states -/
   showProofStates : Bool
 
-instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanBlockConfig m where
+meta instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanBlockConfig m where
   fromArgs :=
     LeanBlockConfig.mk <$>
       .positional `exampleContext .ident <*>
@@ -421,9 +429,9 @@ instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadErr
       .flag `error false "Error expected in code?" <*>
       .flag `showProofStates true "Show proof states in rendered page?"
 
-def LeanInitBlockConfig := LeanBlockConfig
+@[expose] def LeanInitBlockConfig := LeanBlockConfig
 
-instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanInitBlockConfig m where
+meta instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanInitBlockConfig m where
   fromArgs :=
     LeanBlockConfig.mk <$>
       .positional `exampleContext .ident <*>
@@ -435,7 +443,7 @@ instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadErr
 
 
 @[code_block]
-def leanInit : CodeBlockExpanderOf LeanInitBlockConfig
+meta def leanInit : CodeBlockExpanderOf LeanInitBlockConfig
   | config , str => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"leanInit") <| do
     let context := Parser.mkInputContext (← parserInputString str) (← getFileName)
     let (header, state, msgs) ← Parser.parseHeader context
@@ -468,7 +476,7 @@ where
 
 open SubVerso.Highlighting Highlighted in
 @[code_block]
-def lean : CodeBlockExpanderOf LeanBlockConfig
+meta def lean : CodeBlockExpanderOf LeanBlockConfig
   | config, str => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"lean block") <| withoutAsync do
     let x := config.exampleContext
     let (commandState, state) ← match exampleContextExt.getState (← getEnv) |>.contexts.find? x.getId with
@@ -535,7 +543,7 @@ structure LeanInlineConfig where
   /-- Universe variables allowed in the term -/
   universes : Option StrLit
 
-instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanInlineConfig m where
+meta instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanInlineConfig m where
   fromArgs := LeanInlineConfig.mk <$> .positional `exampleContext .ident <*> .named `type strLit true <*> .named `universes strLit true
 where
   strLit : ValDesc m StrLit := {
@@ -551,7 +559,7 @@ open Lean Elab Command in
 Runs an elaborator action with the current namespace and open declarations that have been found via
 inline Lean blocks.
 -/
-def runWithOpenDecls (scopes : List Scope) (act : TermElabM α) : TermElabM α := do
+meta def runWithOpenDecls (scopes : List Scope) (act : TermElabM α) : TermElabM α := do
   let scope := scopes.head!
   withTheReader Core.Context ({· with currNamespace := scope.currNamespace, openDecls := scope.openDecls}) do
     let initNames := (← getThe Term.State).levelNames
@@ -568,7 +576,7 @@ Runs an elaborator action with the section variables that have been established 
 This is a version of `Lean.Elab.Command.runTermElabM`.
 -/
 
-def runWithVariables (scopes : List Scope) (elabFn : Array Expr → TermElabM α) : TermElabM α := do
+meta def runWithVariables (scopes : List Scope) (elabFn : Array Expr → TermElabM α) : TermElabM α := do
   let scope := scopes.head!
   Term.withAutoBoundImplicit do
     let msgLog ← Core.getMessageLog
@@ -587,7 +595,7 @@ def runWithVariables (scopes : List Scope) (elabFn : Array Expr → TermElabM α
         Term.addAutoBoundImplicits' xs someType fun xs _ =>
           Term.withoutAutoBoundImplicit <| elabFn xs
 
-private def withInfoTreeContext {m α} [Monad m] [MonadInfoTree m] [MonadFinally m] (x : m α) (mkInfoTree : PersistentArray InfoTree → m InfoTree) : m (α × InfoTree) := do
+private meta def withInfoTreeContext {m α} [Monad m] [MonadInfoTree m] [MonadFinally m] (x : m α) (mkInfoTree : PersistentArray InfoTree → m InfoTree) : m (α × InfoTree) := do
     let treesSaved ← getResetInfoTrees
     MonadFinally.tryFinally' x fun _ => do
       let st ← getInfoState
@@ -599,7 +607,7 @@ where
     modifyInfoState fun s => { s with trees := f s.trees }
 
 open SubVerso.Highlighting Highlighted in
-private def leanInlineImpl : RoleExpanderOf LeanInlineConfig
+private meta def leanInlineImpl : RoleExpanderOf LeanInlineConfig
   | config, elts => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"lean block") <| do
     let #[code] := elts
       | throwError "Expected precisely one code element"
@@ -675,11 +683,11 @@ private def leanInlineImpl : RoleExpanderOf LeanInlineConfig
       `(Inline.other (Blog.InlineExt.highlightedCode { contextName := $(quote config.exampleContext.getId) } $(quote hls)) #[Inline.code $(quote str.getString)])
 
 @[role lean]
-def leanCanonical : RoleExpanderOf LeanInlineConfig :=
+meta def leanCanonical : RoleExpanderOf LeanInlineConfig :=
   leanInlineImpl
 
 @[role]
-def leanInline : RoleExpanderOf LeanInlineConfig
+meta def leanInline : RoleExpanderOf LeanInlineConfig
   | config, elts => do
     if h : 0 < elts.size then
       logWarningAt elts[0] "`{leanInline}` is deprecated; use `{lean}` instead."
@@ -696,7 +704,7 @@ structure LeanOutputConfig where
   summarize : Bool
   whitespace : WhitespaceMode
 
-instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanOutputConfig m where
+meta instance [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] : FromArgs LeanOutputConfig m where
   fromArgs :=
     LeanOutputConfig.mk <$>
       .positional `name output <*>
@@ -715,18 +723,18 @@ where
   optDef {α} (fallback : α) (p : ArgParse m α) : ArgParse m α := p <|> pure fallback
 
 open SubVerso.Highlighting in
-private def leanOutputBlock [bg : BlogGenre genre] (message : Highlighted.Message) (summarize := false) (expandTraces : List Name := []) : Block genre :=
+def leanOutputBlock [bg : BlogGenre genre] (message : Highlighted.Message) (summarize := false) (expandTraces : List Name := []) : Block genre :=
   .other (bg.block_eq ▸ BlockExt.message summarize message expandTraces) #[.code message.toString]
 
 open SubVerso.Highlighting in
-private def leanOutputInline [bg : BlogGenre genre] (message : Highlighted.Message) (plain : Bool) (expandTraces : List Name := []) : Inline genre :=
+def leanOutputInline [bg : BlogGenre genre] (message : Highlighted.Message) (plain : Bool) (expandTraces : List Name := []) : Inline genre :=
   if plain then
     .code message.toString
   else
     .other (bg.inline_eq ▸ InlineExt.message message expandTraces) #[.code message.toString]
 
 @[code_block]
-def leanOutput : CodeBlockExpanderOf LeanOutputConfig
+meta def leanOutput : CodeBlockExpanderOf LeanOutputConfig
   | config, str => withTraceNode `Elab.Verso.block.lean (fun _ => pure m!"leanOutput") <| do
     let (_, savedInfo) ← messageContextExt.getState (← getEnv) |>.messages |>.getOrSuggest config.name
     let messages ← match savedInfo with

--- a/src/verso-blog/VersoBlog/Basic.lean
+++ b/src/verso-blog/VersoBlog/Basic.lean
@@ -3,22 +3,25 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Data.Json.FromToJson
+module
+public import Lean.Data.Json.FromToJson
 
-import Std.Data.HashMap
-import Std.Data.HashSet
+public import Std.Data.HashMap
+public import Std.Data.HashSet
 
-import SubVerso.Highlighting
-
-
-import Verso.Code
-import Verso.Doc
-import Verso.Doc.Html
-import Verso.Method
-import MultiVerso
+public import SubVerso.Highlighting
 
 
-import VersoBlog.LexedText
+public import Verso.Code
+public import Verso.Doc
+public import Verso.Doc.Html
+public import Verso.Method
+public import MultiVerso
+
+
+public import VersoBlog.LexedText
+
+public section
 
 open Std (HashSet HashMap)
 open Lean (Json ToJson FromJson)
@@ -288,6 +291,7 @@ deriving Repr, BEq, ToJson, FromJson
 /--
 An ordinary web page that is not a blog post.
 -/
+@[expose]
 def Page : Genre where
   PartMetadata := Page.Meta
   Block := Blog.BlockExt
@@ -326,6 +330,7 @@ deriving TypeName, Repr
 /--
 A blog post.
 -/
+@[expose]
 def Post : Genre where
   PartMetadata := Post.Meta
   Block := Blog.BlockExt

--- a/src/verso-blog/VersoBlog/Component.lean
+++ b/src/verso-blog/VersoBlog/Component.lean
@@ -3,10 +3,15 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoBlog.Basic
-import VersoBlog.Component.Ext
-import Verso.Doc.ArgParse
-import Std.Data.HashSet
+module
+public import VersoBlog.Basic
+public import VersoBlog.Component.Ext
+public meta import VersoBlog.Component.Ext
+public import Verso.Doc.ArgParse
+public meta import Verso.Doc.Elab.Block
+public import Std.Data.HashSet
+
+public section
 
 open Verso Genre Blog
 open Verso.Doc
@@ -142,7 +147,7 @@ def Components.fromLists (blocks : List (Name × BlockComponent)) (inlines : Lis
   inlines := .ofList (inlines.map fun (x, b) => (x, Dynamic.mk b)) _
 
 open Lean in
-private def nameAndDef [Monad m] [MonadRef m] [MonadQuotation m] (ext : Name × Name) : m Term := do
+private meta def nameAndDef [Monad m] [MonadRef m] [MonadQuotation m] (ext : Name × Name) : m Term := do
   let quoted : Term := quote ext.fst
   let ident ← mkCIdentFromRef ext.snd
   `(($quoted, $(⟨ident⟩)))
@@ -173,7 +178,7 @@ scoped elab "%registered_inline_components" : term => do
 
 
 open Lean.Parser Term in
-def extContents := structInstFields (sepByIndent Term.structInstField "; " (allowTrailingSep := true))
+meta def extContents := structInstFields (sepByIndent Term.structInstField "; " (allowTrailingSep := true))
 
 /--
 Defines a new block component.
@@ -193,7 +198,7 @@ syntax (docComment)? "inline_component " ident (ppSpace bracketedBinder)* ppInde
 
 
 open Lean in
-def argNames : Lean.TSyntax ``Lean.Parser.Term.bracketedBinder → Array Ident
+meta def argNames : Lean.TSyntax ``Lean.Parser.Term.bracketedBinder → Array Ident
   | `(bracketedBinder| ($xs* : $_) )
   | `(bracketedBinder| {$xs* : $_} )
   | `(bracketedBinder| ⦃$xs* : $_⦄ ) => xs.filterMap getIdents
@@ -203,14 +208,14 @@ where
     if x.raw.isIdent then pure ⟨x.raw⟩ else none
 
 open Lean in
-def argType : Lean.TSyntax ``Lean.Parser.Term.bracketedBinder → Option Term
+meta def argType : Lean.TSyntax ``Lean.Parser.Term.bracketedBinder → Option Term
   | `(bracketedBinder| ($_* : $t) )
   | `(bracketedBinder| {$_* : $t} )
   | `(bracketedBinder| ⦃$_* : $t⦄ ) => pure t
   | _ => none
 
 open Lean in
-def argNamesTypes : Lean.TSyntax ``Lean.Parser.Term.bracketedBinder → Array (Ident × Term)
+meta def argNamesTypes : Lean.TSyntax ``Lean.Parser.Term.bracketedBinder → Array (Ident × Term)
   | `(bracketedBinder| ($xs* : $t) )
   | `(bracketedBinder| {$xs* : $t} )
   | `(bracketedBinder| ⦃$xs* : $t⦄ ) => xs.filterMap getIdents |>.map ((·, t))
@@ -222,7 +227,7 @@ where
 
 
 open Lean Elab Command in
-def splitToHtml (fields : Array (TSyntax ``Lean.Parser.Term.structInstField)) :
+meta def splitToHtml (fields : Array (TSyntax ``Lean.Parser.Term.structInstField)) :
     CommandElabM (Option Term × Array (TSyntax ``Lean.Parser.Term.structInstField)) := do
   let (is, isNot) := fields.partition fun
     | `(Lean.Parser.Term.structInstField|toHtml) => true
@@ -254,7 +259,7 @@ where
       `(_)
 
 open Lean in
-def deJson [Monad m] [MonadQuotation m]
+meta def deJson [Monad m] [MonadQuotation m]
     (b : Ident × Term) : m (TSyntax `Lean.Parser.Term.doSeqItem) :=
   let (x, t) := b
   `(Lean.Parser.Term.doSeqItem| let $x ← match FromJson.fromJson? (α := $t) $x with
@@ -314,7 +319,7 @@ elab_rules : command
         `(command|
           @[directive $x]
           def $dirName : DirectiveExpanderOf T
-            | $argPat, blocks => do `($qArgs #[$$(← blocks.mapM elabBlock),*]))
+            | $argPat, blocks => do `($qArgs #[$$(← blocks.mapM Verso.Doc.Elab.elabBlock),*]))
       elabCommand cmd3
 
 

--- a/src/verso-blog/VersoBlog/Component/Ext.lean
+++ b/src/verso-blog/VersoBlog/Component/Ext.lean
@@ -3,7 +3,11 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Environment
+module
+public import Lean.Environment
+
+public section
+
 open Lean
 
 namespace Verso.Genre.Blog

--- a/src/verso-blog/VersoBlog/Generate.lean
+++ b/src/verso-blog/VersoBlog/Generate.lean
@@ -3,11 +3,14 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
+public import Verso.FS
+public import MultiVerso.Path
+public import VersoBlog.Basic
+public import VersoBlog.Template
+public import VersoBlog.Theme
 
-import Verso.FS
-import VersoBlog.Basic
-import VersoBlog.Template
-import VersoBlog.Theme
+public section
 
 open Verso Doc Output Html HtmlT FS
 open Verso.Code.Hover (State)

--- a/src/verso-blog/VersoBlog/LexedText.lean
+++ b/src/verso-blog/VersoBlog/LexedText.lean
@@ -3,9 +3,13 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Parser
-import Lean.Data.Json.FromToJson
-import Verso.Instances.Deriving
+module
+public import Lean.Parser
+public import Lean.DocString.Parser
+public import Lean.Data.Json.FromToJson
+meta import Verso.Instances.Deriving
+
+public section
 
 open Lean (ToJson FromJson)
 

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -229,10 +229,6 @@ macro_rules
   | `(term|url_subst $pat* => $template*) =>
     `(fun s => url_subst(s) $pat* => $template*)
 
-/-- info: some (Except.ok "foo/foo/bar/baz/f.png") -/
-#guard_msgs in
-#eval (url_subst "xy/" z "/static/" pic ".jpg" => "foo/" z "/" pic ".png") "xy/foo/static/bar/baz/f.jpg"
-
 meta def getSubst [Monad m] : TSyntax ``url_case → m (List Pat × List Template)
   | `(url_case|$pat* => $template*) => do
     let pat := pat.map fun
@@ -247,11 +243,6 @@ meta def getSubst [Monad m] : TSyntax ``url_case → m (List Pat × List Templat
       | t => panic! s!"Didn't understand template {t}"
     pure (pat.toList, template.toList)
   | c => panic! s!"Didn't understand case {c}"
-
-
-/-- info: some (Except.ok "foo/foo/bar/baz/f.png") -/
-#guard_msgs in
-#eval (url_subst "xy/" z "/static/" pic ".jpg" => "foo/" z "/" pic ".png") "xy/foo/static/bar/baz/f.jpg"
 
 end Internal
 

--- a/src/verso-blog/VersoBlog/LiterateLeanPage.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage.lean
@@ -3,12 +3,24 @@ Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import SubVerso.Helper
-import SubVerso.Module
-import Verso.Doc.Concrete
-import VersoBlog.Basic
-import VersoBlog.LiterateLeanPage.Options
-import MD4Lean
+module
+public import SubVerso.Helper
+public import SubVerso.Module
+public import Verso.Doc.Concrete
+public import Verso.Doc.DocName
+public import Verso.Instances
+public import VersoBlog.Basic
+public import VersoBlog.LiterateLeanPage.Options
+public meta import VersoBlog.LiterateLeanPage.Options
+public import VersoBlog.LiterateLeanPage.Config
+public meta import VersoBlog.LiterateLeanPage.Config
+public import VersoBlog.LiterateLeanPage.Rewrite
+public meta import VersoBlog.LiterateLeanPage.Rewrite
+public import MD4Lean
+public import Std.Sync.Mutex
+public import Verso.Parser
+
+public section
 
 open Verso Doc
 open Lean
@@ -20,11 +32,8 @@ open Verso.Doc.Concrete (stringToInlines)
 
 namespace Verso.Genre.Blog.Literate
 
-structure LitPageConfig where
-  header : Bool := false
-
 open System in
-def loadModuleContent
+meta def loadModuleContent
     (leanProject : FilePath) (mod : String)
     (overrideToolchain : Option String := none) : IO (Array ModuleItem) := do
 
@@ -94,7 +103,7 @@ structure Helper where
   highlight (term : String) (type? : Option String) : IO Highlighted
 
 open System in
-def Helper.fromModule
+meta def Helper.fromModule
     (leanProject : FilePath) (mod : String)
     (overrideToolchain : Option String := none) : IO Helper := do
 
@@ -191,67 +200,9 @@ where
       decorateOut "stderr" res.stderr
 
 
-def loadLiteratePage (root : System.FilePath) (module : String) : IO (Array ModuleItem) := do
+meta def loadLiteratePage (root : System.FilePath) (module : String) : IO (Array ModuleItem) := do
   loadModuleContent root module
 
-
-inductive Pat where
-  | char : Char → Pat
-  | str : String → Pat
-  | var : Name → Pat
-  | any : Pat
-deriving BEq, Hashable, Repr, Inhabited
-
--- TODO rewrite with dynamic programming
-partial def Pat.match (p : List Pat) (str : String) : Option (Lean.NameMap String) :=
-  go str.startPos p
-where
-  go iter
-    | [] => if iter = str.endPos then pure {} else failure
-    | .char c :: p' =>
-      if h : iter ≠ str.endPos then
-        if iter.get h == c then
-          go (iter.next h) p'
-        else failure
-      else failure
-    | .str s :: p' =>
-      go iter (s.toList.map .char ++ p')
-    | .var x :: p' => do
-      let mut iter' := str.endPos
-      while iter' ≥ iter do
-        try
-          let rest ← go iter' p'
-          return rest.insert x (str.extract iter iter')
-        catch
-          | () =>
-            if h : iter' = str.startPos then
-              break
-            else
-              iter' := iter'.prev h
-              continue
-      failure
-    | .any :: p' => do
-      let mut iter' := str.endPos
-      while iter' ≥ iter do
-        try
-          return (← go iter' p')
-        catch
-          | () =>
-            if h : iter' = str.startPos then
-              break
-            else
-              iter' := iter'.prev h
-              continue
-      failure
-
-inductive Template where
-  | str : String → Template
-  | var : Name → Template
-deriving BEq, Hashable, Repr, Inhabited
-
-def Template.subst (vars : Lean.NameMap String) : Template → Except String String
-  | .str s => pure s
-  | .var x => if let some s := vars.find? x then pure s else throw s!"Not found: '{x}'"
 
 syntax url_pattern := "*" <|> str <|> char <|> ident
 syntax url_template := str <|> ident
@@ -282,7 +233,7 @@ macro_rules
 #guard_msgs in
 #eval (url_subst "xy/" z "/static/" pic ".jpg" => "foo/" z "/" pic ".png") "xy/foo/static/bar/baz/f.jpg"
 
-def getSubst [Monad m] : TSyntax ``url_case → m (List Pat × List Template)
+meta def getSubst [Monad m] : TSyntax ``url_case → m (List Pat × List Template)
   | `(url_case|$pat* => $template*) => do
     let pat := pat.map fun
       | `(url_pattern| *) => Pat.any
@@ -308,7 +259,7 @@ section
 variable [Monad m] [MonadError m] [MonadQuotation m]
 
 
-partial def getModuleDocString (hl : Highlighted) : m String := do
+meta partial def getModuleDocString (hl : Highlighted) : m String := do
   let str := (← getString hl).trimAscii
   let str := str.dropPrefix "/-!" |>.dropSuffix "-/" |>.trimAscii |>.copy
   pure str
@@ -321,7 +272,7 @@ where getString : Highlighted → m String
   | .token ⟨_, txt⟩ => pure txt
 end
 
-def getFirstMessage : Highlighted → Option (Highlighted.Span.Kind × Highlighted.MessageContents Highlighted)
+meta def getFirstMessage : Highlighted → Option (Highlighted.Span.Kind × Highlighted.MessageContents Highlighted)
   | .span msgs x =>
     msgs[0]? <|> getFirstMessage x
   | .point k m => pure (k, m)
@@ -351,7 +302,7 @@ partial def examplesFromMod [Monad m] [MonadError m]
 
 open Elab PartElabM in
 open Lean.Parser.Command in
-partial def docFromMod (project : System.FilePath) (mod : String)
+meta partial def docFromMod (project : System.FilePath) (mod : String)
     (config : LitPageConfig) (content : Array ModuleItem)
     (rewriter : Array (List Pat × List Template)) : PartElabM Unit := do
   let mut mdHeaders : Array Nat := #[]
@@ -496,7 +447,7 @@ syntax rewrites := "rewriting " ("| " url_case)+
 open Verso Doc in
 open Lean Elab Command in
 open PartElabM in
-def elabLiteratePage (x : Ident) (path : StrLit) (mod : Ident) (config : LitPageConfig) (title : StrLit) (genre : Term) (metadata? : Option Term) (rw : Option (TSyntax ``rewrites)) : CommandElabM Unit :=
+meta def elabLiteratePage (x : Ident) (path : StrLit) (mod : Ident) (config : LitPageConfig) (title : StrLit) (genre : Term) (metadata? : Option Term) (rw : Option (TSyntax ``rewrites)) : CommandElabM Unit :=
   withTraceNode `verso.blog.literate (fun _ => pure m!"Literate '{title.getString}'") do
 
   let rewriter ← rw.mapM fun
@@ -590,7 +541,6 @@ syntax "def_literate_post " ident Lean.Parser.Tactic.optConfig " from " ident " 
 
 
 
-declare_config_elab litPageConfig LitPageConfig
 
 open Verso Doc in
 open Lean Elab Command in

--- a/src/verso-blog/VersoBlog/LiterateLeanPage/Config.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage/Config.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import Lean.Elab.ConfigEval
+
+public section
+
+namespace Verso.Genre.Blog.Literate
+
+structure LitPageConfig where
+  header : Bool := false
+
+declare_config_elab litPageConfig LitPageConfig
+
+end Verso.Genre.Blog.Literate

--- a/src/verso-blog/VersoBlog/LiterateLeanPage/Options.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage/Options.lean
@@ -3,7 +3,10 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Data.Options
+module
+public import Lean.Data.Options
+
+public section
 
 open Lean MonadOptions
 

--- a/src/verso-blog/VersoBlog/LiterateLeanPage/Rewrite.lean
+++ b/src/verso-blog/VersoBlog/LiterateLeanPage/Rewrite.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import Lean.Data.NameMap
+
+public section
+
+open Lean
+
+namespace Verso.Genre.Blog.Literate
+
+inductive Pat where
+  | char : Char → Pat
+  | str : String → Pat
+  | var : Name → Pat
+  | any : Pat
+deriving BEq, Hashable, Repr, Inhabited
+
+-- TODO rewrite with dynamic programming
+partial def Pat.match (p : List Pat) (str : String) : Option (Lean.NameMap String) :=
+  go str.startPos p
+where
+  go iter
+    | [] => if iter = str.endPos then pure {} else failure
+    | .char c :: p' =>
+      if h : iter ≠ str.endPos then
+        if iter.get h == c then
+          go (iter.next h) p'
+        else failure
+      else failure
+    | .str s :: p' =>
+      go iter (s.toList.map .char ++ p')
+    | .var x :: p' => do
+      let mut iter' := str.endPos
+      while iter' ≥ iter do
+        try
+          let rest ← go iter' p'
+          return rest.insert x (str.extract iter iter')
+        catch
+          | () =>
+            if h : iter' = str.startPos then
+              break
+            else
+              iter' := iter'.prev h
+              continue
+      failure
+    | .any :: p' => do
+      let mut iter' := str.endPos
+      while iter' ≥ iter do
+        try
+          return (← go iter' p')
+        catch
+          | () =>
+            if h : iter' = str.startPos then
+              break
+            else
+              iter' := iter'.prev h
+              continue
+      failure
+
+inductive Template where
+  | str : String → Template
+  | var : Name → Template
+deriving BEq, Hashable, Repr, Inhabited
+
+def Template.subst (vars : Lean.NameMap String) : Template → Except String String
+  | .str s => pure s
+  | .var x => if let some s := vars.find? x then pure s else throw s!"Not found: '{x}'"
+
+end Verso.Genre.Blog.Literate

--- a/src/verso-blog/VersoBlog/LiterateModuleDocs.lean
+++ b/src/verso-blog/VersoBlog/LiterateModuleDocs.lean
@@ -3,15 +3,22 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import SubVerso.Helper
-import SubVerso.Module
-import VersoBlog.Basic
-import VersoBlog.LiterateLeanPage.Options
-import MD4Lean
-import VersoLiterate
-import Lean.Compiler.LCNF.ConfigOptions
+module
+public import SubVerso.Helper
+public import SubVerso.Module
+public import VersoBlog.Basic
+public import VersoBlog.LiterateLeanPage.Options
+public import MD4Lean
+public import VersoLiterate
+public meta import Lean.Compiler.LCNF.ConfigOptions
+public meta import Verso.Doc.Concrete
+public meta import Verso.Doc.Elab.Monad
+public meta import Verso.Doc.Elab
+public meta import VersoLiterate.Module
 
 set_option doc.verso true
+
+public section
 
 open Verso Doc
 open Lean
@@ -49,7 +56,7 @@ variable [Monad m] [MonadError m] [MonadQuotation m]
 open Verso Doc in
 open Lean Elab Command Term in
 open PartElabM in
-def elabFromModuleDocs (x : Ident) (path : StrLit) (mod : Ident) (title : StrLit) (genre : Term) (metadata? : Option Term) : CommandElabM Unit :=
+meta def elabFromModuleDocs (x : Ident) (path : StrLit) (mod : Ident) (title : StrLit) (genre : Term) (metadata? : Option Term) : CommandElabM Unit :=
   withTraceNode `verso.blog.literate (fun _ => pure m!"Literate '{title.getString}'") do
 
   let titleParts ← stringToInlines title

--- a/src/verso-blog/VersoBlog/Site.lean
+++ b/src/verso-blog/VersoBlog/Site.lean
@@ -3,10 +3,12 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
+public import Verso.Doc
+public import VersoBlog.Basic
+public import VersoBlog.Traverse
 
-import Verso.Doc
-import VersoBlog.Basic
-import VersoBlog.Traverse
+public section
 
 open Verso Doc
 

--- a/src/verso-blog/VersoBlog/Site/Syntax.lean
+++ b/src/verso-blog/VersoBlog/Site/Syntax.lean
@@ -3,9 +3,13 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import Verso.Doc.Concrete
-import VersoBlog.Site
+public import Verso.Doc.Concrete
+public import Verso.Doc.DocName
+public import VersoBlog.Site
+
+public section
 
 open Lean Elab Macro Term
 

--- a/src/verso-blog/VersoBlog/Template.lean
+++ b/src/verso-blog/VersoBlog/Template.lean
@@ -3,19 +3,23 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
+public import Std.Data.HashSet
 
-import Std.Data.HashSet
+public import SubVerso.Highlighting
 
-import SubVerso.Highlighting
+public import Verso.Doc
+public import Verso.Doc.Html
+public import VersoBlog.Basic
+public import VersoBlog.Site
+public import VersoBlog.Component
+public import Verso.Output.Html
+public import Verso.Output.Html.CssVars
+public import Verso.Code
+public import Verso.Instances
+public import Verso.Doc.DocName
 
-import Verso.Doc
-import Verso.Doc.Html
-import VersoBlog.Basic
-import VersoBlog.Site
-import VersoBlog.Component
-import Verso.Output.Html
-import Verso.Output.Html.CssVars
-import Verso.Code
+public section
 
 open Std (HashSet TreeMap)
 
@@ -51,7 +55,7 @@ instance : Coe Html Template.Params.Val where
    | other => ⟨.mk other, #[]⟩
 
 
-def Params := TreeMap String Params.Val
+@[expose] def Params := TreeMap String Params.Val
 
 instance : EmptyCollection Params := inferInstanceAs <| EmptyCollection (TreeMap _ _ _)
 
@@ -271,7 +275,7 @@ def blogGenreHtml
   inline := bg.inline_eq ▸ inlineHtml g
 
 
-private def mkHd (htmlId : Option String) (lvl : Nat) (contents : Html)  : Html :=
+def mkHd (htmlId : Option String) (lvl : Nat) (contents : Html)  : Html :=
   mkPartHeader lvl contents (htmlId.map (fun x => #[("id", x)]) |>.getD #[])
 
 instance : GenreHtml Page ComponentM := blogGenreHtml Page fun go metadata part =>

--- a/src/verso-blog/VersoBlog/Theme.lean
+++ b/src/verso-blog/VersoBlog/Theme.lean
@@ -3,9 +3,11 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
+public import VersoBlog.Site
+public import VersoBlog.Template
 
-import VersoBlog.Site
-import VersoBlog.Template
+public section
 
 open Verso.Genre.Blog Template
 open Verso Doc Output Html

--- a/src/verso-blog/VersoBlog/Traverse.lean
+++ b/src/verso-blog/VersoBlog/Traverse.lean
@@ -3,8 +3,11 @@ Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoBlog.Basic
-import VersoBlog.Component
+module
+public import VersoBlog.Basic
+public import VersoBlog.Component
+
+public section
 
 open Verso Code Highlighted WebAssets
 

--- a/src/verso-html/VersoHtmlMain.lean
+++ b/src/verso-html/VersoHtmlMain.lean
@@ -3,8 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoLiterateCode
-import VersoSearch.DomainSearch
+module
+public import VersoLiterateCode
+public import VersoSearch.DomainSearch
+public import Verso.Code.Highlighted.WebAssets
+
+public section
 
 open Lean
 

--- a/src/verso-illuminate/VersoIlluminate.lean
+++ b/src/verso-illuminate/VersoIlluminate.lean
@@ -65,17 +65,17 @@ Padding (in diagram units) added on each side of the rendered SVG's view box. Us
 `renderSvg` and `viewBoxWidth` below, so the width returned to the code-block expander matches
 the actual rendered SVG.
 -/
-private def svgPadding : Float := 5
+public def svgPadding : Float := 5
 
 /-- Renders a diagram to SVG using the local `svgPadding`. -/
-private def renderSvg (d : Illuminate.Diagram Illuminate.SVG) : String :=
+public def renderSvg (d : Illuminate.Diagram Illuminate.SVG) : String :=
   d.renderDiagram (padding := svgPadding)
 
 /--
 Computes the view box width (in diagram units) of the SVG produced by `renderSvg`. Returns 0
 for empty diagrams.
 -/
-private def viewBoxWidth (d : Illuminate.Diagram Illuminate.SVG) : Float :=
+public def viewBoxWidth (d : Illuminate.Diagram Illuminate.SVG) : Float :=
   match d.getEnvelope with
   | .empty => 0
   | .nonempty env => env Illuminate.Vec2.west + env Illuminate.Vec2.east + 2 * svgPadding

--- a/src/verso-literate-code/VersoLiterateCode.lean
+++ b/src/verso-literate-code/VersoLiterateCode.lean
@@ -3,15 +3,19 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Data.Json
-import VersoLiterate
-import Verso.Doc.Html
-import Verso.Output.Html
-import Verso.Output.Html.ElasticLunr
-import Std.Data.HashMap
-import Verso.FS
-import VersoSearch
-import Verso.Code.External.Code
+module
+public import Lean.Data.Json
+public import VersoLiterate
+public import Verso.Doc.Html
+public import Verso.Output.Html
+public import Verso.Output.Html.ElasticLunr
+public import Std.Data.HashMap
+public import Verso.FS
+public import VersoSearch
+public import VersoSearch.DomainSearch
+public import Verso.Code.External.Code
+
+public section
 
 open Lean
 
@@ -993,6 +997,11 @@ open Verso.Search
 
 def constDomainName := `VersoHtml.constant
 def moduleDomainName := `VersoHtml.module
+
+@[grind =]
+theorem constDomainName.isPublic : Verso.NameMap.isPublic constDomainName := by grind [constDomainName]
+@[grind =]
+theorem moduleDomainName.isPublic : Verso.NameMap.isPublic moduleDomainName := by grind [moduleDomainName]
 
 def constMapper : DomainMapper where
   displayName := "Declaration"

--- a/src/verso-literate-html/LiterateHtmlMain.lean
+++ b/src/verso-literate-html/LiterateHtmlMain.lean
@@ -3,8 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoLiterateCode
-import VersoSearch.DomainSearch
+module
+public import VersoLiterateCode
+public import VersoSearch.DomainSearch
+public import Verso.Code.Highlighted.WebAssets
+
+public section
 
 open Lean
 

--- a/src/verso-literate-plan/LiteratePlanMain.lean
+++ b/src/verso-literate-plan/LiteratePlanMain.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoLiterate
-import Std.Data.HashMap
+module
+public import VersoLiterate
+public import Std.Data.HashMap
+
+public section
 
 open Lean
 open VersoLiterate

--- a/src/verso-literate/VersoLiterateMain.lean
+++ b/src/verso-literate/VersoLiterateMain.lean
@@ -3,15 +3,22 @@ Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import SubVerso.Compat
-import SubVerso.Examples.Env
-import SubVerso.Module
-import SubVerso.Highlighting.Export
-import MD4Lean
-import Lean.DocString.Syntax
-import Lean.DocString.Extension
+module
+public import SubVerso.Compat
+public import SubVerso.Examples.Env
+public import SubVerso.Module
+public import SubVerso.Highlighting.Export
+public import MD4Lean
+public import Lean.DocString.Syntax
+public import Lean.DocString.Extension
+public import Lean.Elab.Frontend
+public import Lean.Server.InfoUtils
+public import Lean.Server.References
 
-import VersoLiterate
+public import VersoLiterate
+public import Verso.SyntaxUtils
+
+public section
 
 open Lean Elab Frontend
 open Lean.Elab.Command hiding Context

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -4,46 +4,52 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Verso.Doc
-import Verso.Doc.Concrete
-import Verso.Doc.TeX
-import Verso.Doc.Html
-import Verso.Output.TeX
-import Verso.Output.Html
-import Verso.Output.Html.CssVars
-import Verso.Output.Html.KaTeX
-import Verso.Output.Html.ElasticLunr
-import Verso.Doc.Lsp
-import Verso.Doc.Elab
-import Verso.FS
+module
+public import Verso.Doc
+public import Verso.Doc.Concrete
+public import Verso.Doc.TeX
+public import Verso.Doc.Html
+public import Verso.Output.TeX
+public import Verso.Output.Html
+public import Verso.Output.Html.CssVars
+public import Verso.Output.Html.KaTeX
+public import Verso.Output.Html.ElasticLunr
+public import Verso.Doc.Lsp
+public import Verso.Doc.Elab
+public import Verso.FS
 
-import VersoSearch
+public import VersoSearch
+public import VersoSearch.DomainSearch
 
-import MultiVerso
+public import MultiVerso
 
-import VersoManual.Basic
-import VersoManual.TeX
-import VersoManual.TeX.Config
-import VersoManual.Html
-import VersoManual.Html.Style
-import VersoManual.Draft
-import VersoManual.Imports
-import VersoManual.Index
-import VersoManual.License
-import VersoManual.Glossary
-import VersoManual.Docstring
-import VersoManual.WebAssets
-import VersoManual.WordCount
-import VersoManual.Linters
-import VersoManual.LocalContents
-import VersoManual.InlineLean
-import VersoManual.ExternalLean
-import VersoManual.Literate
-import VersoManual.Marginalia
-import VersoManual.Bibliography
-import VersoManual.Row
-import VersoManual.Diagrams
-import VersoManual.Table
+public import VersoManual.Basic
+public import VersoManual.TeX
+public import VersoManual.TeX.Config
+public import VersoManual.Html
+public import VersoManual.Html.Config
+public import VersoManual.Html.Features
+public import VersoManual.Html.Style
+public import VersoManual.Draft
+public import VersoManual.Imports
+public import VersoManual.Index
+public import VersoManual.License
+public import VersoManual.Glossary
+public import VersoManual.Docstring
+public import VersoManual.WebAssets
+public import VersoManual.WordCount
+public import VersoManual.Linters
+public import VersoManual.LocalContents
+public import VersoManual.InlineLean
+public import VersoManual.ExternalLean
+public import VersoManual.Literate
+public import VersoManual.Marginalia
+public import VersoManual.Bibliography
+public import VersoManual.Row
+public import VersoManual.Diagrams
+public import VersoManual.Table
+
+public section
 
 open Lean (Name NameMap Json ToJson FromJson quote)
 
@@ -152,7 +158,7 @@ structure RoleArgs where
   domain : Option Name
   remote : Option String := none
 
-instance : FromArgs RoleArgs m where
+meta instance : FromArgs RoleArgs m where
   fromArgs :=
     RoleArgs.mk <$>
       .positional `canonicalName (ValDesc.string.as "canonical name (string literal)") <*>
@@ -172,7 +178,7 @@ end
 Inserts a reference to the provided tag.
 -/
 @[role]
-def ref : RoleExpanderOf RoleArgs
+meta def ref : RoleExpanderOf RoleArgs
   | {canonicalName, domain, remote}, content => do
     let content ← content.mapM elabInline
     ``(Inline.other (Inline.ref $(quote canonicalName) $(quote domain) $(quote remote)) #[$content,*])
@@ -194,7 +200,7 @@ paragraph. In HTML output, they are rendered with less space between them, and L
 a single paragraph (e.g. without extraneous indentation).
 -/
 @[directive]
-def paragraph : DirectiveExpanderOf Unit
+meta def paragraph : DirectiveExpanderOf Unit
   | (), stxs => do
     let args ← stxs.mapM elabBlock
     ``(Block.other Block.paragraph #[ $[ $args ],* ])

--- a/src/verso-manual/VersoManual/Bibliography.lean
+++ b/src/verso-manual/VersoManual/Bibliography.lean
@@ -4,16 +4,19 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Lean.Data.Json
-import Lean.Elab.InfoTree.Types
+module
+public import Lean.Data.Json
+public import Lean.Elab.InfoTree.Types
 
-import Verso.Output.Html
-import Verso.Output.TeX
-import MultiVerso.Path
-import MultiVerso.Slug
-import VersoManual.Basic
-import VersoManual.Marginalia
+public import Verso.Output.Html
+public import Verso.Output.TeX
+public import MultiVerso.Path
+public import MultiVerso.Slug
+public import VersoManual.Basic
+public import VersoManual.Marginalia
+public meta import Verso.Doc.Elab.Monad
 
+public section
 
 open Lean Elab
 open Verso Doc Elab Html
@@ -396,12 +399,12 @@ structure CiteConfig where
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] [MonadFileMap m]
 
-partial def CiteConfig.parse : ArgParse m CiteConfig :=
+meta partial def CiteConfig.parse : ArgParse m CiteConfig :=
   CiteConfig.mk <$> many1 (.positional `citation .resolvedName)
 where
   many1 p := (· :: ·) <$> p <*> .many p
 
-instance : FromArgs CiteConfig m where
+meta instance : FromArgs CiteConfig m where
   fromArgs := CiteConfig.parse
 
 end
@@ -413,19 +416,19 @@ export Verso.Genre.Manual.Bibliography (InProceedings Thesis ArXiv Article)
 open Bibliography
 
 @[role]
-def citep : RoleExpanderOf CiteConfig
+meta def citep : RoleExpanderOf CiteConfig
   | config, extra => do
     let xs := config.citations.map mkIdent |>.toArray
     ``(Doc.Inline.other (Inline.cite ([$xs,*] : List Citable) Style.parenthetical) #[$(← extra.mapM elabInline),*])
 
 @[role]
-def citet : RoleExpanderOf CiteConfig
+meta def citet : RoleExpanderOf CiteConfig
   | config, extra => do
     let xs := config.citations.map mkIdent |>.toArray
     ``(Doc.Inline.other (Inline.cite ([$xs,*] : List Citable) Style.textual) #[$(← extra.mapM elabInline),*])
 
 @[role]
-def citehere : RoleExpanderOf CiteConfig
+meta def citehere : RoleExpanderOf CiteConfig
   | config, extra => do
     let xs := config.citations.map mkIdent |>.toArray
     ``(Doc.Inline.other (Inline.cite ([$xs,*] : List Citable) Style.here) #[$(← extra.mapM elabInline),*])

--- a/src/verso-manual/VersoManual/Diagrams.lean
+++ b/src/verso-manual/VersoManual/Diagrams.lean
@@ -3,10 +3,16 @@ Copyright (c) 2024-2026 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import VersoManual.Basic
-import VersoManual.InlineLean.Scopes
-import VersoIlluminate
+public import VersoManual.Basic
+public import VersoManual.InlineLean.Scopes
+public meta import VersoManual.InlineLean.Scopes
+public import VersoIlluminate
+public meta import VersoIlluminate
+public meta import Verso.Doc.Elab.Monad
+
+public section
 
 open Lean Elab
 open Verso ArgParse Doc Elab Genre.Manual Html
@@ -55,7 +61,7 @@ section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
 /-- Argument parser for `DiagramConfig`. -/
-def DiagramConfig.parse : ArgParse m DiagramConfig :=
+meta def DiagramConfig.parse : ArgParse m DiagramConfig :=
   DiagramConfig.mk <$>
     (CssWidth.width <$> .named' `cssWidth false <|>
       CssWidth.scale <$> .named `cssScale .float false <|>
@@ -63,7 +69,7 @@ def DiagramConfig.parse : ArgParse m DiagramConfig :=
     <*> .named' `texWidth true
     <*> .flag `inline false
 
-instance : FromArgs DiagramConfig m := ⟨DiagramConfig.parse⟩
+meta instance : FromArgs DiagramConfig m := ⟨DiagramConfig.parse⟩
 
 end
 
@@ -144,7 +150,7 @@ automatically to the preamble), the `inkscape` binary, and `lualatex -shell-esca
 those, the document compiles to HTML but the PDF build will fail when it reaches a diagram.
 -/
 @[code_block]
-def diagram : CodeBlockExpanderOf DiagramConfig
+meta def diagram : CodeBlockExpanderOf DiagramConfig
   | cfg, str => do
     let (svg, diagramWidth) ← elabAndStoreDiagram str
       (scope := fun act => runWithOpenDecls <| runWithVariables fun _ => act)

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -3,37 +3,49 @@ Copyright (c) 2024 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.PrettyPrinter.Delaborator.Builtins
-import Lean.Elab.Term
-import Lean.DocString
-import Lean.Widget.TaggedText
-import Lean.Meta.Reduce
+module
+-- `docs_for%` reads the docstrings of `Bool`'s constructors at elaboration time; `import all`
+-- makes that metadata available when building in batch mode.
+meta import all Init.Prelude
+public import Lean.PrettyPrinter.Delaborator.Builtins
+public import Lean.Elab.Term
+public import Lean.DocString
+public meta import Lean.DocString
+public import Lean.Widget.TaggedText
+public import Lean.Meta.Reduce
 
-import Std.Data.HashSet
+public import Std.Data.HashSet
 
-import VersoManual.Basic
-import VersoManual.HighlightedCode
-import VersoManual.Index
-import VersoManual.Markdown
-import VersoManual.Docstring.Basic
-import VersoManual.Docstring.Config
-import VersoManual.Docstring.DocName
-import VersoManual.Docstring.PrettyPrint
-import VersoManual.Docstring.Progress
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+public import VersoManual.Index
+public import VersoManual.Markdown
+public meta import VersoManual.Markdown
+public import VersoManual.Docstring.Basic
+public meta import VersoManual.Docstring.Basic
+public import VersoManual.Docstring.Config
+public meta import VersoManual.Docstring.Config
+public import VersoManual.Docstring.DocName
+public meta import VersoManual.Docstring.DocName
+public import VersoManual.Docstring.PrettyPrint
+public meta import VersoManual.Docstring.PrettyPrint
+public import VersoManual.Docstring.Progress
 
-import Verso.Instances
-import Verso.Code
-import Verso.Doc.Elab.Block
-import Verso.Doc.Elab.Monad
-import Verso.Doc.ArgParse
-import Verso.Doc.DocName
-import Verso.Doc.PointOfInterest
-import Verso.Doc.Suggestion.Basic
+public import Verso.Instances
+public import Verso.Code
+public meta import Verso.Code.Highlighted
+public import Verso.Doc.Elab.Block
+public import Verso.Doc.Elab.Monad
+public import Verso.Doc.ArgParse
+public import Verso.Doc.DocName
+public import Verso.Doc.PointOfInterest
+public meta import Verso.Doc.PointOfInterest
+public import Verso.Doc.Suggestion.Basic
 
 
-import SubVerso.Highlighting
+public import SubVerso.Highlighting
 
-import MD4Lean
+public import MD4Lean
 
 
 open Lean
@@ -57,7 +69,7 @@ open Verso.Doc.Suggestion
 
 variable {m} [Monad m] [MonadOptions m] [MonadEnv m] [MonadLiftT CoreM m] [MonadError m] [MonadLog m] [AddMessageContext m] [MonadInfoTree m] [MonadLiftT MetaM m]
 
-def ValDesc.documentableName : ValDesc m (Ident × Name) where
+meta def ValDesc.documentableName : ValDesc m (Ident × Name) where
   description := "a name with documentation"
   signature := .Ident
   get
@@ -83,7 +95,7 @@ def ValDesc.documentableName : ValDesc m (Ident × Name) where
 
 end Verso.ArgParse
 
-private def renderTaggedInMeta (code : Lean.Widget.CodeWithInfos) : MetaM Highlighted := do
+private meta def renderTaggedInMeta (code : Lean.Widget.CodeWithInfos) : MetaM Highlighted := do
   let hlCtx : SubVerso.Highlighting.Context := ⟨{}, false, false, [], false, (← IO.mkRef {})⟩
   (renderTagged none code : ReaderT SubVerso.Highlighting.Context MetaM _) hlCtx
 
@@ -91,9 +103,15 @@ namespace Verso.Genre.Manual.Block.Docstring
 
 inductive Visibility where
   | «public» | «private» | «protected»
-deriving Inhabited, Repr, ToJson, FromJson, DecidableEq, Ord, Quote
+deriving Inhabited, Repr, ToJson, FromJson, DecidableEq, Ord
 
-def Visibility.of (env : Environment) (n : Name) : Visibility :=
+meta instance : Quote Visibility where
+  quote
+    | .public => Syntax.mkCApp ``Visibility.public #[]
+    | .private => Syntax.mkCApp ``Visibility.private #[]
+    | .protected => Syntax.mkCApp ``Visibility.protected #[]
+
+meta def Visibility.of (env : Environment) (n : Name) : Visibility :=
   if isPrivateName n then .private else if isProtected env n then .protected else .public
 
 structure FieldInfo where
@@ -111,7 +129,14 @@ structure FieldInfo where
   autoParam  : Bool
   docString? : Option String
   visibility : Visibility
-deriving Inhabited, Repr, ToJson, FromJson, Quote
+deriving Inhabited, Repr, ToJson, FromJson
+
+meta instance : Quote FieldInfo where
+  quote
+    | {fieldName, fieldFrom, type, projFn, subobject?, binderInfo, autoParam, docString?, visibility} =>
+      Syntax.mkCApp ``FieldInfo.mk #[
+        quote fieldName, quote fieldFrom, quote type, quote projFn, quote subobject?,
+        quote binderInfo, quote autoParam, quote docString?, quote visibility]
 
 
 structure ParentInfo where
@@ -119,7 +144,12 @@ structure ParentInfo where
   name : Name
   parent : Highlighted
   index : Nat
-deriving ToJson, FromJson, Quote
+deriving ToJson, FromJson
+
+meta instance : Quote ParentInfo where
+  quote
+    | {projFn, name, parent, index} =>
+      Syntax.mkCApp ``ParentInfo.mk #[quote projFn, quote name, quote parent, quote index]
 
 inductive DeclType where
   /--
@@ -135,7 +165,23 @@ inductive DeclType where
   | recursor (safety : DefinitionSafety)
   | quotPrim (kind : QuotKind)
   | other
-deriving ToJson, FromJson, Quote
+deriving ToJson, FromJson
+
+meta instance : Quote DeclType where
+  quote
+    | .structure isClass constructor fieldNames fieldInfo parents ancestors =>
+      Syntax.mkCApp ``DeclType.structure #[
+        quote isClass, quote constructor, quote fieldNames, quote fieldInfo, quote parents, quote ancestors]
+    | .def safety => Syntax.mkCApp ``DeclType.def #[quote safety]
+    | .opaque safety => Syntax.mkCApp ``DeclType.opaque #[quote safety]
+    | .inductive constructors numArgs propOnly =>
+      Syntax.mkCApp ``DeclType.inductive #[quote constructors, quote numArgs, quote propOnly]
+    | .axiom safety => Syntax.mkCApp ``DeclType.axiom #[quote safety]
+    | .theorem => Syntax.mkCApp ``DeclType.theorem #[]
+    | .ctor ofInductive safety => Syntax.mkCApp ``DeclType.ctor #[quote ofInductive, quote safety]
+    | .recursor safety => Syntax.mkCApp ``DeclType.recursor #[quote safety]
+    | .quotPrim kind => Syntax.mkCApp ``DeclType.quotPrim #[quote kind]
+    | .other => Syntax.mkCApp ``DeclType.other #[]
 
 def DeclType.label : DeclType → String
   | .structure false .. => "structure"
@@ -158,7 +204,7 @@ def DeclType.label : DeclType → String
   | .other => ""
 
 
-partial def getStructurePathToBaseStructureAux (env : Environment) (baseStructName : Name) (structName : Name) (path : List Name) : Option (List Name) :=
+meta partial def getStructurePathToBaseStructureAux (env : Environment) (baseStructName : Name) (structName : Name) (path : List Name) : Option (List Name) :=
   if baseStructName == structName then
     some path.reverse
   else
@@ -180,12 +226,12 @@ partial def getStructurePathToBaseStructureAux (env : Environment) (baseStructNa
 If `baseStructName` is an ancestor structure for `structName`, then return a sequence of projection functions
 to go from `structName` to `baseStructName`. Returns `[]` if `baseStructName == structName`.
 -/
-def getStructurePathToBaseStructure? (env : Environment) (baseStructName : Name) (structName : Name) : Option (List Name) :=
+meta def getStructurePathToBaseStructure? (env : Environment) (baseStructName : Name) (structName : Name) : Option (List Name) :=
   getStructurePathToBaseStructureAux env baseStructName structName []
 
 
 open Meta in
-def DeclType.ofName (c : Name)
+meta def DeclType.ofName (c : Name)
     (hideFields : Bool := false)
     (hideStructureConstructor : Bool := false) :
     MetaM DeclType := do
@@ -311,7 +357,7 @@ def constructorSignature (signature : Highlighted) : Block where
 end Block
 
 
-def Signature.forName [Monad m] [MonadWithOptions m] [MonadEnv m] [MonadMCtx m] [MonadOptions m] [MonadResolveName m] [MonadNameGenerator m] [MonadLiftT MetaM m] [MonadLiftT BaseIO m] [MonadLiftT IO m] [MonadFileMap m] [Alternative m] (name : Name) : m Signature := do
+meta def Signature.forName [Monad m] [MonadWithOptions m] [MonadEnv m] [MonadMCtx m] [MonadOptions m] [MonadResolveName m] [MonadNameGenerator m] [MonadLiftT MetaM m] [MonadLiftT BaseIO m] [MonadLiftT IO m] [MonadFileMap m] [Alternative m] (name : Name) : m Signature := do
   let (⟨fmt, infos⟩ : FormatWithInfos) ← withOptions (·.setBool `pp.tagAppFns true) <| Block.Docstring.ppSignature name (constantInfo := false)
 
   let ctx := {
@@ -891,7 +937,7 @@ def leanFromMarkdown.blockdescr : BlockDescr := withHighlighting {
 }
 
 open Lean Elab Term in
-def tryElabCodeTermWith (mk : Highlighted → String → DocElabM α) (str : String) (ignoreElabErrors := false) (identOnly := false) : DocElabM α := do
+meta def tryElabCodeTermWith (mk : Highlighted → String → DocElabM α) (str : String) (ignoreElabErrors := false) (identOnly := false) : DocElabM α := do
   let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos
   let src :=
     if let some ⟨line, col⟩ := loc then s!"<docstring at {← getFileName}:{line}:{col}>"
@@ -936,7 +982,7 @@ scoped syntax (name := docMetavar) term ":" term : doc_metavar
 
 
 open Lean Elab Term in
-def tryElabCodeMetavarTermWith (mk : Highlighted → String → DocElabM α) (str : String) (ignoreElabErrors := false) : DocElabM α := do
+meta def tryElabCodeMetavarTermWith (mk : Highlighted → String → DocElabM α) (str : String) (ignoreElabErrors := false) : DocElabM α := do
   let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos
   let src :=
     if let some ⟨line, col⟩ := loc then s!"<docstring at {← getFileName}:{line}:{col}>"
@@ -976,25 +1022,25 @@ def tryElabCodeMetavarTermWith (mk : Highlighted → String → DocElabM α) (st
       throwError "Not a doc metavar: {stx}"
 
 open Lean Elab Term in
-def tryElabInlineCodeTerm (str : String) (ignoreElabErrors := false) (identOnly := false) : DocElabM Term :=
+meta def tryElabInlineCodeTerm (str : String) (ignoreElabErrors := false) (identOnly := false) : DocElabM Term :=
   tryElabCodeTermWith (ignoreElabErrors := ignoreElabErrors) (identOnly := identOnly) (fun hls str =>
     ``(Verso.Doc.Inline.other (Inline.leanFromMarkdown $(quote hls)) #[Verso.Doc.Inline.code $(quote str)]))
     str
 
 open Lean Elab Term in
-def tryElabInlineCodeMetavarTerm (str : String) (ignoreElabErrors := false) : DocElabM Term :=
+meta def tryElabInlineCodeMetavarTerm (str : String) (ignoreElabErrors := false) : DocElabM Term :=
   tryElabCodeMetavarTermWith (ignoreElabErrors := ignoreElabErrors) (fun hls str =>
     ``(Verso.Doc.Inline.other (Inline.leanFromMarkdown $(quote hls)) #[Verso.Doc.Inline.code $(quote str)]))
     str
 
 open Lean Elab Term in
-def tryElabBlockCodeTerm (str : String)  (ignoreElabErrors := false) : DocElabM Term :=
+meta def tryElabBlockCodeTerm (str : String)  (ignoreElabErrors := false) : DocElabM Term :=
   tryElabCodeTermWith (ignoreElabErrors := ignoreElabErrors) (fun hls str =>
     ``(Verso.Doc.Block.other (Block.leanFromMarkdown $(quote hls)) #[Verso.Doc.Block.code $(quote str)]))
     str
 
 open Lean Elab Term in
-def tryParseInlineCodeTactic (str : String) : DocElabM Term := do
+meta def tryParseInlineCodeTactic (str : String) : DocElabM Term := do
   let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos
   let src :=
     if let some ⟨line, col⟩ := loc then s!"<docstring at {← getFileName}:{line}:{col}>"
@@ -1008,7 +1054,7 @@ def tryParseInlineCodeTactic (str : String) : DocElabM Term := do
     ``(Verso.Doc.Inline.other (Inline.leanFromMarkdown $(quote hls)) #[Verso.Doc.Inline.code $(quote str)])
 
 open Lean Elab Term in
-def tryInlineOption (str : String) : DocElabM Term := do
+meta def tryInlineOption (str : String) : DocElabM Term := do
   let optName := str.trimAscii.toName
   let optDecl ← getOptionDecl optName
   let hl : Highlighted := optTok optName optDecl.declName optDecl.descr
@@ -1018,7 +1064,7 @@ where
     .token ⟨.option name declName descr, name.toString⟩
 
 open Lean Elab in
-def tryTacticName (tactics : Array Tactic.Doc.TacticDoc) (str : String) : DocElabM Term := do
+meta def tryTacticName (tactics : Array Tactic.Doc.TacticDoc) (str : String) : DocElabM Term := do
   for t in tactics do
     if t.userName == str then
       let hl : Highlighted := tacToken t
@@ -1030,7 +1076,7 @@ where
 
 open Lean Elab Term in
 open Lean.Parser in
-def tryHighlightKeywords (extraKeywords : Array String) (str : String) : DocElabM Term := do
+meta def tryHighlightKeywords (extraKeywords : Array String) (str : String) : DocElabM Term := do
   let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos
   let src :=
     if let some ⟨line, col⟩ := loc then s!"<docstring at {← getFileName}:{line}:{col}>"
@@ -1070,14 +1116,14 @@ syntax (name := plain) attr : braces_attr
 syntax (name := bracketed) "[" attr "]" : braces_attr
 syntax (name := atBracketed) "@[" attr "]" : braces_attr
 
-private def getAttr : Syntax → Syntax
+private meta def getAttr : Syntax → Syntax
   | `(plain| $a)
   | `(bracketed| [ $a ] )
   | `(atBracketed| @[ $a ]) => a
   | _ => .missing
 
 open Lean Elab Term in
-def tryParseInlineCodeAttribute (validate := true) (str : String) : DocElabM Term := do
+meta def tryParseInlineCodeAttribute (validate := true) (str : String) : DocElabM Term := do
   let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos
   let src :=
     if let some ⟨line, col⟩ := loc then s!"<docstring at {← getFileName}:{line}:{col}>"
@@ -1104,7 +1150,7 @@ def tryParseInlineCodeAttribute (validate := true) (str : String) : DocElabM Ter
       ``(Verso.Doc.Inline.other (Inline.leanFromMarkdown $(quote hls)) #[Verso.Doc.Inline.code $(quote str)])
 
 
-private def indentColumn (str : String) : Nat := Id.run do
+private meta def indentColumn (str : String) : Nat := Id.run do
   let mut i : Option Nat := none
   for line in str.splitToList (· == '\n') do
     let leading := line.takeWhile Char.isWhitespace
@@ -1135,7 +1181,7 @@ private def indentColumn (str : String) : Nat := Id.run do
 #eval indentColumn "   abc\n\n  def\n    a"
 
 open Lean Elab Term in
-def tryElabBlockCodeCommand (str : String) (ignoreElabErrors := false) : DocElabM Term := do
+meta def tryElabBlockCodeCommand (str : String) (ignoreElabErrors := false) : DocElabM Term := do
     let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos
     let src :=
       if let some ⟨line, col⟩ := loc then s!"<docstring at {← getFileName}:{line}:{col}>"
@@ -1178,7 +1224,7 @@ def tryElabBlockCodeCommand (str : String) (ignoreElabErrors := false) : DocElab
 
 
 open Lean Elab Term in
-def tryElabInlineCodeName (str : String) : DocElabM Term := do
+meta def tryElabInlineCodeName (str : String) : DocElabM Term := do
   let str := str.trimAscii
   let x := str.toName
   if x.toString.toSlice == str then
@@ -1198,7 +1244,7 @@ where
     pure <| .token ⟨.const name sig docs false none, str⟩
 
 open Lean Elab Term in
-private def attempt (str : String) (xs : List (String → DocElabM α)) : DocElabM α := do
+private meta def attempt (str : String) (xs : List (String → DocElabM α)) : DocElabM α := do
   match xs with
   | [] => throwError "No attempt succeeded"
   | [x] => x str
@@ -1216,7 +1262,7 @@ private def attempt (str : String) (xs : List (String → DocElabM α)) : DocEla
 
 
 open Lean Elab Term in
-def tryElabInlineCodeUsing (elabs : List (String → DocElabM Term))
+meta def tryElabInlineCodeUsing (elabs : List (String → DocElabM Term))
     (priorWord : Option String) (str : String) : DocElabM Term := do
   -- Don't try to show Lake commands as terms
   if "lake ".isPrefixOf str then return (← ``(Verso.Doc.Inline.code $(quote str)))
@@ -1239,7 +1285,7 @@ where
     | _ => []
 
 open Elab in
-def tryElabInlineCode (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
+meta def tryElabInlineCode (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
     (priorWord : Option String) (str : String) : DocElabM Term :=
   tryElabInlineCodeUsing [
     tryElabInlineCodeName,
@@ -1262,7 +1308,7 @@ Like `tryElabInlineCode`, but prefers producing un-highlighted code blocks to
 displaying metavariable-typed terms (e.g., through auto-bound implicits or
 elaboration failures).
 -/
-def tryElabInlineCodeStrict (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
+meta def tryElabInlineCodeStrict (allTactics : Array Tactic.Doc.TacticDoc) (extraKeywords : Array String)
     (priorWord : Option String) (str : String) : DocElabM Term :=
   tryElabInlineCodeUsing [
     tryElabInlineCodeName,
@@ -1278,7 +1324,7 @@ def tryElabInlineCodeStrict (allTactics : Array Tactic.Doc.TacticDoc) (extraKeyw
   ] priorWord str
 
 open Lean Elab Term in
-def tryElabBlockCode (_info? _lang? : Option String) (str : String) : DocElabM Term := do
+meta def tryElabBlockCode (_info? _lang? : Option String) (str : String) : DocElabM Term := do
   try
     attempt str [
       tryElabBlockCodeCommand,
@@ -1304,7 +1350,7 @@ Heuristically elaborate Lean fragments in Markdown code. The provided names are 
 from left to right, with the names bound by the signature being available in the local scope in
 which the Lean fragments are elaborated.
 -/
-def blockFromMarkdownWithLean (names : List Name) (b : MD4Lean.Block) : DocElabM Term := do
+meta def blockFromMarkdownWithLean (names : List Name) (b : MD4Lean.Block) : DocElabM Term := do
   unless (← Docstring.getElabMarkdown) do
     return (← Markdown.blockFromMarkdown b (handleHeaders := Markdown.strongEmphHeaders))
   let tactics ← Elab.Tactic.Doc.allTacticDocs
@@ -1365,7 +1411,7 @@ section
 variable [Monad m] [MonadOptions m] [MonadEnv m] [MonadLiftT CoreM m] [MonadLiftT MetaM m] [MonadError m]
 variable [MonadLog m] [AddMessageContext m] [Elab.MonadInfoTree m]
 
-def DocstringConfig.parse : ArgParse m DocstringConfig :=
+meta def DocstringConfig.parse : ArgParse m DocstringConfig :=
   DocstringConfig.mk <$>
     .positional `name .documentableName <*>
     .flagM `allowMissing (verso.docstring.allowMissing.get <$> getOptions)
@@ -1374,12 +1420,12 @@ def DocstringConfig.parse : ArgParse m DocstringConfig :=
     .flag `hideStructureConstructor false <*>
     .named `label .string true
 
-instance : FromArgs DocstringConfig m := ⟨DocstringConfig.parse⟩
+meta instance : FromArgs DocstringConfig m := ⟨DocstringConfig.parse⟩
 
 end
 
 @[block_command]
-def docstring : BlockCommandOf DocstringConfig
+meta def docstring : BlockCommandOf DocstringConfig
   | ⟨(x, name), allowMissing, hideFields, hideCtor, customLabel⟩ => do
     let opts : Options → Options := (verso.docstring.allowMissing.set · allowMissing)
 
@@ -1470,16 +1516,16 @@ structure IncludeDocstringOpts where
   name : Name
   elaborate : Bool
 
-def IncludeDocstringOpts.parse : ArgParse m IncludeDocstringOpts :=
+meta def IncludeDocstringOpts.parse : ArgParse m IncludeDocstringOpts :=
   IncludeDocstringOpts.mk <$> (.positional `name .documentableName <&> (·.2)) <*> .flag `elab true
 
-instance : FromArgs IncludeDocstringOpts m where
+meta instance : FromArgs IncludeDocstringOpts m where
   fromArgs := IncludeDocstringOpts.parse
 
 end
 
 @[block_command]
-def includeDocstring : BlockCommandOf IncludeDocstringOpts
+meta def includeDocstring : BlockCommandOf IncludeDocstringOpts
   | {name, elaborate} => do
     let fromMd :=
       if elaborate then
@@ -1517,7 +1563,7 @@ elab "sig_for%" name:ident : term => do
   pure <| .lit <| .strVal tt.stripTags
 
 
-def highlightDataValue (v : DataValue) : Highlighted :=
+meta def highlightDataValue (v : DataValue) : Highlighted :=
   .token <|
     match v with
     | .ofString (v : String) => ⟨.str (some v) false, toString v⟩
@@ -1533,10 +1579,10 @@ def highlightDataValue (v : DataValue) : Highlighted :=
 
 @[expose]
 def optionDocs.Args := Ident
-instance : FromArgs optionDocs.Args DocElabM := ⟨.positional `name .ident "The option name"⟩
+meta instance : FromArgs optionDocs.Args DocElabM := ⟨.positional `name .ident "The option name"⟩
 
 @[block_command]
-def optionDocs : BlockCommandOf optionDocs.Args
+meta def optionDocs : BlockCommandOf optionDocs.Args
   | x => do
     let optDecl ← getOptionDecl x.getId
     Doc.PointOfInterest.save x.raw optDecl.declName.toString
@@ -1614,7 +1660,7 @@ section
 
 variable [Monad m] [MonadError m] [MonadLiftT CoreM m] [MonadOptions m]
 
-def TacticDocsOptions.parse  : ArgParse m TacticDocsOptions :=
+meta def TacticDocsOptions.parse  : ArgParse m TacticDocsOptions :=
   TacticDocsOptions.mk <$>
     .positional `name strOrName <*>
     .named `show .string true <*>
@@ -1631,12 +1677,12 @@ where
       | .num n => throwErrorAt n "Expected tactic name (either first token as string, or internal parser name)"
   }
 
-instance : FromArgs TacticDocsOptions m := ⟨TacticDocsOptions.parse⟩
+meta instance : FromArgs TacticDocsOptions m := ⟨TacticDocsOptions.parse⟩
 
 end
 
 open Lean Elab Term Parser Tactic Doc in
-private def getTactic (name : StrLit ⊕ Ident) : TermElabM TacticDoc := do
+private meta def getTactic (name : StrLit ⊕ Ident) : TermElabM TacticDoc := do
   for t in ← allTacticDocs do
     match name with
     | .inr name => if t.internalName == name.getId then return t
@@ -1650,7 +1696,7 @@ private def getTactic (name : StrLit ⊕ Ident) : TermElabM TacticDoc := do
 
 
 open Lean Elab Term Parser Tactic Doc in
-private def getTacticOverloads (name : StrLit ⊕ Ident) : TermElabM (Array TacticDoc) := do
+private meta def getTacticOverloads (name : StrLit ⊕ Ident) : TermElabM (Array TacticDoc) := do
   let mut out := #[]
   for t in ← allTacticDocs do
     match name with
@@ -1667,14 +1713,14 @@ private def getTacticOverloads (name : StrLit ⊕ Ident) : TermElabM (Array Tact
 
 
 open Lean Elab Term Parser Tactic Doc in
-private def getTactic? (name : String ⊕ Name) : TermElabM (Option TacticDoc) := do
+private meta def getTactic? (name : String ⊕ Name) : TermElabM (Option TacticDoc) := do
   for t in ← allTacticDocs do
     if .inr t.internalName == name || .inl t.userName == name then
       return some t
   return none
 
 @[directive]
-def tactic : DirectiveExpanderOf TacticDocsOptions
+meta def tactic : DirectiveExpanderOf TacticDocsOptions
   | opts, more => do
     let tactics ← getTacticOverloads opts.name
     let blame : Syntax := opts.name.elim TSyntax.raw TSyntax.raw
@@ -1774,15 +1820,15 @@ structure TacticInlineOptions where
 section
 variable [Monad m] [MonadError m]
 
-def TacticInlineOptions.parse : ArgParse m TacticInlineOptions :=
+meta def TacticInlineOptions.parse : ArgParse m TacticInlineOptions :=
   TacticInlineOptions.mk <$> .named `show .string true
 
-instance : FromArgs TacticInlineOptions m where
+meta instance : FromArgs TacticInlineOptions m where
   fromArgs := TacticInlineOptions.parse
 end
 
 @[role tactic]
-def tacticInline : RoleExpanderOf TacticInlineOptions
+meta def tacticInline : RoleExpanderOf TacticInlineOptions
   | {«show»}, inlines => do
     let #[arg] := inlines
       | throwError "Expected exactly one argument"
@@ -1831,7 +1877,7 @@ structure ConvTacticDoc where
   docs? : Option String
 
 open Lean Elab Term Parser Tactic Doc in
-def getConvTactic (name : StrLit ⊕ Ident) (allowMissing : Option Bool) : TermElabM ConvTacticDoc :=
+meta def getConvTactic (name : StrLit ⊕ Ident) (allowMissing : Option Bool) : TermElabM ConvTacticDoc :=
   withOptions (allowMissing.map (fun b opts => verso.docstring.allowMissing.set opts b) |>.getD id) do
     let .inr kind := name
       | throwError "Strings not yet supported here"
@@ -1844,7 +1890,7 @@ def getConvTactic (name : StrLit ⊕ Ident) (allowMissing : Option Bool) : TermE
     throwError m!"Conv tactic not found: {kind}"
 
 @[directive]
-def conv : DirectiveExpanderOf TacticDocsOptions
+meta def conv : DirectiveExpanderOf TacticDocsOptions
   | opts, more => do
     let tactic ← getConvTactic opts.name opts.allowMissing
     Doc.PointOfInterest.save (← getRef) tactic.name.toString
@@ -1939,7 +1985,7 @@ inline_extension Inline.conv (hl : Highlighted) via withHighlighting where
         hl.inlineHtml (g := Manual) "examples"
 
 @[role_expander conv]
-def convInline : RoleExpander
+meta def convInline : RoleExpander
   | _args, inlines => do
     let #[arg] := inlines
       | throwError "Expected exactly one argument"

--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1161,25 +1161,6 @@ private meta def indentColumn (str : String) : Nat := Id.run do
     else i := some leading.length
   return i.getD 0
 
-/-- info: 0 -/
-#guard_msgs in
-#eval indentColumn ""
-/-- info: 0 -/
-#guard_msgs in
-#eval indentColumn "abc"
-/-- info: 3 -/
-#guard_msgs in
-#eval indentColumn "   abc"
-/-- info: 3 -/
-#guard_msgs in
-#eval indentColumn "   abc\n\n   def"
-/-- info: 2 -/
-#guard_msgs in
-#eval indentColumn "   abc\n\n  def"
-/-- info: 2 -/
-#guard_msgs in
-#eval indentColumn "   abc\n\n  def\n    a"
-
 open Lean Elab Term in
 meta def tryElabBlockCodeCommand (str : String) (ignoreElabErrors := false) : DocElabM Term := do
     let loc := (← getRef).getPos?.map (← getFileMap).utf8PosToLspPos

--- a/src/verso-manual/VersoManual/Docstring/Basic.lean
+++ b/src/verso-manual/VersoManual/Docstring/Basic.lean
@@ -17,16 +17,32 @@ open SubVerso.Highlighting
 
 namespace Verso.Genre.Manual
 
+/--
+Reads the docstring of `declName`, logging an error when none is found.
+
+The error is demoted to a warning if `verso.docstring.allowMissing` is set.
+
+This is the entry point for rendering a declaration's documentation. Lookups that treat a missing
+docstring as ordinary, such as hover tokens for cross-referenced constants, should call `findDocString?`
+directly.
+-/
 public def getDocString?
     [Monad m] [MonadLiftT IO m] [MonadOptions m] [MonadLog m] [AddMessageContext m]
     (env : Environment) (declName : Name) :
     m (Option String) := do
   let docs? ← findDocString? env declName
   if docs?.isNone then
+    let importAllHint :=
+      if env.header.isModule then
+        match env.getModuleIdxFor? declName |>.bind (env.allImportedModuleNames[·.toNat]?) with
+        | some mod =>
+          m!"If `{.ofConstName declName}` is documented, add `import all {mod}` to import docstrings from `{mod}`.".hint'
+        | none => m!""
+      else m!""
     if !(← Verso.Genre.Manual.Docstring.getAllowMissing) then
-      Lean.logError m!"'{declName}' is not documented.\n\nSet option 'verso.docstring.allowMissing' to 'true' to allow missing docstrings."
+      Lean.logError m!"'{declName}' is not documented.{importAllHint}\n\nSet option 'verso.docstring.allowMissing' to 'true' to allow missing docstrings."
     else
-      Lean.logWarning m!"'{declName}' is not documented.\n\nSet option 'verso.docstring.allowMissing' to 'false' to disallow missing docstrings."
+      Lean.logWarning m!"'{declName}' is not documented.{importAllHint}\n\nSet option 'verso.docstring.allowMissing' to 'false' to disallow missing docstrings."
   return docs?
 
 

--- a/src/verso-manual/VersoManual/ExternalLean.lean
+++ b/src/verso-manual/VersoManual/ExternalLean.lean
@@ -4,12 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Verso
-import VersoManual.Basic
-import VersoManual.HighlightedCode
-import Verso.Code.External
-import Verso.Code.HighlightedToTex
-import SubVerso.Examples.Messages
+module
+public import Verso
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+public import Verso.Code.External
+public import Verso.Code.HighlightedToTex
+public import SubVerso.Examples.Messages
+
+public section
 
 set_option linter.missingDocs true
 

--- a/src/verso-manual/VersoManual/Imports.lean
+++ b/src/verso-manual/VersoManual/Imports.lean
@@ -4,10 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab
-import SubVerso.Highlighting.Code
-import VersoManual.ExternalLean
+module
+public import Verso.Doc.ArgParse
+public import Verso.Doc.Elab
+public import SubVerso.Highlighting.Code
+public import VersoManual.ExternalLean
+public meta import Verso.Doc.Elab.Monad
+
+public section
 
 open scoped Lean.Doc.Syntax
 
@@ -22,14 +26,14 @@ namespace Verso.Genre.Manual
 structure ImportsParams where
   «show» : Bool := true
 
-instance : FromArgs ImportsParams m where
+meta instance : FromArgs ImportsParams m where
   fromArgs := ImportsParams.mk <$> .flag `show true (some "Whether to show the import header")
 
 /--
 Parses, but does not validate, a module header.
 -/
 @[code_block]
-def imports : CodeBlockExpanderOf ImportsParams
+meta def imports : CodeBlockExpanderOf ImportsParams
   | { «show» } , str => do
     let p := Parser.whitespace >> Parser.Module.header.fn
     let headerStx ← parseStrLitWith p str

--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -3,26 +3,33 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import Lean.Elab.Command
-import Lean.Elab.InfoTree
+public import Lean.Elab.Command
+public import Lean.Elab.InfoTree
+public import Lean.Linter.UnusedVariables
 
-import SubVerso.Highlighting
-import SubVerso.Examples
+public import SubVerso.Highlighting
+public import SubVerso.Examples
+public meta import SubVerso.Examples.Messages
+public meta import SubVerso.Examples.Messages.NormalizeMetavars
 
-import Verso
+public import Verso
 
-import VersoManual.Basic
-import VersoManual.HighlightedCode
-import VersoManual.InlineLean.Block
-import VersoManual.InlineLean.IO
-import VersoManual.InlineLean.LongLines
-import VersoManual.InlineLean.Option
-import VersoManual.InlineLean.Outputs
-import VersoManual.InlineLean.Scopes
-import VersoManual.InlineLean.Signature
-import VersoManual.InlineLean.SyntaxError
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+public import VersoManual.InlineLean.Block
+public import VersoManual.InlineLean.IO
+public import VersoManual.InlineLean.LongLines
+public meta import VersoManual.InlineLean.LongLines
+public import VersoManual.InlineLean.Option
+public import VersoManual.InlineLean.Outputs
+public import VersoManual.InlineLean.Scopes
+public meta import VersoManual.InlineLean.Scopes
+public import VersoManual.InlineLean.Signature
+public import VersoManual.InlineLean.SyntaxError
 
+public section
 
 open Verso ArgParse Doc Elab Genre.Manual Html Code Highlighted.WebAssets ExpectString
 open Lean Elab
@@ -84,10 +91,10 @@ structure LeanBlockConfig where
   error : Bool
   fresh : Bool
 
-def LeanBlockConfig.parse : ArgParse m LeanBlockConfig :=
+meta def LeanBlockConfig.parse : ArgParse m LeanBlockConfig :=
   LeanBlockConfig.mk <$> .flag `show true <*> .flag `keep true <*> .named `name .name true <*> .flag `error false <*> .flag `fresh false
 
-instance : FromArgs LeanBlockConfig m := ⟨LeanBlockConfig.parse⟩
+meta instance : FromArgs LeanBlockConfig m := ⟨LeanBlockConfig.parse⟩
 
 structure LeanInlineConfig extends LeanBlockConfig where
   /-- The expected type of the term -/
@@ -95,7 +102,7 @@ structure LeanInlineConfig extends LeanBlockConfig where
   /-- Universe variables allowed in the term -/
   universes : Option StrLit
 
-def LeanInlineConfig.parse : ArgParse m LeanInlineConfig :=
+meta def LeanInlineConfig.parse : ArgParse m LeanInlineConfig :=
   LeanInlineConfig.mk <$> LeanBlockConfig.parse <*> .named `type strLit true <*> .named `universes strLit true
 where
   strLit : ValDesc m StrLit := {
@@ -106,19 +113,19 @@ where
       | other => throwError "Expected string, got {repr other}"
   }
 
-instance : FromArgs LeanInlineConfig m := ⟨LeanInlineConfig.parse⟩
+meta instance : FromArgs LeanInlineConfig m := ⟨LeanInlineConfig.parse⟩
 
 end Config
 
 
 open Verso.Genre.Manual.InlineLean.Scopes (getScopes setScopes runWithOpenDecls runWithVariables)
 
-private def abbrevFirstLine (width : Nat) (str : String) : String :=
+private meta def abbrevFirstLine (width : Nat) (str : String) : String :=
   let str := str.trimAsciiStart
   let short := str.take width |>.replace "\n" "⏎"
   if short.toSlice == str then short else short ++ "…"
 
-def LeanBlockConfig.outlineMeta : LeanBlockConfig → String
+meta def LeanBlockConfig.outlineMeta : LeanBlockConfig → String
   | {«show», error, ..} =>
     match «show», error with
     | true, true => " (error)"
@@ -126,7 +133,7 @@ def LeanBlockConfig.outlineMeta : LeanBlockConfig → String
     | false, false => " (hidden)"
     | _, _ => " "
 
-def firstToken? (stx : Syntax) : Option Syntax :=
+meta def firstToken? (stx : Syntax) : Option Syntax :=
   stx.find? fun
     | .ident info .. => usable info
     | .atom info .. => usable info
@@ -147,7 +154,7 @@ is `some false`, then the author expected no errors; in this case, messages are 
 `none` case and an additional error is thrown. If it is `some true`, then errors are downgraded to
 warnings and all messages are logged silently.
 -/
-def reportMessages {m} [Monad m] [MonadLog m] [MonadError m]
+meta def reportMessages {m} [Monad m] [MonadLog m] [MonadError m]
     (errorExpected : Option Bool) (blame : Syntax) (messages : MessageLog) :
     m Unit := do
   match errorExpected with
@@ -179,7 +186,7 @@ within the DocElabM monad, `← quoteHighlightViaSerialization hls` will result 
 represents the same highlight as `quote hls`, but will hopefully produce smaller code because of
 quoting a compressed version of the highlighted code.
 -/
-private def quoteHighlightViaSerialization (hls : Highlighted) : DocElabM Term := do
+private meta def quoteHighlightViaSerialization (hls : Highlighted) : DocElabM Term := do
   match (( ← readThe DocElabContext).docReconstructionPlaceholder, (← getThe DocElabM.State).highlightDeduplicationTable) with
     | (.some placeholder, .some exportTable) =>
       let (key, exportTable) := hls.export.run exportTable
@@ -193,7 +200,7 @@ private def quoteHighlightViaSerialization (hls : Highlighted) : DocElabM Term :
 De-indents and returns (syntax of) a Block representation containing highlighted Lean code.
 The argument `hls` must be a highlighting of the parsed string `str`.
 -/
-private def toHighlightedLeanBlock (shouldShow : Bool) (hls : Highlighted) (str: StrLit) : DocElabM Term := do
+private meta def toHighlightedLeanBlock (shouldShow : Bool) (hls : Highlighted) (str: StrLit) : DocElabM Term := do
   if !shouldShow then
     return ← ``(Block.concat #[])
 
@@ -212,7 +219,7 @@ private def toHighlightedLeanBlock (shouldShow : Bool) (hls : Highlighted) (str:
 Returns (syntax of) an Inline representation containing highlighted Lean code.
 The argument `hls` must be a highlighting of the parsed string `str`.
 -/
-private def toHighlightedLeanInline (shouldShow : Bool) (hls : Highlighted) (str : StrLit) : DocElabM Term := do
+private meta def toHighlightedLeanInline (shouldShow : Bool) (hls : Highlighted) (str : StrLit) : DocElabM Term := do
   if !shouldShow then
     return ← ``(Inline.concat #[])
 
@@ -229,7 +236,7 @@ needs to run, so that its warnings are accurately recorded. But the linter also 
 document, at which time it can inspect the info trees left behind by the embedded Lean and generate
 spurious warnings. Turning it off before saving info trees works around this issue.
 -/
-private partial def disableUnusedVarLinterInInfoTree : InfoTree → InfoTree
+private meta partial def disableUnusedVarLinterInInfoTree : InfoTree → InfoTree
   | .context (.commandCtx ci) child =>
     .context (.commandCtx { ci with options := Lean.Linter.linter.unusedVariables.set ci.options false })
       (disableUnusedVarLinterInInfoTree child)
@@ -239,7 +246,7 @@ private partial def disableUnusedVarLinterInInfoTree : InfoTree → InfoTree
     .node info (children.map disableUnusedVarLinterInInfoTree)
   | .hole id => .hole id
 
-def elabCommands (config : LeanBlockConfig) (str : StrLit)
+meta def elabCommands (config : LeanBlockConfig) (str : StrLit)
     (toHighlightedLeanContent : (shouldShow : Bool) → (hls : Highlighted) → (str: StrLit) → DocElabM Term)
     (minCommands : Option Nat := none)
     (maxCommands : Option Nat := none) :
@@ -254,10 +261,12 @@ def elabCommands (config : LeanBlockConfig) (str : StrLit)
     let origScopes ← if config.fresh then pure [{header := ""}] else getScopes
 
     -- Turn off async elaboration so that info trees and messages are available when highlighting syntax.
+    -- Elaborate declarations as public so that documented code keeps its written names rather than
+    -- the mangled private names used in a module, and so later code blocks can refer to them.
     let origScopes := origScopes.modifyHead fun sc =>
       let opts := Elab.async.set sc.opts false
       let opts := pp.tagAppFns.set opts true
-      { sc with opts }
+      { sc with opts, isPublic := true }
 
     let text ← getFileMap
     let (ictx, startPos) ← SyntaxUtils.strLitInputContext str.raw (← getFileName)
@@ -358,11 +367,11 @@ where
 Elaborates the provided Lean command in the context of the current Verso module.
 -/
 @[code_block]
-def lean : CodeBlockExpanderOf LeanBlockConfig
+meta def lean : CodeBlockExpanderOf LeanBlockConfig
   | config, str => elabCommands config str toHighlightedLeanBlock
 
 @[role]
-def leanCommand : RoleExpanderOf LeanBlockConfig
+meta def leanCommand : RoleExpanderOf LeanBlockConfig
   | config, inls => do
     if let some str ← oneCodeStr? inls then
       elabCommands config str toHighlightedLeanInline (minCommands := some 1) (maxCommands := some 1)
@@ -374,7 +383,7 @@ def leanCommand : RoleExpanderOf LeanBlockConfig
 Elaborates the provided Lean term in the context of the current Verso module.
 -/
 @[code_block]
-def leanTerm : CodeBlockExpanderOf LeanInlineConfig
+meta def leanTerm : CodeBlockExpanderOf LeanInlineConfig
   | config, str => withoutAsync <| do
 
     let leveller :=
@@ -445,7 +454,7 @@ def leanTerm : CodeBlockExpanderOf LeanInlineConfig
 Elaborates the provided Lean term in the context of the current Verso module.
 -/
 @[role lean]
-def leanInline : RoleExpanderOf LeanInlineConfig
+meta def leanInline : RoleExpanderOf LeanInlineConfig
   -- Async elab is turned off to make sure that info trees and messages are available when highlighting
   | config, inlines => withoutAsync do
     let #[arg] := inlines
@@ -536,7 +545,7 @@ def leanInline : RoleExpanderOf LeanInlineConfig
 Elaborates the provided term in the current Verso context, then ensures that it's a type class that has an instance.
 -/
 @[role]
-def inst : RoleExpanderOf LeanBlockConfig
+meta def inst : RoleExpanderOf LeanBlockConfig
   | config, inlines => withoutAsync <| do
     let #[arg] := inlines
       | throwError "Expected exactly one argument"
@@ -588,7 +597,7 @@ def inst : RoleExpanderOf LeanBlockConfig
 Elaborates the contained document in a new section.
 -/
 @[directive_expander leanSection]
-def leanSection : DirectiveExpander
+meta def leanSection : DirectiveExpander
   | args, contents => do
     let name? ← ArgParse.run ((some <$> .positional `name .string) <|> pure none) args
     let scopes ← getScopes
@@ -656,7 +665,7 @@ structure LeanOutputConfig where
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
-def LeanOutputConfig.parser : ArgParse m LeanOutputConfig :=
+meta def LeanOutputConfig.parser : ArgParse m LeanOutputConfig :=
   LeanOutputConfig.mk <$>
     .positional `name output <*>
     .flag `show true <*>
@@ -677,16 +686,16 @@ where
       | other => throwError "Expected output name, got {repr other}"
   }
 
-instance : FromArgs LeanOutputConfig m := ⟨LeanOutputConfig.parser⟩
+meta instance : FromArgs LeanOutputConfig m := ⟨LeanOutputConfig.parser⟩
 
 end
 
-private def withNl (s : String) : String :=
+private meta def withNl (s : String) : String :=
   if s.endsWith "\n" then s else s ++ "\n"
 
 open SubVerso.Examples.Messages in
 @[code_block]
-def leanOutput : CodeBlockExpanderOf LeanOutputConfig
+meta def leanOutput : CodeBlockExpanderOf LeanOutputConfig
  | config, str => do
 
     PointOfInterest.save (← getRef) (config.name.getId.toString)
@@ -811,7 +820,7 @@ structure NameConfig where
 section
 variable [Monad m] [MonadError m] [MonadLiftT CoreM m] [MonadLiftT TermElabM m]
 
-def NameConfig.parse : ArgParse m NameConfig :=
+meta def NameConfig.parse : ArgParse m NameConfig :=
   NameConfig.mk <$> ((fun _ => none) <$> .done <|> .positional `name ref)
 where
   ref : ValDesc m (Option Name) := {
@@ -828,10 +837,10 @@ where
       | other => throwError "Expected reference name, got {repr other}"
   }
 
-instance : FromArgs NameConfig m := ⟨NameConfig.parse⟩
+meta instance : FromArgs NameConfig m := ⟨NameConfig.parse⟩
 end
 
-def constTok [Monad m] [MonadEnv m] [MonadLiftT MetaM m] [MonadLiftT IO m]
+meta def constTok [Monad m] [MonadEnv m] [MonadLiftT MetaM m] [MonadLiftT IO m]
     (name : Name) (str : String) :
     m Highlighted := do
   let docs ← findDocString? (← getEnv) name
@@ -839,7 +848,7 @@ def constTok [Monad m] [MonadEnv m] [MonadLiftT MetaM m] [MonadLiftT IO m]
   pure <| .token ⟨.const name sig docs false none, str⟩
 
 @[role]
-def name : RoleExpanderOf NameConfig
+meta def name : RoleExpanderOf NameConfig
   | cfg, #[arg] => do
     let `(inline|code( $name:str )) := arg
       | throwErrorAt arg "Expected code literal with the example name"
@@ -867,7 +876,7 @@ def name : RoleExpanderOf NameConfig
 -- Placeholder for module names (eventually hyperlinking these will be important, so better to tag them now)
 
 @[role]
-def module : RoleExpanderOf Unit
+meta def module : RoleExpanderOf Unit
   | (), #[arg] => do
     let `(inline|code( $name:str )) := arg
       | throwErrorAt arg "Expected code literal with the module's name"

--- a/src/verso-manual/VersoManual/InlineLean/Block.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Block.lean
@@ -3,14 +3,17 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import Lean.Data.Json.Basic
-import VersoManual.Basic
-import VersoManual.HighlightedCode
-import Verso.Code.Highlighted.WebAssets
-import Verso.Code.HighlightedToTex
+public import Lean.Data.Json.Basic
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+public import Verso.Code.Highlighted.WebAssets
+public import Verso.Code.HighlightedToTex
 
-import SubVerso.Highlighting
+public import SubVerso.Highlighting
+
+public section
 
 open Verso Genre Manual
 open Verso Code Highlighted WebAssets

--- a/src/verso-manual/VersoManual/InlineLean/IO.lean
+++ b/src/verso-manual/VersoManual/InlineLean/IO.lean
@@ -3,24 +3,27 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import Lean.Elab.Command
-import Lean.Elab.InfoTree
+public import Lean.Elab.Command
+public import Lean.Elab.InfoTree
 
-import Verso
-import Verso.FS
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab.Monad
-import Verso.Code
-import Verso.Instances
+public import Verso
+public import Verso.FS
+public import Verso.Doc.ArgParse
+public import Verso.Doc.Elab.Monad
+public import Verso.Code
+public import Verso.Instances
 
-import SubVerso.Highlighting
-import SubVerso.Examples
+public import SubVerso.Highlighting
+public import SubVerso.Examples
 
-import VersoManual.InlineLean.Scopes
-import VersoManual.InlineLean.IO.Context
-import VersoManual.InlineLean.Block
+public import VersoManual.InlineLean.Scopes
+public import VersoManual.InlineLean.IO.Context
+public meta import VersoManual.InlineLean.IO.Context
+public import VersoManual.InlineLean.Block
 
+public section
 
 open Verso ArgParse Doc Elab Genre.Manual Html Code Highlighted.WebAssets
 open SubVerso.Highlighting Highlighted
@@ -39,7 +42,16 @@ inductive FileType where
   | input (file : System.FilePath)
   | output (file : System.FilePath)
   | other (file : System.FilePath)
-deriving ToJson, FromJson, Repr, BEq, DecidableEq, Quote
+deriving ToJson, FromJson, Repr, BEq, DecidableEq
+
+meta instance : Quote FileType where
+  quote
+    | .stdin => Syntax.mkCApp ``FileType.stdin #[]
+    | .stdout => Syntax.mkCApp ``FileType.stdout #[]
+    | .stderr => Syntax.mkCApp ``FileType.stderr #[]
+    | .input f => Syntax.mkCApp ``FileType.input #[quote f]
+    | .output f => Syntax.mkCApp ``FileType.output #[quote f]
+    | .other f => Syntax.mkCApp ``FileType.other #[quote f]
 
 
 def Block.exampleFile (type : FileType) : Block where
@@ -49,7 +61,7 @@ structure ExampleFileConfig where
   type : FileType
   «show» : Bool := true
 
-def FileType.parse [Monad m] [MonadError m] : ArgParse m FileType :=
+meta def FileType.parse [Monad m] [MonadError m] : ArgParse m FileType :=
     (.positional `type (literally `stdin) *> pure .stdin) <|>
     (.positional `type (literally `stdout) *> pure .stdout) <|>
     (.positional `type (literally `stderr) *> pure .stderr) <|>
@@ -72,18 +84,18 @@ section
 
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
-def ExampleFileConfig.parse  : ArgParse m ExampleFileConfig :=
+meta def ExampleFileConfig.parse  : ArgParse m ExampleFileConfig :=
   ExampleFileConfig.mk <$> FileType.parse <*> (.flag `show true)
 
-def IOExample.exampleFileSyntax [Monad m] [MonadQuotation m] (type : FileType) (contents : String) : m Term := do
+meta def IOExample.exampleFileSyntax [Monad m] [MonadQuotation m] (type : FileType) (contents : String) : m Term := do
   ``(Block.other (Block.exampleFile $(quote type)) #[Block.code $(quote contents)])
 
-instance : FromArgs ExampleFileConfig m := ⟨ExampleFileConfig.parse⟩
+meta instance : FromArgs ExampleFileConfig m := ⟨ExampleFileConfig.parse⟩
 
 end
 
 @[code_block]
-def exampleFile : CodeBlockExpanderOf ExampleFileConfig
+meta def exampleFile : CodeBlockExpanderOf ExampleFileConfig
   | config, str => do
     let s := str.getString
     if config.show then
@@ -280,7 +292,7 @@ private def getSubversoDir : IO System.FilePath := do
     throw <| IO.userError s!"SubVerso directory {p} not found"
 
 
-def startExample [Monad m] [MonadEnv m] [MonadError m] [MonadQuotation m] [MonadRef m] : m Unit := do
+meta def startExample [Monad m] [MonadEnv m] [MonadError m] [MonadQuotation m] [MonadRef m] : m Unit := do
   match ioExampleCtx.getState (← getEnv) with
   | some _ => throwError "Can't initialize - already in a context"
   | none =>
@@ -288,7 +300,7 @@ def startExample [Monad m] [MonadEnv m] [MonadError m] [MonadQuotation m] [Monad
     modifyEnv fun env =>
       ioExampleCtx.setState env (some {leanCodeName})
 
-def saveLeanCode (src : StrLit) : DocElabM Ident := do
+meta def saveLeanCode (src : StrLit) : DocElabM Ident := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwError "Can't set Lean code - not in an IO example"
   | some st =>
@@ -299,19 +311,19 @@ def saveLeanCode (src : StrLit) : DocElabM Ident := do
     else throwError "Code already specified"
 
 
-def saveInputFile [Monad m] [MonadEnv m] [MonadError m] (name : System.FilePath) (contents : StrLit) : m Unit := do
+meta def saveInputFile [Monad m] [MonadEnv m] [MonadError m] (name : System.FilePath) (contents : StrLit) : m Unit := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwError "Can't save file - not in an IO example"
   | some st =>
     modifyEnv fun env => ioExampleCtx.setState env (some {st with inputFiles := st.inputFiles.push (name, contents)})
 
-def saveOutputFile [Monad m] [MonadEnv m] [MonadError m] (name : System.FilePath) (contents : StrLit) : m Unit := do
+meta def saveOutputFile [Monad m] [MonadEnv m] [MonadError m] (name : System.FilePath) (contents : StrLit) : m Unit := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwError "Can't save file - not in an IO example"
   | some st =>
     modifyEnv fun env => ioExampleCtx.setState env (some {st with outputFiles := st.outputFiles.push (name, contents)})
 
-def saveStdin [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit := do
+meta def saveStdin [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwError "Can't save stdin - not in an IO example"
   | some st =>
@@ -319,7 +331,7 @@ def saveStdin [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit
     | none => modifyEnv fun env => ioExampleCtx.setState env (some {st with stdin := some contents})
     | some _ => throwError "stdin already specified"
 
-def saveStdout [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit := do
+meta def saveStdout [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwError "Can't save stdout - not in an IO example"
   | some st =>
@@ -327,7 +339,7 @@ def saveStdout [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Uni
     | none => modifyEnv fun env => ioExampleCtx.setState env (some {st with stdout := some contents})
     | some _ => throwError "stdout already specified"
 
-def saveStderr [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit := do
+meta def saveStderr [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Unit := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwError "Can't save stderr - not in an IO example"
   | some st =>
@@ -336,7 +348,7 @@ def saveStderr [Monad m] [MonadEnv m] [MonadError m] (contents : StrLit) : m Uni
     | some _ => throwError "stderr already specified"
 
 
-def check
+meta def check
     (leanCode : StrLit) (leanCodeName : Name)
     (inputFiles outputFiles : Array (System.FilePath × StrLit))
     (stdin stdout stderr : Option StrLit) : DocElabM Highlighted :=
@@ -437,7 +449,7 @@ where
   shorten (str : String) : String :=
     if str.length < 30 then str else (str.take 30).copy ++ "…"
 
-def endExample (body : TSyntax `term) : DocElabM (TSyntax `term) := do
+meta def endExample (body : TSyntax `term) : DocElabM (TSyntax `term) := do
   match ioExampleCtx.getState (← getEnv) with
   | none => throwErrorAt body "Can't end example - never started"
   | some {code, leanCodeName, inputFiles, outputFiles, stdin, stdout, stderr} => do
@@ -459,18 +471,18 @@ structure Config where
   tag : Option String := none
   «show» : Bool := true
 
-def Config.parse : ArgParse m Config :=
+meta def Config.parse : ArgParse m Config :=
   Config.mk <$> .named `tag .string true <*> (.flag `show true)
 
-instance : FromArgs Config m := ⟨Config.parse⟩
+meta instance : FromArgs Config m := ⟨Config.parse⟩
 
 structure FileConfig extends Config where
   name : String
 
-def FileConfig.parse : ArgParse m FileConfig :=
+meta def FileConfig.parse : ArgParse m FileConfig :=
   FileConfig.mk <$> Config.parse <*> .positional `name .string
 
-instance : FromArgs FileConfig m := ⟨FileConfig.parse⟩
+meta instance : FromArgs FileConfig m := ⟨FileConfig.parse⟩
 
 end
 
@@ -478,7 +490,7 @@ end IOExample
 
 open IOExample in
 @[code_block]
-def inputFile : CodeBlockExpanderOf FileConfig
+meta def inputFile : CodeBlockExpanderOf FileConfig
   | opts, str => do
     saveInputFile opts.name str
     -- The quote step here is to prevent the editor from showing document AST internals when the
@@ -490,7 +502,7 @@ def inputFile : CodeBlockExpanderOf FileConfig
 
 open IOExample in
 @[code_block]
-def outputFile : CodeBlockExpanderOf FileConfig
+meta def outputFile : CodeBlockExpanderOf FileConfig
   | opts, str => do
     saveOutputFile opts.name str
     -- The quote step here is to prevent the editor from showing document AST internals when the
@@ -502,7 +514,7 @@ def outputFile : CodeBlockExpanderOf FileConfig
 
 open IOExample in
 @[code_block]
-def stdin : CodeBlockExpanderOf Config
+meta def stdin : CodeBlockExpanderOf Config
   | opts, str => do
     saveStdin str
     -- The quote step here is to prevent the editor from showing document AST internals when the
@@ -514,7 +526,7 @@ def stdin : CodeBlockExpanderOf Config
 
 open IOExample in
 @[code_block]
-def stdout : CodeBlockExpanderOf Config
+meta def stdout : CodeBlockExpanderOf Config
   | opts, str => do
     saveStdout str
     -- The quote step here is to prevent the editor from showing document AST internals when the
@@ -526,7 +538,7 @@ def stdout : CodeBlockExpanderOf Config
 
 open IOExample in
 @[code_block]
-def stderr : CodeBlockExpanderOf Config
+meta def stderr : CodeBlockExpanderOf Config
   | opts, str => do
     saveStderr str
     -- The quote step here is to prevent the editor from showing document AST internals when the
@@ -539,7 +551,7 @@ def stderr : CodeBlockExpanderOf Config
 
 open IOExample in
 @[code_block]
-def ioLean : CodeBlockExpanderOf Config
+meta def ioLean : CodeBlockExpanderOf Config
   | opts, str => do
     let x ← saveLeanCode str
     if opts.show then
@@ -551,7 +563,7 @@ def ioLean : CodeBlockExpanderOf Config
 
 open IOExample in
 @[directive ioExample]
-def ioExample : DirectiveExpanderOf Unit
+meta def ioExample : DirectiveExpanderOf Unit
  | (), blocks => do
     startExample
     let body ← blocks.mapM elabBlock

--- a/src/verso-manual/VersoManual/InlineLean/IO/Context.lean
+++ b/src/verso-manual/VersoManual/InlineLean/IO/Context.lean
@@ -3,8 +3,11 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import Lean.Environment
+public import Lean.Environment
+
+public section
 
 namespace Verso.Genre.Manual.InlineLean.IOExample
 

--- a/src/verso-manual/VersoManual/InlineLean/LongLines.lean
+++ b/src/verso-manual/VersoManual/InlineLean/LongLines.lean
@@ -3,10 +3,14 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Data.Lsp.Utf16
-import Lean.Data.Options
-import Lean.Data.Position
-import Lean.Log
+module
+
+public import Lean.Data.Lsp.Utf16
+public import Lean.Data.Options
+public import Lean.Data.Position
+public import Lean.Log
+
+public section
 
 open Lean MonadOptions
 

--- a/src/verso-manual/VersoManual/InlineLean/Option.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Option.lean
@@ -3,9 +3,14 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import VersoManual.Basic
-import VersoManual.HighlightedCode
+module
+
+public import Verso
+public meta import Verso.WithoutAsync
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+
+public section
 
 open SubVerso.Highlighting
 
@@ -20,7 +25,7 @@ namespace Verso.Genre.Manual.InlineLean
 def Inline.option : Inline where
 
 @[role]
-def option : RoleExpanderOf Unit
+meta def option : RoleExpanderOf Unit
   | (), inlines => withoutAsync do
     let #[arg] := inlines
       | throwError "Expected exactly one argument"

--- a/src/verso-manual/VersoManual/InlineLean/Outputs.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Outputs.lean
@@ -3,10 +3,16 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Environment
-import Lean.Message
-import Lean.Exception
-import Verso
+module
+
+public import Lean.Data.EditDistance
+public import Lean.Environment
+public import Lean.Message
+public import Lean.Exception
+public import Verso
+public import Verso.Doc.Suggestion.Basic
+
+public section
 
 open Lean
 open SubVerso.Highlighting

--- a/src/verso-manual/VersoManual/InlineLean/Scopes.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Scopes.lean
@@ -3,9 +3,12 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
+module
 
-import Lean.Elab.Command
-import Lean.Environment
+public import Lean.Elab.Command
+public import Lean.Environment
+
+public section
 
 open Lean Elab Command
 

--- a/src/verso-manual/VersoManual/InlineLean/Signature.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Signature.lean
@@ -3,12 +3,18 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Elab.InfoTree.Types
+module
 
-import Verso
-import VersoManual.Basic
-import VersoManual.HighlightedCode
-import SubVerso.Examples
+public import Lean.Elab.InfoTree.Types
+
+public import Verso
+public meta import Verso.WithoutAsync
+public meta import Verso.Code.Highlighted
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+public import SubVerso.Examples
+
+public section
 
 open SubVerso.Highlighting
 
@@ -48,16 +54,16 @@ section
 
 variable [Monad m] [MonadError m] [MonadLiftT CoreM m]
 
-def SignatureConfig.parse  : ArgParse m SignatureConfig :=
+meta def SignatureConfig.parse  : ArgParse m SignatureConfig :=
   SignatureConfig.mk <$>
     (.flag `show true)
 
-instance : FromArgs SignatureConfig m where
+meta instance : FromArgs SignatureConfig m where
   fromArgs := SignatureConfig.parse
 end
 
 @[code_block]
-def signature : CodeBlockExpanderOf SignatureConfig
+meta def signature : CodeBlockExpanderOf SignatureConfig
   | {«show»}, str => withoutAsync do
     let col? := (← getRef).getPos? |>.map (← getFileMap).utf8PosToLspPos |>.map (·.character)
 

--- a/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
+++ b/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
@@ -3,13 +3,19 @@ Copyright (c) 2024-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Elab.InfoTree.Types
+module
 
-import Verso
-import VersoManual.Basic
-import VersoManual.HighlightedCode
-import VersoManual.InlineLean.Outputs
-import SubVerso.Examples
+public import Lean.Elab.InfoTree.Types
+
+public import Verso
+public meta import Verso.WithoutAsync
+public import VersoManual.Basic
+public import VersoManual.HighlightedCode
+public import VersoManual.InlineLean.Outputs
+public meta import VersoManual.InlineLean.Outputs
+public import SubVerso.Examples
+
+public section
 
 open SubVerso.Highlighting
 
@@ -119,20 +125,20 @@ structure SyntaxErrorConfig where
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
-def SyntaxErrorConfig.parse : ArgParse m SyntaxErrorConfig :=
+meta def SyntaxErrorConfig.parse : ArgParse m SyntaxErrorConfig :=
   SyntaxErrorConfig.mk <$>
     .positional `name (ValDesc.name.as "name for later reference") <*>
     .flag `show true <*>
     .namedD `category (ValDesc.name.as "syntax category (default `command`)") `command <*>
     .namedD `precedence .nat 0
 
-instance : FromArgs SyntaxErrorConfig m := ⟨SyntaxErrorConfig.parse⟩
+meta instance : FromArgs SyntaxErrorConfig m := ⟨SyntaxErrorConfig.parse⟩
 
 end
 
 open Lean.Parser in
 @[code_block]
-def syntaxError : CodeBlockExpanderOf SyntaxErrorConfig
+meta def syntaxError : CodeBlockExpanderOf SyntaxErrorConfig
   | config, str => withoutAsync do
 
     PointOfInterest.save (← getRef) config.name.toString

--- a/src/verso-manual/VersoManual/Linters.lean
+++ b/src/verso-manual/VersoManual/Linters.lean
@@ -3,26 +3,24 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Lean.Linter.Basic
-import Lean.Meta.Hint
-import Verso.Doc.Concrete
-import MultiVerso.Slug
+module
+public meta import Lean.Linter.Basic
+public meta import Lean.Meta.Hint
+public meta import Verso.Doc.Concrete
+public meta import MultiVerso.Slug
+public meta import VersoManual.Linters.Options
+
+public section
 
 set_option linter.missingDocs true
 
 open Lean Linter Elab Command
 open Lean.Doc.Syntax
 
-/-- Warns when headers don't have tags -/
-register_option linter.verso.manual.headerTags : Bool := {
-  defValue := false
-  descr := "if true, warn when headers don't have tags"
-}
-
 /--
 Lints for tagless headers.
 -/
-partial def headerTagLinter : Linter where
+meta partial def headerTagLinter : Linter where
   run := withSetOptionIn fun stx => do
     unless (`Verso.Doc.Concrete).isPrefixOf stx.getKind do return
     unless getLinterValue linter.verso.manual.headerTags (← getLinterOptions) do return
@@ -141,4 +139,4 @@ where
       | _ => pure ()
     return strTitle
 
-initialize addLinter headerTagLinter
+meta initialize addLinter headerTagLinter

--- a/src/verso-manual/VersoManual/Linters/Options.lean
+++ b/src/verso-manual/VersoManual/Linters/Options.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import Lean.Data.Options
+
+public section
+
+/-- Warns when headers don't have tags -/
+register_option linter.verso.manual.headerTags : Bool := {
+  defValue := false
+  descr := "if true, warn when headers don't have tags"
+}

--- a/src/verso-manual/VersoManual/Literate.lean
+++ b/src/verso-manual/VersoManual/Literate.lean
@@ -3,11 +3,15 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import VersoManual.Basic
-import VersoManual.ExternalLean
-import VersoLiterate
-import Lean.Data.Json
-import Lean.Compiler.LCNF.ConfigOptions
+module
+public import VersoManual.Basic
+public import VersoManual.ExternalLean
+public import VersoLiterate
+public meta import VersoLiterate.Module
+public import Lean.Data.Json
+public meta import Lean.Compiler.LCNF.ConfigOptions
+
+public section
 
 namespace Verso.Genre.Manual
 
@@ -86,7 +90,7 @@ open Verso.Doc Elab Concrete
 open Lean.Elab Command Term
 open PartElabM
 
-def getModuleWithDocs (path : StrLit) (mod : Ident) (title : StrLit) (metadata? : Option Term) (genre : Syntax := mkIdent ``Manual) : TermElabM Name :=
+meta def getModuleWithDocs (path : StrLit) (mod : Ident) (title : StrLit) (metadata? : Option Term) (genre : Syntax := mkIdent ``Manual) : TermElabM Name :=
   withTraceNode `verso.blog.literate (fun _ => pure m!"Literate '{title.getString}'") do
 
   let titleParts ← stringToInlines title
@@ -146,13 +150,13 @@ structure IncludeLiterateConfig where
   modName : Ident
   title : StrLit
 
-instance : FromArgs IncludeLiterateConfig m where
+meta instance : FromArgs IncludeLiterateConfig m where
   fromArgs :=
     IncludeLiterateConfig.mk <$> .positional' `path  <*> .named' `level true <*> .positional' `name <*> .positional' `title
 
 
 @[part_command Lean.Doc.Syntax.command]
-def includeLiterateSection : PartCommand
+meta def includeLiterateSection : PartCommand
   | `(block|command{includeLiterate $args* }) => do
     let {path, level, modName, title} ← parseThe IncludeLiterateConfig (← parseArgs args)
     let ref ← getRef

--- a/src/verso-manual/VersoManual/LocalContents.lean
+++ b/src/verso-manual/VersoManual/LocalContents.lean
@@ -3,10 +3,12 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-import Verso
-import MultiVerso.Slug
-import VersoManual.Basic
+module
+public import Verso
+public import MultiVerso.Slug
+public import VersoManual.Basic
 
+public section
 
 open Lean
 open Verso.Multi
@@ -22,10 +24,10 @@ def LocalContentItemRecognizer.failure : LocalContentItemRecognizer := fun _ => 
 
 def LocalContentItemRecognizer.orElse (r1 r2 : LocalContentItemRecognizer) : LocalContentItemRecognizer := fun b => r1 b <|> r2 b
 
-initialize localContentAttr : TagAttribute ←
+meta initialize localContentAttr : TagAttribute ←
   registerTagAttribute `local_content_list "Functions that recognize items for the page-local table of contents"
 
-private def localContentRecognizers [Monad m] [MonadLiftT MetaM m] [MonadOptions m] [MonadEnv m] [MonadError m] : m (Array Name) := do
+private meta def localContentRecognizers [Monad m] [MonadLiftT MetaM m] [MonadOptions m] [MonadEnv m] [MonadError m] : m (Array Name) := do
   let st := localContentAttr.ext.toEnvExtension.getState (← getEnv)
   let st' := st.importedEntries.flatten ++ st.state.toArray
 

--- a/src/verso-manual/VersoManual/Marginalia.lean
+++ b/src/verso-manual/VersoManual/Marginalia.lean
@@ -4,11 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Verso
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab.Monad
-import Verso.Code
-import VersoManual.Basic
+module
+public import Verso
+public import Verso.Doc.ArgParse
+public import Verso.Doc.Elab.Monad
+public import Verso.Code
+public import VersoManual.Basic
+public meta import Verso.Doc.Elab.Inline
+
+public section
 
 namespace Verso.Genre.Manual
 
@@ -145,7 +149,7 @@ inline_extension Inline.margin where
       Marginalia.html <$> content.mapM goI
 
 @[role]
-def margin : RoleExpanderOf Unit
+meta def margin : RoleExpanderOf Unit
   | (), inlines => do
     let content ← inlines.mapM elabInline
     ``(Doc.Inline.other Inline.margin #[$content,*])

--- a/src/verso-manual/VersoManual/Row.lean
+++ b/src/verso-manual/VersoManual/Row.lean
@@ -4,9 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import VersoManual.Basic
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab
+module
+public import VersoManual.Basic
+public import Verso.Doc.ArgParse
+public import Verso.Doc.Elab
+public meta import Verso.Doc.Elab.Block
+
+public section
 
 open Lean Elab
 open Verso ArgParse Doc Elab Genre.Manual Html
@@ -40,10 +44,10 @@ structure RowConfig where
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m]
 
-def RowConfig.parse : ArgParse m RowConfig :=
+meta def RowConfig.parse : ArgParse m RowConfig :=
   RowConfig.mk <$> .namedD' `align "top"
 
-instance : FromArgs RowConfig m := ⟨RowConfig.parse⟩
+meta instance : FromArgs RowConfig m := ⟨RowConfig.parse⟩
 
 end
 
@@ -56,7 +60,7 @@ The `align` argument controls vertical alignment within the row, accepting `"top
 `"bottom"`. It is only meaningful for HTML output.
 -/
 @[directive]
-def row : DirectiveExpanderOf RowConfig
+meta def row : DirectiveExpanderOf RowConfig
   | config, stxs => do
     let alignItems ←
       match config.align with

--- a/src/verso-manual/VersoManual/Table.lean
+++ b/src/verso-manual/VersoManual/Table.lean
@@ -4,9 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import VersoManual.Basic
-import Verso.Doc.ArgParse
-import Verso.Doc.Elab
+module
+public import VersoManual.Basic
+public import Verso.Doc.ArgParse
+public import Verso.Doc.Elab
+public meta import Verso.Doc.Elab.Block
+
+public section
 
 open Verso Doc Elab
 open Verso.Genre Manual
@@ -25,7 +29,7 @@ deriving ToJson, FromJson, DecidableEq, Repr, Ord
 
 open Syntax in
 open TableConfig.Alignment in
-instance : Quote TableConfig.Alignment where
+meta instance : Quote TableConfig.Alignment where
   quote
     | .left => mkCApp ``left #[]
     | .center => mkCApp ``center #[]
@@ -164,7 +168,7 @@ table.tabular td > p:last-child, table.tabular th > p:first-child {
 section
 variable [Monad m] [MonadInfoTree m] [MonadLiftT CoreM m] [MonadEnv m] [MonadError m] [MonadFileMap m]
 
-def TableConfig.parse : ArgParse m TableConfig :=
+meta def TableConfig.parse : ArgParse m TableConfig :=
   TableConfig.mk <$> .named `tag .string true <*> .flag `header true <*> .named `align alignment true
 where
   alignment := {
@@ -180,12 +184,12 @@ where
       | .num x | .str x => throwErrorAt x "Expected 'left', 'right', or 'center'"
   }
 
-instance : FromArgs TableConfig m := ⟨TableConfig.parse⟩
+meta instance : FromArgs TableConfig m := ⟨TableConfig.parse⟩
 
 end
 
 @[directive]
-def table : DirectiveExpanderOf TableConfig
+meta def table : DirectiveExpanderOf TableConfig
   | cfg, contents => do
     -- The table should be a list of lists. Extract them!
     let #[oneBlock] := contents

--- a/src/verso-tutorial/VersoTutorial.lean
+++ b/src/verso-tutorial/VersoTutorial.lean
@@ -4,18 +4,21 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import MultiVerso
-import Verso.Doc
-import VersoManual.Basic
-import VersoManual
-import Lean.Data.Json
-import VersoUtil.LzCompress
-import VersoUtil.Zip
-import VersoBlog.Basic
-import VersoBlog.Component
-import VersoBlog.Template
-import VersoBlog.Generate
-import VersoTutorial.Basic
+module
+public import MultiVerso
+public import Verso.Doc
+public import VersoManual.Basic
+public import VersoManual
+public import Lean.Data.Json
+public import VersoUtil.LzCompress
+public import VersoUtil.Zip
+public import VersoBlog.Basic
+public import VersoBlog.Component
+public import VersoBlog.Template
+public import VersoBlog.Generate
+public import VersoTutorial.Basic
+
+public section
 
 open Lean
 open Std

--- a/src/verso-tutorial/VersoTutorial/Basic.lean
+++ b/src/verso-tutorial/VersoTutorial/Basic.lean
@@ -4,17 +4,22 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import MultiVerso
-import Verso.Doc
-import VersoManual.Basic
-import VersoManual
-import Lean.Data.Json
-import VersoUtil.LzCompress
-import VersoUtil.Zip
-import VersoBlog.Basic
-import VersoBlog.Component
-import VersoBlog.Template
-import VersoBlog.Generate
+module
+public import MultiVerso
+public import Verso.Doc
+public import Verso.Doc.Concrete.InlineString
+public import VersoManual.Basic
+public import VersoManual
+public import Lean.Data.Json
+public import VersoUtil.LzCompress
+public import VersoUtil.Zip
+public import VersoBlog.Basic
+public import VersoBlog.Component
+public import VersoBlog.Template
+public import VersoBlog.Generate
+public meta import Verso.Doc.Elab.Block
+
+public section
 
 set_option linter.missingDocs true
 
@@ -25,13 +30,13 @@ open Lean
 open Verso.Doc (Genre)
 open Verso.Multi
 
-private def defaultToolchain :=
+@[expose] def defaultToolchain :=
   if Lean.versionString.find? "nightly" |>.isSome then
     "leanprover/lean4:nightly" ++ (Lean.versionString.split "nightly" |>.toArray[1]!).copy
   else
     "leanprover/lean4:" ++ Lean.versionString
 
-private def defaultLive := "lean-v" ++ Lean.versionString
+@[expose] def defaultLive := "lean-v" ++ Lean.versionString
 
 /-- A style by which example code in a tutorial should be made runnable. -/
 inductive ExampleCodeStyle where
@@ -59,13 +64,13 @@ deriving BEq, Hashable, Inhabited, Repr, ToJson, FromJson
 /--
 Information that tracks the current context of traversal for a set of tutorials.
 -/
-def Tutorial.TraverseContext := Manual.TraverseContext
+@[expose] def Tutorial.TraverseContext := Manual.TraverseContext
 
 /--
 Tutorials may use all the extensions of the manual genre, but are rendered as ordinary single web
 pages via the blog genre. They may contain example code, which can be extracted and tested.
 -/
-def Tutorial : Genre :=
+@[expose] def Tutorial : Genre :=
   { Manual with
     TraverseContext := Tutorial.TraverseContext
     PartMetadata := Tutorial.PartMetadata
@@ -151,7 +156,7 @@ block_extension Block.displayOnly where
 
 /-- Indicates code that is to be displayed in tutorials, but not extracted or run. -/
 @[directive]
-def displayOnly : Elab.DirectiveExpanderOf Unit
+meta def displayOnly : Elab.DirectiveExpanderOf Unit
   | (), contents => do
     ``(Block.other Block.displayOnly #[$(← contents.mapM Elab.elabBlock),*])
 
@@ -162,7 +167,7 @@ block_extension Block.codeOnly where
 
 /-- Indicates code that is to be extracted and run from tutorials, but not rendered to HTML. -/
 @[directive]
-def codeOnly : Elab.DirectiveExpanderOf Unit
+meta def codeOnly : Elab.DirectiveExpanderOf Unit
   | (), contents => do
     ``(Block.other Block.codeOnly #[$(← contents.mapM Elab.elabBlock),*])
 

--- a/src/verso/Verso/Doc/ArgParse.lean
+++ b/src/verso/Verso/Doc/ArgParse.lean
@@ -30,6 +30,7 @@ inductive SigDoc where
   | text (str : String)
   | name (name : Name)
   | append (d1 d2 : SigDoc)
+deriving ToExpr
 
 instance : Append SigDoc := ⟨.append⟩
 

--- a/src/verso/Verso/Doc/Elab/Incremental.lean
+++ b/src/verso/Verso/Doc/Elab/Incremental.lean
@@ -4,9 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 
-import Lean.Elab.Command
-import Lean.Elab.Term
-import Lean.Language.Basic
+module
+public import Lean.Elab.Command
+public import Lean.Elab.Term
+public import Lean.Language.Basic
+
+public section
 
 open Lean Language Elab Command
 

--- a/src/verso/Verso/Doc/Elab/Monad.lean
+++ b/src/verso/Verso/Doc/Elab/Monad.lean
@@ -677,18 +677,28 @@ private unsafe def evalIOOptStringUnsafe (x : Name) : MetaM (Option SigDoc) := d
 @[implemented_by evalIOOptStringUnsafe]
 private opaque evalOptMsg (x : Name) : MetaM (Option SigDoc)
 
+private meta unsafe def evalSigDocUnsafe (s : Expr) : MetaM (Option SigDoc) :=
+  Meta.evalExpr (Option SigDoc) (.app (.const ``Option [0]) (.const ``SigDoc [])) s (checkMeta := false)
+
+@[implemented_by evalSigDocUnsafe]
+private opaque evalSigDoc (s : Expr) : MetaM (Option SigDoc)
+
 private def saveSignature (expanderName : Name) (argTy : Expr) : MetaM Unit := do
   let s ← Meta.mkAppM ``sig #[argTy]
   let inst ← Meta.synthInstance (mkApp2 (.const ``FromArgs []) argTy (.const ``DocElabM []))
   let s := .app s inst
   let s ← instantiateExprMVars s
-  let s ← Meta.whnf s
+  -- Evaluate the signature now, while the argument parser's definitions are available in the
+  -- elaboration environment, and store the result as data. The parser may be built from `partial`
+  -- or meta definitions; storing the parser expression unevaluated would re-run it when the module
+  -- is loaded, where those definitions are absent.
+  let sig ← evalSigDoc s
   let name ← mkFreshUserName <| expanderName ++ `signature
   let decl := Declaration.defnDecl {
     name,
     levelParams := [],
     type := .app (.const ``Option [0]) (.const ``SigDoc []),
-    value := s,
+    value := toExpr sig,
     hints := .opaque,
     safety := .safe
   }


### PR DESCRIPTION
Now that `import all` loads docstrings, migrating all of Verso to the module system is much easier.

This requires a recent nightly that includes https://github.com/leanprover/lean4/pull/14120 .