### PR TITLE
fix: report expected content when allowDiff > 0

### DIFF
--- a/src/tests/Tests/LeanCode.lean
+++ b/src/tests/Tests/LeanCode.lean
@@ -131,3 +131,66 @@ The binding can be removed (if unused) or named `_` (if used implicitly).
 Note: This linter can be disabled with `set_option linter.unusedVariables false`
 ```
 :::::::
+
+/--
+error: Didn't match - got: ⏎
+  [a
+   b
+   c]
+but expected:
+  b
+  ⏎
+
+Hint: Replace with the actual message:
+  information: a̲
+  ̲b
+  c̲
+  ̲
+-/
+#guard_msgs in
+#docs (Genre.Manual) allowDiff30 "Not enough allowDiff" :=
+:::::::
+```lean (name := foo)
+#print "a\nb\nc"
+```
+```leanOutput foo
+b
+```
+:::::::
+
+/--
+error: Didn't match within tolerance of 1 - got: ⏎
+  [a
+   b
+   c]
+but expected:
+  b
+  ⏎
+
+Hint: Replace with the actual message:
+  information: a̲
+  ̲b
+  c̲
+  ̲
+-/
+#guard_msgs in
+#docs (Genre.Manual) allowDiff31 "Not enough allowDiff" :=
+:::::::
+```lean (name := foo)
+#print "a\nb\nc"
+```
+```leanOutput foo (allowDiff := 1)
+b
+```
+:::::::
+
+#guard_msgs in
+#docs (Genre.Manual) allowDiff32 "Enough allowDiff" :=
+:::::::
+```lean (name := foo)
+#print "a\nb\nc"
+```
+```leanOutput foo (allowDiff := 2)
+b
+```
+:::::::

--- a/src/tests/Tests/LeanCode.lean
+++ b/src/tests/Tests/LeanCode.lean
@@ -159,7 +159,7 @@ b
 :::::::
 
 /--
-error: Didn't match within tolerance of 1 - got: ⏎
+error: Didn't match even with allowDiff := 1 - got: ⏎
   [a
    b
    c]

--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -738,7 +738,8 @@ def leanOutput : CodeBlockExpanderOf LeanOutputConfig
     else
       let mut best : Option (Nat × String × Highlighted.Message) := none
       for msg in msgs do
-        let txt := msg.toString
+        let txt := msg.toString (expandTraces := config.expandTraces)git
+        texts := texts.push (msg.severity, txt)
         let actual :=
           if config.normalizeMetas then
             normalizeMetavars txt
@@ -770,7 +771,7 @@ def leanOutput : CodeBlockExpanderOf LeanOutputConfig
     let hintMsg := if suggs.size > 1 then m!"Replace with one of the actual messages:" else m!"Replace with the actual message:"
     let hint ← hintAt str hintMsg suggs
 
-    throwErrorAt str (m!"Didn't match - got: {indentD (toMessageData <| texts.map (Std.Format.text ·.2))}\nbut expected:{indentD (toMessageData str.getString)}" ++ hint)
+    throwErrorAt str (m!"Didn't match{if config.allowDiff > 0 then s!" within tolerance of {config.allowDiff}" else ""} - got: {indentD (toMessageData <| texts.map (Std.Format.text ·.2))}\nbut expected:{indentD (toMessageData str.getString)}" ++ hint)
 where
   sevStr : MessageSeverity → String
     | .error => "error"

--- a/src/verso-manual/VersoManual/InlineLean.lean
+++ b/src/verso-manual/VersoManual/InlineLean.lean
@@ -738,7 +738,7 @@ def leanOutput : CodeBlockExpanderOf LeanOutputConfig
     else
       let mut best : Option (Nat × String × Highlighted.Message) := none
       for msg in msgs do
-        let txt := msg.toString (expandTraces := config.expandTraces)git
+        let txt := msg.toString (expandTraces := config.expandTraces)
         texts := texts.push (msg.severity, txt)
         let actual :=
           if config.normalizeMetas then
@@ -771,7 +771,7 @@ def leanOutput : CodeBlockExpanderOf LeanOutputConfig
     let hintMsg := if suggs.size > 1 then m!"Replace with one of the actual messages:" else m!"Replace with the actual message:"
     let hint ← hintAt str hintMsg suggs
 
-    throwErrorAt str (m!"Didn't match{if config.allowDiff > 0 then s!" within tolerance of {config.allowDiff}" else ""} - got: {indentD (toMessageData <| texts.map (Std.Format.text ·.2))}\nbut expected:{indentD (toMessageData str.getString)}" ++ hint)
+    throwErrorAt str (m!"Didn't match{if config.allowDiff > 0 then s!" even with allowDiff := {config.allowDiff}" else ""} - got: {indentD (toMessageData <| texts.map (Std.Format.text ·.2))}\nbut expected:{indentD (toMessageData str.getString)}" ++ hint)
 where
   sevStr : MessageSeverity → String
     | .error => "error"


### PR DESCRIPTION
Currently, 

`````lean4
#docs (Genre.Manual) allowDiff31 "Not enough allowDiff" :=
:::::::
```lean (name := foo)
#print "a\nb\nc"
```
```leanOutput foo (allowDiff := 1)
b
```
:::::::
`````

will report 

```
error: Didn't match - got:
  []
but expected:
  b
```

and I can imagine a multitude of fancy ways to do that right, but that this PR does is the lazy way of piggybacking off of the existing reporting. 

```
error: Didn't match within even with allowDiff := 1 - got:
  [a
   b
   c]
but expected:
  b
```

The new error message would have gotten me from getting into a cul-de-sac trying to merge refman main into refman nightly earlier today, and now there's a test for it. (Three tests, two already passed, but the middle one failed before and is fixed by this PR.)