### PR TITLE
chore: fix nightly, don't skip sections regression

### DIFF
--- a/src/tests/Tests/VersoManual.lean
+++ b/src/tests/Tests/VersoManual.lean
@@ -3,11 +3,10 @@ Copyright (c) 2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
-module
-public import Tests.VersoManual.Docstring
-public import Tests.VersoManual.Html
-public import Tests.VersoManual.Html.SoftHyphenate
-public import Tests.VersoManual.License
-public import Tests.VersoManual.Markdown
-public import Tests.VersoManual.WordCount
-public section
+import Tests.VersoManual.Docstring
+import Tests.VersoManual.Html
+import Tests.VersoManual.Html.SoftHyphenate
+import Tests.VersoManual.License
+import Tests.VersoManual.Markdown
+import Tests.VersoManual.Sections
+import Tests.VersoManual.WordCount


### PR DESCRIPTION
Because we're importing a non-module file, move VersoManual.lean back off the module system