### PR TITLE
chore: install all subproject toolchains in CI explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
 
             - uses: actions/checkout@v7
 
+            - name: Install subproject toolchains
+              run: |
+                  find . -name lean-toolchain -type f -not -path './.*' | while read -r f; do
+                      elan toolchain install "$(cat "$f")"
+                  done
+
             - name: List all files
               run: |
                   find . -name "*.lean" -type f

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -23,6 +23,12 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - name: Install subproject toolchains
+              run: |
+                  find . -name lean-toolchain -type f -not -path './.*' | while read -r f; do
+                      elan toolchain install "$(cat "$f")"
+                  done
+
             - name: Lean version
               run: lean --version
 


### PR DESCRIPTION
This prevents concurrent toolchain install passes from stepping on each other by accident.