### PR TITLE
fix: set left and right margins to be equal in TeX output

### DIFF
--- a/src/verso-manual/VersoManual/TeX.lean
+++ b/src/verso-manual/VersoManual/TeX.lean
@@ -9,6 +9,8 @@ namespace Verso.Genre.Manual.TeX
 public def preamble (title : String) (authors : List String) (date : String) (packages : List String) (extraPreamble : List String) : String :=
 r##"
 \documentclass{memoir}
+\setlrmarginsandblock{1.7in}{1.7in}{*}
+\checkandfixthelayout
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}


### PR DESCRIPTION
A TeX file generated by Verso uses the `memoir` documentclass.  The default layout of this documentclass has left and right margins that differ greatly.  That might be OK for printing, but it is jarring when you view a PDF file in a desktop application, which is the typical use case today.

This commit modifies the left and right margins to be equal.  In my opinion this makes the PDF quite a bit nicer to view in Evince (on Linux), and probably in other PDF viewers too.