### PR TITLE
chore: drop no-op `@[expose]` on `optionDocs.Args`

### DIFF
--- a/src/verso-manual/VersoManual/Docstring.lean
+++ b/src/verso-manual/VersoManual/Docstring.lean
@@ -1531,7 +1531,6 @@ def highlightDataValue (v : DataValue) : Highlighted :=
     | .ofInt (v : Int) => ⟨.unknown, toString v⟩
     | .ofSyntax (v : Syntax) => ⟨.unknown, toString v⟩ -- TODO
 
-@[expose]
 def optionDocs.Args := Ident
 instance : FromArgs optionDocs.Args DocElabM := ⟨.positional `name .ident "The option name"⟩
 


### PR DESCRIPTION
The `@[expose]` attribute on `optionDocs.Args` in `src/verso-manual/VersoManual/Docstring.lean` has no effect because that file is not a `module` file, and it produces a `@[expose] has no effect outside a module file` warning on every build (including in downstream projects that build the manual). This removes the attribute; it can be reintroduced if and when the file is migrated to the module system.

The change is a no-op for compilation (the compiler itself reports the attribute has no effect), so behaviour is unchanged.