### PR TITLE
chore: bump SubVerso

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -35,7 +35,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "6b0b76cb79974cc1d43f988d26f7d3fa35e773cc",
+   "rev": "4343da18d95390b09fde98efb18125677c4b500c",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -35,7 +35,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "859ab80c32c5851151919a7d757d7c0c0b6e39d2",
+   "rev": "6b0b76cb79974cc1d43f988d26f7d3fa35e773cc",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/src/verso-blog/VersoBlog.lean
+++ b/src/verso-blog/VersoBlog.lean
@@ -325,7 +325,7 @@ meta def leanCommand : BlockCommandOf LeanCommandConfig
     let projectExamples ← getSubproject project
     let (_, {highlighted := hls, original := str, ..}) ← projectExamples.getOrSuggest exampleName
     Verso.Hover.addCustomHover exampleName s!"```lean\n{str}\n```"
-    `(Block.other (Blog.BlockExt.highlightedCode { contextName := $(quote project.getId), showProofStates := $(quote showProofStates) } (SubVerso.Highlighting.Highlighted.seq $(quote hls))) #[Block.code $(quote str)])
+    `(Block.other (Blog.BlockExt.highlightedCode { contextName := $(quote project.getId), showProofStates := $(quote showProofStates) } $(quote hls)) #[Block.code $(quote str)])
 
 structure LeanCommandAtArgs where
   project : Ident
@@ -402,7 +402,7 @@ meta def leanTerm : RoleExpanderOf LeanTermArgs
     let projectExamples ← getSubproject project
     let (_, {highlighted := hls, original := str, ..}) ← projectExamples.getOrSuggest <| mkIdentFrom name exampleName
     Verso.Hover.addCustomHover arg s!"```lean\n{str}\n```"
-    `(Inline.other (Blog.InlineExt.highlightedCode { contextName := $(quote project.getId) } (SubVerso.Highlighting.Highlighted.seq $(quote hls))) #[Inline.code $(quote str)])
+    `(Inline.other (Blog.InlineExt.highlightedCode { contextName := $(quote project.getId) } $(quote hls)) #[Inline.code $(quote str)])
   | _, more =>
     if h : more.size > 0 then
       throwErrorAt more[0] "Unexpected contents"

--- a/src/verso-manual/VersoManual/InlineLean/Signature.lean
+++ b/src/verso-manual/VersoManual/InlineLean/Signature.lean
@@ -87,7 +87,7 @@ meta def signature : CodeBlockExpanderOf SignatureConfig
       try
         let ((hls, _, _, _), st') ← ((SubVerso.Examples.checkSignature name sig).run cmdCtx).run cmdState
         setInfoState st'.infoState
-        pure (Highlighted.seq hls)
+        pure hls
       catch e =>
         let fmt ← PrettyPrinter.ppSignature (TSyntax.mk name.raw[0]).getId
         Suggestion.saveSuggestion str (fmt.fmt.pretty 60) (fmt.fmt.pretty 30 ++ "\n")

--- a/test-projects/anchor-examples/lake-manifest.json
+++ b/test-projects/anchor-examples/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
+      "rev": "ea0fbc7d444662260125aa58490499ab107ef9b6",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/anchor-examples/lake-manifest.json
+++ b/test-projects/anchor-examples/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "09b053f74253377ba2d51c5c379757ed237f17f9",
+      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/documented-package/lake-manifest.json
+++ b/test-projects/documented-package/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
+      "rev": "ea0fbc7d444662260125aa58490499ab107ef9b6",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/documented-package/lake-manifest.json
+++ b/test-projects/documented-package/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "09b053f74253377ba2d51c5c379757ed237f17f9",
+      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/literate-config/lake-manifest.json
+++ b/test-projects/literate-config/lake-manifest.json
@@ -52,7 +52,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "859ab80c32c5851151919a7d757d7c0c0b6e39d2",
+      "rev": "6b0b76cb79974cc1d43f988d26f7d3fa35e773cc",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/literate-config/lake-manifest.json
+++ b/test-projects/literate-config/lake-manifest.json
@@ -52,7 +52,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "6b0b76cb79974cc1d43f988d26f7d3fa35e773cc",
+      "rev": "4343da18d95390b09fde98efb18125677c4b500c",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/literate-multi-root/lake-manifest.json
+++ b/test-projects/literate-multi-root/lake-manifest.json
@@ -52,7 +52,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "859ab80c32c5851151919a7d757d7c0c0b6e39d2",
+      "rev": "6b0b76cb79974cc1d43f988d26f7d3fa35e773cc",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/literate-multi-root/lake-manifest.json
+++ b/test-projects/literate-multi-root/lake-manifest.json
@@ -52,7 +52,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "6b0b76cb79974cc1d43f988d26f7d3fa35e773cc",
+      "rev": "4343da18d95390b09fde98efb18125677c4b500c",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/website-examples/lake-manifest.json
+++ b/test-projects/website-examples/lake-manifest.json
@@ -6,7 +6,7 @@
       "url": "https://github.com/leanprover/subverso",
       "type": "git",
       "subDir": null,
-      "rev": "09b053f74253377ba2d51c5c379757ed237f17f9",
+      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/website-examples/lake-manifest.json
+++ b/test-projects/website-examples/lake-manifest.json
@@ -6,7 +6,7 @@
       "url": "https://github.com/leanprover/subverso",
       "type": "git",
       "subDir": null,
-      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
+      "rev": "ea0fbc7d444662260125aa58490499ab107ef9b6",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/website-literate/lake-manifest.json
+++ b/test-projects/website-literate/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
+      "rev": "ea0fbc7d444662260125aa58490499ab107ef9b6",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/website-literate/lake-manifest.json
+++ b/test-projects/website-literate/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "09b053f74253377ba2d51c5c379757ed237f17f9",
+      "rev": "f8a1991a3cc31fb61688f38429fb98396e3a9711",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",


### PR DESCRIPTION
This PR bumps SubVerso. The new version makes it possible to enable `precompileModules` on SubVerso, though does not enable it by default for now (see PR discussion).