### PR TITLE
chore: make defaultPostName.slugify public as slugifyTitle

### DIFF
--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -7,7 +7,6 @@ Author: David Thrane Christiansen
 import SubVerso.Highlighting
 import SubVerso.Examples
 
-<<<<<<< Updated upstream
 import VersoBlog.Basic
 import VersoBlog.LiterateLeanPage
 import VersoBlog.LiterateModuleDocs
@@ -22,10 +21,6 @@ import Verso.Doc.Lsp
 import Verso.Doc.Suggestion
 import Verso.Hover
 import Verso.WithoutAsync
-=======
-#check Verso.Genre.Blog.defaultPostName
-
->>>>>>> Stashed changes
 open Verso.Output Html
 
 namespace Verso.Genre.Blog

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -7,6 +7,7 @@ Author: David Thrane Christiansen
 import SubVerso.Highlighting
 import SubVerso.Examples
 
+<<<<<<< Updated upstream
 import VersoBlog.Basic
 import VersoBlog.LiterateLeanPage
 import VersoBlog.LiterateModuleDocs
@@ -21,6 +22,10 @@ import Verso.Doc.Lsp
 import Verso.Doc.Suggestion
 import Verso.Hover
 import Verso.WithoutAsync
+=======
+#check Verso.Genre.Blog.defaultPostName
+
+>>>>>>> Stashed changes
 open Verso.Output Html
 
 namespace Verso.Genre.Blog

--- a/src/verso-blog/VersoBlog/Basic.lean
+++ b/src/verso-blog/VersoBlog/Basic.lean
@@ -205,16 +205,19 @@ where
   pad (n : Nat) : String :=
     (if n ≤ 9 then "0" else "") ++ toString n
 
-def defaultPostName (date : Date) (title : String) : String :=
-  s!"{date.year}-{date.month}-{date.day}-{slugify title}"
-where
-  slugify str := Id.run do
+def slugifyTitle (str: String) := Id.run do
     let mut slug := ""
     for c in str.toList do
       if c == ' ' then slug := slug.push '-'
       else if c.isAlpha || c.isDigit then slug := slug.push c.toLower
       else continue
     pure slug
+
+@[deprecated slugifyTitle (since := "2026-07-07")]
+def defaultPostName.slugify := slugifyTitle
+
+def defaultPostName (date : Date) (title : String) : String :=
+  s!"{date.year}-{date.month}-{date.day}-{slugifyTitle title}"
 
 structure Config where
   destination : System.FilePath := "./_site"


### PR DESCRIPTION
module-ification happening on nightly testing made the existing defaultPostName.slugify private, breaking downstream web components module. Deprecate the old version and give the new version a better name