### PR TITLE
fix: force block/inline descrs attributes to be public

### DIFF
--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -841,6 +841,7 @@ meta initialize
       name := name,
       ref := by exact decl_name%,
       add := fun decl stx kind => do
+        ensureAttrDeclIsPublic name decl kind
         unless kind == AttributeKind.global do throwError "invalid attribute '{name}', must be global"
         unless ((← getEnv).getModuleIdxFor? decl).isNone do
           throwError "invalid attribute '{name}', declaration is in an imported module"
@@ -926,7 +927,7 @@ elab_rules : command
     let cmd3 ←
       `(command|
         @[block_extension $x]
-        private def $descrName : BlockDescr := $(← applyMixins innerDescrName))
+        public def $descrName : BlockDescr := $(← applyMixins innerDescrName))
     elabCommand cmd1
     elabCommand cmd2
     elabCommand cmd3
@@ -951,7 +952,7 @@ elab_rules : command
     let cmd3 ←
       `(command|
         @[inline_extension $x]
-        private def $descrName : InlineDescr := $(← applyMixins innerDescrName))
+        public def $descrName : InlineDescr := $(← applyMixins innerDescrName))
     elabCommand cmd1
     elabCommand cmd2
     elabCommand cmd3


### PR DESCRIPTION
This came from trying to figure out failures from merging changes into the significantly-more-module-ified nightly-testing branch: any place where extension implementations were called upon was failing in the module system — they need to refer to the private definitions to operate — but none of the relevant tests had been module-ified yet.

(Unfortunately there aren't good tests to be had here, because the tests would need to exist on the nightly-testing branch.)