### PR TITLE
chore: adapt verso-literate to new deferred/custom type

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2026-07-02
+leanprover/lean4:nightly-2026-07-03

--- a/src/verso-literate/VersoLiterate/Basic.lean
+++ b/src/verso-literate/VersoLiterate/Basic.lean
@@ -76,12 +76,6 @@ def handleConst : InlineToLiterate
     let i := .other (.highlighted <| .token ⟨k, s⟩) content
     return some i
 
-def handlePostponed : InlineToLiterate
-  | val, content => do
-    let some { .. } := val.get? Lean.Doc.PostponedCheck | return none
-    -- TODO postponed checks need a solution here
-    return some <| .concat content
-
 def highlightDocCode : Lean.Doc.DocCode → Highlighted
   | ⟨code⟩ => Id.run do
     let mut out : Highlighted := .empty
@@ -162,7 +156,7 @@ def handleSyntaxCat : InlineToLiterate
     let some { .. } := val.get? Lean.Doc.Data.SyntaxCat | return none
     return some <| .concat content
 
-def inline := #[handleLocal, handleConst, handlePostponed, handleAttr, handleTerm, handleSetOption, handleOption, handleModName, handleTactic, handleConvTactic, handleKwAtom, handleSyntax, handleSyntaxCat]
+def inline := #[handleLocal, handleConst, handleAttr, handleTerm, handleSetOption, handleOption, handleModName, handleTactic, handleConvTactic, handleKwAtom, handleSyntax, handleSyntaxCat]
 
 def handleLeanBlock : BlockToLiterate
   | val, content => do

--- a/src/verso-literate/VersoLiterateMain.lean
+++ b/src/verso-literate/VersoLiterateMain.lean
@@ -66,14 +66,6 @@ where
     | .original l l' t _ => .original l l' t contents.rawEndPos
     | i => i
 
-instance : ToJson ElabInline where
-  toJson v := s!"{v.val.typeName}"
-instance : ToJson ElabBlock where
-  toJson v := s!"{v.val.typeName}"
-instance : ToJson Empty where
-  toJson := nofun
-
-
 section
 open SubVerso.Highlighting
 open Lean.Parser.Command
@@ -502,13 +494,16 @@ where
     | .link txt url => (.link · url) <$> txt.mapM inlineToLit
     | .image alt url => pure <| .image alt url
     | .footnote name xs => .footnote name <$> xs.mapM inlineToLit
-    | .other x xs => do
+    | .other (.deferred _) xs =>
+      -- TODO deferred checks need a solution here
+      .concat <$> xs.mapM inlineToLit
+    | .other (.custom val) xs => do
       let xs ← xs.mapM inlineToLit
       let handlers ← getInlineToLiterate
       for h in handlers do
-        if let some v ← h x.val xs then
+        if let some v ← h val xs then
           return ← relocateInline v
-      logWarning m!"No inline handler for {x.val.typeName}; using fallback content"
+      logWarning m!"No inline handler for {val.typeName}; using fallback content"
       return .concat xs
 
 
@@ -520,13 +515,16 @@ where
     | .dl items => .dl <$> items.mapM fun x => DescItem.mk <$> x.term.mapM inlineToLit <*> x.desc.mapM blockToLit
     | .blockquote xs => .blockquote <$> xs.mapM blockToLit
     | .code s => pure <| .code s
-    | .other x xs => do
+    | .other (.deferred _) xs =>
+      -- TODO deferred checks need a solution here
+      .concat <$> xs.mapM blockToLit
+    | .other (.custom val) xs => do
       let xs ← xs.mapM blockToLit
       let handlers ← getBlockToLiterate
       for h in handlers do
-        if let some v ← h x.val xs then
+        if let some v ← h val xs then
           return ← relocateBlock v
-      logWarning m!"No block handler for {x.val.typeName}; using fallback content"
+      logWarning m!"No block handler for {val.typeName}; using fallback content"
       return .concat xs
 
   partToLit (p : Lean.Doc.Part ElabInline ElabBlock Empty) : ToLitM (Lean.Doc.Part Ext Ext Empty) :=

--- a/test-projects/literate-config/LitConfig/UserExt.lean
+++ b/test-projects/literate-config/LitConfig/UserExt.lean
@@ -49,8 +49,8 @@ The content of the role is ignored.
 -/
 @[doc_role]
 def unknownRole (_ : TSyntaxArray `inline) : Lean.Doc.DocM (Lean.Doc.Inline ElabInline) := do
-  return .other
-    { val := .mk (FallbackPayload.mk "no-handler-fallback") }
+  return .custom
+    (FallbackPayload.mk "no-handler-fallback")
     #[.text "THIS IS THE FALLBACK"]
 
 end LitConfig.UserExt

--- a/test-projects/literate-config/lean-toolchain
+++ b/test-projects/literate-config/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2026-07-02
+leanprover/lean4:nightly-2026-07-03

--- a/test-projects/literate-multi-root/lean-toolchain
+++ b/test-projects/literate-multi-root/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2026-07-02
+leanprover/lean4:nightly-2026-07-03


### PR DESCRIPTION
also removes a dead ToJson instance that broken with the update