### PR TITLE
doc: fix "paramter" and "correponding" typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In the past, the `main` branch tracked upstream Lean closely, but
 these procedures make it easier to coordinate PRs across many
 repositories.
 
-When a Lean release is created, a correponding tag for the compatible
+When a Lean release is created, a corresponding tag for the compatible
 version of Verso is also created. For example, the `v4.19.0` tag
 should be used for projects that are built in Lean 4.19.0.
 

--- a/doc/UsersGuide/Manuals.lean
+++ b/doc/UsersGuide/Manuals.lean
@@ -109,7 +109,7 @@ The {name}`table` directive is used to implement tables.
 Tables are written as bulleted list of bulleted lists; the outer lists are rows, and the inner lists are columns; each row must contain the same number of columns.
 
 The flag `header` determines whether the first row should be considered as table data or as headers for the remaining rows.
-The named paramter `align`, which may be {name TableConfig.Alignment.left}`left`, {name TableConfig.Alignment.center}`center`, or {name TableConfig.Alignment.right}`right`, determines the alignment of the table with respect to the surrounding text.
+The named parameter `align`, which may be {name TableConfig.Alignment.left}`left`, {name TableConfig.Alignment.center}`center`, or {name TableConfig.Alignment.right}`right`, determines the alignment of the table with respect to the surrounding text.
 
 ::::paragraph
 This table maps $`n` to $`n!`:


### PR DESCRIPTION
This PR fixes two typos in documentation:
- "paramter" → "parameter" in the manuals user guide
- "correponding" → "corresponding" in the README
