### PR TITLE
docs: escape &amp; in HTML entity docstrings

### DIFF
--- a/src/verso/Verso/Output/Html.lean
+++ b/src/verso/Verso/Output/Html.lean
@@ -31,7 +31,7 @@ A representation of HTML, used to render Verso to the web.
 public inductive Html where
   /--
   Textual content. If `escape` is `true`, then characters such as `'&'` are escaped to entities such
-  as `"&amp;"` during rendering.
+  as `"&amp;amp;"` during rendering.
   -/
   | text (escape : Bool) (string : String)
   /--

--- a/src/verso/Verso/Output/Html/Entities.lean
+++ b/src/verso/Verso/Output/Html/Entities.lean
@@ -64,18 +64,18 @@ The JSON HTML entity database, from [the specification](https://html.spec.whatwg
 public def json := entityInfo.1
 
 /--
-A table mapping HTML entity strings (such as `&amp;`) to the strings that they denote (such as `&`).
+A table mapping HTML entity strings (such as `&amp;amp;`) to the strings that they denote (such as `&`).
 Most entities denote just one character, but some entities are represented by combining characters,
 so the returned string may have a length greater than one.
 -/
 public def entityStrings := entityInfo.2.1
 
 /--
-A table mapping strings (such as `&`) to the named entities that denote them (such as `&amp;`).
+A table mapping strings (such as `&`) to the named entities that denote them (such as `&amp;amp;`).
 
 Most entities denote just one character, but some entities are represented by combining characters.
 Some strings are denoted by more than one named entity; for example, `&` can be represented by both
-`&amp;` and `&AMP`. Not all named entities end in a semicolon.
+`&amp;amp;` and `&AMP`. Not all named entities end in a semicolon.
 -/
 public def stringEntities := entityInfo.2.2
 


### PR DESCRIPTION
## Summary
- Double-escape `&amp;` in `Html.text` / `Entities` docstrings so rendered docs show the literal entity name instead of `&`.

Fixes #898.

## Test plan
- [ ] Check rendered docs for `Html.text` show `"&amp;"` literally

Made with [Cursor](https://cursor.com)