### PR TITLE
fix: deduplicate auto-generated heading tags in freshTag

### DIFF
--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -417,7 +417,9 @@ def freshTag [Monad m] [MonadStateOf TraverseState m] (hint : String) (id : Inte
   let mut numPart : Option Nat := none
   repeat
     let attempt := tagStr strPart numPart
-    if (← get).tags.contains  attempt then
+    -- Lookup must use `Tag.internal`: `attempt` is a `String`, and the `Coe String Tag`
+    -- instance would otherwise search for `Tag.provided`, so generated tags never collide.
+    if (← get).tags.contains (Tag.internal attempt) then
       numPart := some <| numPart.map (· + 1) |>.getD 0
     else break
   let tag := tagStr strPart numPart


### PR DESCRIPTION
## Summary
- `freshTag` looked up candidates via `tags.contains attempt`, which coerced the `String` to `Tag.provided`, while generated tags are stored as `Tag.internal`.
- Lookup now uses `Tag.internal attempt` so colliding headings get a numeric suffix instead of failing with "Duplicate tag".

Fixes #897.

## Test plan
- [ ] Manual with two `# Same` headings: `lake exe` succeeds and assigns unique tags
- [ ] Existing unique headings still get the same slug as before

Made with [Cursor](https://cursor.com)