### PR TITLE
feat: produce one-sided LaTeX output by default

### DIFF
--- a/src/tests/TestMain.lean
+++ b/src/tests/TestMain.lean
@@ -44,12 +44,14 @@ def testTexOutput
     (dir : System.FilePath)
     (doc : Verso.Doc.VersoDoc Verso.Genre.Manual)
     (config : Config)
+    (twoside : Bool := false)
     (extraFiles : List (System.FilePath × String) := [])
     (extraFilesTeX : List (System.FilePath × String) := []) : IO Unit := do
   let versoConfig : Verso.Genre.Manual.Config := {
     destination := "src/tests/integration" / dir / "output",
     emitTeX := true,
     emitHtmlMulti := .no,
+    twoside,
     extraFiles,
     extraFilesTeX
   }
@@ -365,6 +367,7 @@ def tests := [
   testTexOutput "escape-doc" Escape.doc,
   testTexOutput "front-matter-doc" FrontMatter.doc,
   testTexOutput "diagram-doc" DiagramDoc.doc,
+  testTexOutput "twoside-doc" TwoSideDoc.doc (twoside := true),
   testZip,
   testInteractive,
   testLiterateConfig,

--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -27,6 +27,7 @@ import Tests.Integration.ExtraFilesDoc
 import Tests.Integration.FrontMatter
 import Tests.Integration.InheritanceDoc
 import Tests.Integration.LeanSection
+import Tests.Integration.TwoSideDoc
 import Tests.LeanCode
 import Tests.Linters
 import Tests.Method

--- a/src/tests/Tests/Integration/TwoSideDoc.lean
+++ b/src/tests/Tests/Integration/TwoSideDoc.lean
@@ -1,0 +1,29 @@
+/-
+Copyright (c) 2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+public section
+namespace Verso.Integration.TwoSideDoc
+
+open Verso Genre Manual
+
+#docs (Manual) doc "Two-Sided Test Document" :=
+:::::::
+
+%%%
+shortTitle := "TwoSide"
+authors := ["Test Author"]
+%%%
+
+# Testing Two-Sided Output
+
+This document is for testing the `--twoside` option.
+
+:::::::
+
+end Verso.Integration.TwoSideDoc

--- a/src/tests/integration/code-content-doc/expected/tex/main.tex
+++ b/src/tests/integration/code-content-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/diagram-doc/expected/tex/main.tex
+++ b/src/tests/integration/diagram-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/escape-doc/expected/tex/main.tex
+++ b/src/tests/integration/escape-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/extra-files-doc/expected/tex/main.tex
+++ b/src/tests/integration/extra-files-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/front-matter-doc/expected/tex/main.tex
+++ b/src/tests/integration/front-matter-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/inheritance-doc/expected/tex/main.tex
+++ b/src/tests/integration/inheritance-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/sample-doc/expected/tex/main.tex
+++ b/src/tests/integration/sample-doc/expected/tex/main.tex
@@ -1,5 +1,5 @@
 
-\documentclass{memoir}
+\documentclass[oneside]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/tests/integration/twoside-doc/expected/tex/main.tex
+++ b/src/tests/integration/twoside-doc/expected/tex/main.tex
@@ -88,6 +88,7 @@
 \definecolor{bordercolor}{HTML}{98B2C0}
 \definecolor{medgray}{HTML}{555555}
 \newtcolorbox{docstringBox}[2][]{colback=white,
+before lower={\parindent15pt\noindent}, % indent all paragraphs after first within lower part of box
 breakable,
 colframe=bordercolor,
 colbacktitle=white,

--- a/src/tests/integration/twoside-doc/expected/tex/main.tex
+++ b/src/tests/integration/twoside-doc/expected/tex/main.tex
@@ -1,0 +1,153 @@
+
+\documentclass[twoside]{memoir}
+
+\usepackage{sourcecodepro}
+\usepackage{sourcesanspro}
+\usepackage{sourceserifpro}
+
+\usepackage{fancyvrb}
+\usepackage{fvextra}
+\usepackage{xparse}
+
+\usepackage[most]{tcolorbox}
+
+% Detect whether we're in a footnote. This is used later to avoid \href rendering bugs.
+\newif\ifinfootnote
+\infootnotefalse
+
+\let\oldfootnote\footnote
+\renewcommand{\footnote}[1]{%
+  \oldfootnote{\infootnotetrue#1\infootnotefalse}%
+}
+
+\let\oldfootnotetext\footnotetext
+\renewcommand{\footnotetext}[1]{%
+  \oldfootnotetext{\infootnotetrue#1\infootnotefalse}%
+}
+
+\usepackage[breaklinks=true, hyperfootnotes=false]{hyperref}
+
+% Redefines \href to show footnotes with URLs instead. This works around a page breaking bug in
+% hyperref and also makes the link useful on paper. If already in a footnote, the URL is
+% in parentheses instead.
+\let\oldhref\href
+\RenewDocumentCommand{\href}{mm}{%
+  \ifinfootnote%
+    #2~(\url{#1})%
+  \else%
+    #2\footnote{\url{#1}}%
+  \fi%
+}
+
+\usepackage[normalem]{ulem}
+\newcommand{\coloredwave}[2]{\textcolor{#1}{\uwave{\textcolor{black}{#2}}}}
+\usepackage{newunicodechar}
+
+% Work around the fact that
+% U+271D LATIN CROSS doesn't exist in
+% DejaVu Sans Mono Oblique. \textup
+% is fontspec for "upright, not italic/oblique".
+\newunicodechar{✝}{\textup{✝}}
+% Work around missing U+2011 (non-breaking hyphen) in Source Serif Pro
+\newunicodechar{‑}{-}
+
+\definecolor{errorColor}{HTML}{B91C1C}
+\definecolor{infoColor}{HTML}{1E6BB8}
+\definecolor{warningColor}{HTML}{D97706}
+\newcommand{\errorDecorate}[1]{\coloredwave{errorColor}{#1}}
+\newcommand{\infoDecorate}[1]{\coloredwave{infoColor}{#1}}
+\newcommand{\warningDecorate}[1]{\coloredwave{warningColor}{#1}}
+\DefineVerbatimEnvironment{LeanVerbatim}{Verbatim}
+  {commandchars=\\\{\},fontsize=\small,breaklines=true}
+\DefineVerbatimEnvironment{FileVerbatim}{Verbatim}{commandchars=\\\{\},fontsize=\small,breaklines=true,frame=single,framesep=2mm,numbers=left}
+\CustomVerbatimCommand{\LeanVerb}{Verb}
+  {commandchars=\\\{\},fontsize=\small,breaklines=true}
+\CustomVerbatimCommand{\FileListingVerb}{Verb}
+  {commandchars=\\\{\},fontsize=\small,frame=single,framesep=2mm, numbers=left}
+
+%%% Trace messages
+\newlength{\traceindent}
+\setlength{\traceindent}{1.5em}
+
+\newcommand{\expandedIndicator}{$\blacktriangledown$\hspace{2pt}}
+\newcommand{\collapsedIndicator}{$\blacktriangleright$\hspace{2pt}}
+
+\newenvironment{expandedtrace}[1]{%
+  \par\noindent\expandedIndicator #1\par
+  \advance\leftskip by \traceindent
+}{%
+}
+
+\newenvironment{collapsedtrace}[1]{%
+  \par\noindent\collapsedIndicator #1\par
+  \advance\leftskip by \traceindent
+}{%
+}
+%%% End Trace messages
+
+\definecolor{bordercolor}{HTML}{98B2C0}
+\definecolor{medgray}{HTML}{555555}
+\newtcolorbox{docstringBox}[2][]{colback=white,
+breakable,
+colframe=bordercolor,
+colbacktitle=white,
+enhanced,
+coltitle=medgray,
+attach boxed title to top left={xshift=2mm,yshift=-2mm},
+boxrule=0.4pt,
+fonttitle=\sffamily\fontsize{6pt}{7pt}\selectfont,
+boxed title style={top=-0.3mm,bottom=-0.3mm,left=-0.3mm,right=-0.3mm,boxrule=0.4pt},
+title={#2},#1}
+
+
+\makechapterstyle{lean}{%
+\renewcommand*{\chaptitlefont}{\sffamily\HUGE}
+\renewcommand*{\chapnumfont}{\chaptitlefont}
+% allow for 99 chapters!
+\settowidth{\chapindent}{\chapnumfont 999}
+\renewcommand*{\printchaptername}{}
+\renewcommand*{\chapternamenum}{}
+\renewcommand*{\chapnumfont}{\chaptitlefont}
+\renewcommand*{\printchapternum}{%
+\noindent\llap{\makebox[\chapindent][l]{%
+\chapnumfont \thechapter}}}
+\renewcommand*{\afterchapternum}{}
+}
+
+\chapterstyle{lean}
+
+\setsecheadstyle{\sffamily\bfseries\Large}
+\setsubsecheadstyle{\sffamily\bfseries\large}
+\setsubsubsecheadstyle{\sffamily\bfseries}
+
+\renewcommand{\cftchapterfont}{\normalfont\sffamily}
+\renewcommand{\cftsectionfont}{\normalfont\sffamily}
+\renewcommand{\cftchapterpagefont}{\normalfont\sffamily}
+\renewcommand{\cftsectionpagefont}{\normalfont\sffamily}
+\setmonofont{DejaVu Sans Mono}
+
+\title{\sffamily Two-Sided Test Document}
+\author{\sffamily Test Author}
+\date{\sffamily }
+
+\begin{document}
+
+\frontmatter
+
+\begin{titlingpage}
+\maketitle
+\end{titlingpage}
+
+\tableofcontents
+
+
+
+\mainmatter
+\chapter{Testing Two-Sided Output}\label{Two--Sided--Test--Document----Testing--Two--Sided--Output}
+
+This document is for testing the \LeanVerb|--twoside| option.
+
+
+
+
+\end{document}

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -220,7 +220,6 @@ structure OutputConfig where
   emitHtmlMulti : EmitHtml := .immediately
   wordCount : Option System.FilePath := none
   draft : Bool := false
-  twoside : Bool := false  -- two-sided output for printing
   /-- Be verbose while generating output -/
   verbose : Bool := false
 deriving ToJson, FromJson

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -220,6 +220,7 @@ structure OutputConfig where
   emitHtmlMulti : EmitHtml := .immediately
   wordCount : Option System.FilePath := none
   draft : Bool := false
+  twoside : Bool := false  -- two-sided output for printing
   /-- Be verbose while generating output -/
   verbose : Bool := false
 deriving ToJson, FromJson
@@ -401,7 +402,7 @@ def emitTeX (config : Config) (text : Part Manual) : EmitM Unit := do
   withFile (dir.join "main.tex") .write fun h => do
     if config.verbose then
       IO.println s!"Saving {dir.join "main.tex"}"
-    h.putStrLn (preamble text.titleString authors date packages.toList preambleItems.toList)
+    h.putStrLn (preamble text.titleString authors date packages.toList preambleItems.toList config.twoside)
     -- \frontmatter is inserted by our hardcoded preamble before the ToC, so it doesn't get inserted
     -- here. If there's any text at the start of the front matter, then we need to clear it to a new
     -- recto page after the ToC
@@ -997,6 +998,7 @@ where
       | .error e => throw (↑ e)
     | ("--without-word-count"::more) => opts { cfg with wordCount := none } more
     | ("--draft"::more) => opts { cfg with draft := true } more
+    | ("--twoside"::more) => opts { cfg with twoside := true } more
     | ("--verbose"::more) => opts { cfg with verbose := true } more
     | ("--remote-config"::more) =>
       match requireFilename "--remote-config" more with

--- a/src/verso-manual/VersoManual/TeX.lean
+++ b/src/verso-manual/VersoManual/TeX.lean
@@ -6,9 +6,10 @@ Author: David Thrane Christiansen
 module
 namespace Verso.Genre.Manual.TeX
 
-public def preamble (title : String) (authors : List String) (date : String) (packages : List String) (extraPreamble : List String) : String :=
+public def preamble (title : String) (authors : List String) (date : String) (packages : List String)
+                    (extraPreamble : List String) (twoside: Bool) : String :=
 r##"
-\documentclass{memoir}
+\documentclass["## ++ (if twoside then "twoside" else "oneside") ++ r##"]{memoir}
 
 \usepackage{sourcecodepro}
 \usepackage{sourcesanspro}

--- a/src/verso-manual/VersoManual/TeX/Config.lean
+++ b/src/verso-manual/VersoManual/TeX/Config.lean
@@ -12,4 +12,6 @@ open Lean
 
 public structure TeXConfig where
   extraFilesTeX : List (System.FilePath × String) := []
+  /-- two-sided output for printing -/
+  twoside : Bool := false
 deriving ToJson, FromJson


### PR DESCRIPTION
Produce one-sided LaTeX output by default, which is best for online viewing, probably the most common use case.  Also added an option `--twoside` for two-sided output intended for printing.