### PR TITLE
chore: add inkscape install to release-tag workflow

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -49,6 +49,9 @@ jobs:
             - name: Install PDF Dependencies
               uses: ./.github/actions/install-texlive
 
+            - name: Install Inkscape
+              run: sudo apt-get update && sudo apt-get install -y --no-install-recommends inkscape
+
             - name: Generate the manual
               run: ./deploy/generate.sh
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,6 +4,7 @@ on:
     push:
         tags:
             - "v4*"
+    workflow_dispatch: # Allow manual triggering (possibly not something we want always)
 
 jobs:
     deploy:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,7 +4,6 @@ on:
     push:
         tags:
             - "v4*"
-    workflow_dispatch: # Allow manual triggering (possibly not something we want always)
 
 jobs:
     deploy:


### PR DESCRIPTION
the release-tag job is failing due to inkscape not being available as a dependency