### PR TITLE
fix: include reference text in TeX output

### DIFF
--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -112,7 +112,7 @@ inline_extension Inline.ref (canonicalName : String) (domain : Option Name) (rem
         else
           -- Intra-document links should be page references
           let label := labelForTeX dest.htmlId
-          pure \TeX{\autoref{\Lean{label}}" (p."~\pageref{\Lean{label}} ")"}
+          pure \TeX{\hyperref[\Lean{label}]{\Lean{← content.mapM go}}" (p."~\pageref{\Lean{label}} ")"}
 
   toHtml :=
     open Verso.Output.Html in


### PR DESCRIPTION
Includes the link text in references along with the page number, using a `\hyperref` tag instead of `\autoref`.

Closes #915