### PR TITLE
fix: preserve CSS for section elements

### DIFF
--- a/src/verso-literate-html/literate.css
+++ b/src/verso-literate-html/literate.css
@@ -528,8 +528,8 @@ a:visited {
     line-height: 1.7;
 }
 
-.code-content > .verso-text.mod-doc > *,
-.code-content > .md-text.mod-doc > * {
+.code-content > .verso-text.mod-doc :is(p, ul, ol, blockquote, pre, table),
+.code-content > .md-text.mod-doc :is(p, ul, ol, blockquote, pre, table) {
     margin-bottom: 0.75rem;
     display: block;
 }

--- a/test-projects/literate-config/lakefile.toml
+++ b/test-projects/literate-config/lakefile.toml
@@ -7,4 +7,4 @@ path = "../.."
 
 [[lean_lib]]
 name = "LitConfig"
-leanOptions = [{name = "doc.verso", value = true}]
+leanOptions = {doc.verso = true}


### PR DESCRIPTION
If you have a `/-! -/` verso doc with headers, the paragraphs won't be appropriately spaced; this fixes the issue. Also picks up a fix that was causing the toml validator to fail in lakefile.toml