### PR TITLE
fix: don't run 'lake update subverso' in IO example projects

### DIFF
--- a/src/verso-manual/VersoManual/InlineLean/IO.lean
+++ b/src/verso-manual/VersoManual/InlineLean/IO.lean
@@ -428,11 +428,6 @@ meta def check
           logErrorAt (loc (some o)) s!"Output file {f} mismatch. Got:\n{contents}"
       else Lean.logError s!"Output file {f} not found"
 
-    let out ← IO.Process.output {cmd := "lake", args := #["update", "subverso"], cwd := some dirname}
-    if out.exitCode != 0 then
-      throwError
-        m!"When running 'lake update subverso' in {dirname}, the exit code was {out.exitCode}\n" ++
-        m!"Stderr:\n{out.stderr}\n\nStdout:\n{out.stdout}\n\n"
     let jsonFile := s!"{leanCodeName}.json"
     let out ← IO.Process.output {cmd := toString «subverso-extract-mod» , args := #[leanCodeName, jsonFile], cwd := some dirname}
     if out.exitCode != 0 then


### PR DESCRIPTION
The temporary project generated for an IO example does not depend on SubVerso, so there is nothing to update. Recent versions of Lake reject updating a package that the project does not require.