### PR TITLE
fix: deprecation warning

### DIFF
--- a/src/multi-verso/MultiVerso/NameMap.lean
+++ b/src/multi-verso/MultiVerso/NameMap.lean
@@ -233,7 +233,7 @@ public instance : GetElem? (NameMap α) Name α fun xs n => n ∈ xs where
   getElem xs x ok :=
     if h : isPublic x then
       show α from GetElem.getElem (coll := TreeMap PublicName α PublicName.quickCmp) (idx := PublicName) (elem := α) (valid := fun xs x => x ∈ xs) xs ⟨x, h⟩ <| by
-        simp only [Membership.mem, h, dite_cond_eq_true] at ok
+        simp only [Membership.mem, h, dite_eq_left_of_eq_true] at ok
         exact ok
     else
      False.elim <| by


### PR DESCRIPTION
dite_cond_eq_true was renamed to dite_eq_left_of_eq_true.

No-Changelog: this is a minor internal change