### PR TITLE
Fix multi-page manual TOC links

### DIFF
--- a/src/tests/TestMain.lean
+++ b/src/tests/TestMain.lean
@@ -172,6 +172,9 @@ def testLiterateHtml (_ : Config) : IO Unit :=
 def testLiterateHtmlMultiRoot (_ : Config) : IO Unit :=
   Tests.LiterateHtml.testLiterateHtmlMultiRoot
 
+def testManualHtmlMultiLinks (_ : Config) : IO Unit :=
+  Tests.ManualHtmlMulti.testManualHtmlMultiLinks
+
 -- Interactive tests via the LSP server
 def testInteractive (_ : Config) : IO Unit := do
   IO.println "Running interactive (LSP) tests..."
@@ -370,6 +373,7 @@ def tests := [
   testLiterateConfig,
   testLiterateHtml,
   testLiterateHtmlMultiRoot,
+  testManualHtmlMultiLinks,
   testSetupLiterate
 ]
 

--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -48,3 +48,4 @@ import Tests.Z85
 import Tests.Zip
 import Tests.LiterateConfig
 import Tests.LiterateHtml
+import Tests.ManualHtmlMulti

--- a/src/tests/Tests/ManualHtmlMulti.lean
+++ b/src/tests/Tests/ManualHtmlMulti.lean
@@ -1,0 +1,42 @@
+namespace Tests.ManualHtmlMulti
+
+private def hasSubstring (s : String) (sub : String) : Bool :=
+  s.find? sub |>.isSome
+
+private def assertContains (label : String) (haystack needle : String) : IO Unit := do
+  unless hasSubstring haystack needle do
+    throw <| IO.userError s!"{label}: expected output to contain {repr needle}, got:\n{haystack}"
+
+def testManualHtmlMultiLinks : IO Unit := do
+  IO.println "Running manual multi-page HTML link tests..."
+  IO.FS.withTempDir fun tmpDir => do
+    let result ← IO.Process.output {
+      cmd := "lake"
+      args := #["--quiet", "exe", "demotextbook", "--output", tmpDir.toString]
+    }
+    unless result.exitCode == 0 do
+      throw <| IO.userError s!"demotextbook failed with exit code {result.exitCode}:\n{result.stderr}"
+
+    let rootHtml ← IO.FS.readFile (tmpDir / "html-multi" / "index.html")
+    let chapterHtml ← IO.FS.readFile (tmpDir / "html-multi" / "Lean-Code" / "index.html")
+
+    assertContains
+      "root contents link"
+      rootHtml
+      "href=\"Lean-Code/index.html#A-Textbook--Lean-Code\""
+    assertContains
+      "root next button"
+      rootHtml
+      "href=\"Lean-Code/index.html#A-Textbook--Lean-Code\" rel=\"next\""
+    assertContains
+      "chapter child-page link"
+      chapterHtml
+      "href=\"Lean-Code/Saved-Lean-Code/index.html#A-Textbook--Lean-Code--Saved-Lean-Code\""
+    assertContains
+      "chapter previous button"
+      chapterHtml
+      "href=\"index.html\" rel=\"prev\""
+    assertContains
+      "same-page chapter anchor"
+      chapterHtml
+      "href=\"#A-Textbook--Lean-Code\">Lean Code</a>"

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -740,7 +740,7 @@ where
       if bookToc.size > 0 then {{
         <section>
         <h2>"Table of Contents"</h2>
-        <ol class="section-toc">{{bookToc.map (·.html config.rootTocDepth)}}</ol>
+        <ol class="section-toc">{{bookToc.map (·.html ctxt.path config.rootTocDepth)}}</ol>
         </section>
       }} else .empty
     let contents ←
@@ -892,7 +892,7 @@ where
         let subTocHtml := if subToc.size > 0 then {{
             <section>
             <h2>"Contents"</h2>
-            <ol class="section-toc">{{subToc.map (·.html config.rootTocDepth)}}</ol>
+            <ol class="section-toc">{{subToc.map (·.html ctxt.path config.rootTocDepth)}}</ol>
             </section>
           }}
         else .empty
@@ -900,7 +900,7 @@ where
       else
         let subTocHtml :=
           if (depth > 0 && part.htmlSplit != .never) && subToc.size > 0 && part.htmlToc then
-            {{<ol class="section-toc">{{subToc.map (·.html config.sectionTocDepth)}}</ol>}}
+            {{<ol class="section-toc">{{subToc.map (·.html ctxt.path config.sectionTocDepth)}}</ol>}}
           else .empty
         {{<section><h1>{{titleHtml}}</h1> {{introHtml}} {{contents}} {{subTocHtml}}</section>}}
 

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -33,6 +33,36 @@ deriving Repr, Inhabited
 namespace Toc
 
 /--
+Link to a generated manual page by explicit file path rather than a directory URL.
+This keeps multi-page manuals navigable when opened directly from disk.
+-/
+private def pageLink (path : Path) (htmlId : Option String := none) : String :=
+  let htmlId :=
+    match htmlId with
+    | some "" => none
+    | other => other
+  let anchor := htmlId.map ("#" ++ ·) |>.getD ""
+  let base :=
+    if path.isEmpty then
+      "/index.html"
+    else
+      "/" ++ String.join (path.toList.map (· ++ "/")) ++ "index.html"
+  base ++ anchor
+
+/--
+Prefer same-page anchors when possible, but use explicit page files for cross-page navigation.
+-/
+private def pageHref (currentPath targetPath : Path) (htmlId : Option String := none) : String :=
+  let htmlId :=
+    match htmlId with
+    | some "" => none
+    | other => other
+  if currentPath == targetPath then
+    htmlId.map ("#" ++ ·) |>.getD (pageLink targetPath)
+  else
+    pageLink targetPath htmlId
+
+/--
 Remove all ToC elements that don't have their own paths.
 -/
 partial def onlyPages (toc : Toc) : Toc :=
@@ -209,13 +239,11 @@ Convert a `Toc` to `HTML`.
 
 The `depth` is a limit for the tree depth of the generated HTML (`none` for no limit).
 -/
-public partial def Toc.html (depth : Option Nat) : Toc → Html
+public partial def Toc.html (currentPath : Path) (depth : Option Nat) : Toc → Html
   | {title, shortTitle := _, path, id, sectionNum, children} =>
     if depth = some 0 then .empty
     else
-      let page :=
-        if path.isEmpty then "/"
-        else path.link id
+      let page := pageHref currentPath path id
       let sectionNum :=
         match sectionNum with
         | none => {{<span class="unnumbered"></span>}}
@@ -224,7 +252,7 @@ public partial def Toc.html (depth : Option Nat) : Toc → Html
         <li>
           <a href={{page}}>{{sectionNum}}{{title}}</a>
           {{if children.isEmpty || depth == some 1 then .empty
-            else {{<ol> {{children.map (·.html (depth.map Nat.pred))}} </ol>}} }}
+            else {{<ol> {{children.map (·.html currentPath (depth.map Nat.pred))}} </ol>}} }}
         </li>
       }}
 
@@ -249,7 +277,7 @@ where
       let relAttr := rel.map (fun r => #[("rel", r)]) |>.getD #[]
       let titleAttr := toc.bind getTitle |>.map (fun t => #[("title", t)]) |>.getD #[]
       {{
-        <a class="local-button active" href={{dest.path.link dest.id}} {{relAttr ++ titleAttr}}>
+        <a class="local-button active" href={{pageHref path dest.path dest.id}} {{relAttr ++ titleAttr}}>
           {{label}}
         </a>
       }}
@@ -370,10 +398,10 @@ where
     splitTocWrapper isTop isOpen true chapterId «section» title children
 
 
-  linkify (path : Path) (id : Option String) (html : Html) :=
+  linkify (targetPath : Path) (id : Option String) (html : Html) :=
     match html with
     | .tag "a" _ _ => html
-    | other => {{<a href={{path.link id}}>{{other}}</a>}}
+    | other => {{<a href={{pageHref path targetPath id}}>{{other}}</a>}}
   sectionNum num :=
       match num with
       | none => {{<span class="unnumbered"></span>}}


### PR DESCRIPTION
Emit explicit index.html targets for manual multi-page navigation so TOC and nav links work when opened directly from disk.

Add a regression test that builds the demo textbook and checks the generated html-multi links.