### PR TITLE
feat: variables for all code colors, coherent hover behavior

### DIFF
--- a/browser-tests/hover_media.py
+++ b/browser-tests/hover_media.py
@@ -1,0 +1,10 @@
+import pytest
+from playwright.sync_api import Page
+
+
+def require_hover_media(page: Page):
+    """Skip when the browser reports no hover support, which disables CSS guarded by
+    @media (hover: hover). Linux headless Firefox does this:
+    https://bugzilla.mozilla.org/show_bug.cgi?id=2037020"""
+    if not page.evaluate("matchMedia('(hover: hover)').matches"):
+        pytest.skip("Browser does not enable CSS guarded by @media (hover: hover)")

--- a/browser-tests/literate/test_gallery.py
+++ b/browser-tests/literate/test_gallery.py
@@ -5,10 +5,18 @@ these tests check that each one is present in the generated page and that hoveri
 produces the right tooltip theme.
 """
 
+import pytest
 from playwright.sync_api import Page
 
 
 GALLERY = "/LitConfig/Gallery/"
+
+
+def require_hover_media(page: Page):
+    # Linux headless Firefox can report no hover support, so CSS guarded by
+    # @media (hover: hover) is disabled: https://bugzilla.mozilla.org/show_bug.cgi?id=2037020
+    if not page.evaluate("matchMedia('(hover: hover)').matches"):
+        pytest.skip("Browser does not enable CSS guarded by @media (hover: hover)")
 
 
 class TestGalleryContents:
@@ -93,6 +101,7 @@ class TestGalleryContents:
         whole span; the token hover highlight is removed so it reads as one region."""
         page.goto(f"{server}{GALLERY}")
         page.wait_for_load_state("networkidle")
+        require_hover_media(page)
         token = page.locator(".hl.lean .has-info.warning > .token").first
         token.hover()
         span_bg = page.evaluate(
@@ -208,6 +217,8 @@ class TestGalleryContents:
         box = page.locator(".tippy-box").first
         box.wait_for(state="visible")
         assert "Runs a tactic sequence" in box.inner_text()
+        # The highlight assertions read CSS that is guarded by @media (hover: hover).
+        require_hover_media(page)
         result = page.evaluate(
             """() => {
                 const token = Array.from(document.querySelectorAll('.hl.lean .has-info.warning .token'))
@@ -300,13 +311,17 @@ class TestGalleryContents:
         page.goto(f"{server}{GALLERY}")
         page.wait_for_load_state("networkidle")
         label = page.locator(".hl.lean .has-info.warning .tactic > label").first
-        label.hover()
+        # Aim at whitespace inside the label: hovering the label's center would land on
+        # whichever token the browser's font metrics put there, and a documented token
+        # would rightly claim the tooltip for itself once the region is expanded.
+        target = label.locator(".inter-text").first
+        target.hover()
         page.locator(".tippy-box[data-theme~='tactic']").first.wait_for(state="visible")
-        label.click()
+        target.click()
         page.locator(".tippy-box[data-theme~='warning']").first.wait_for(
             state="visible"
         )
-        label.click()
+        target.click()
         page.locator(".tippy-box[data-theme~='tactic']").first.wait_for(state="visible")
 
     def test_message_tooltip_after_expanding_proof(self, server: str, page: Page):

--- a/browser-tests/literate/test_gallery.py
+++ b/browser-tests/literate/test_gallery.py
@@ -44,7 +44,7 @@ class TestGalleryContents:
         information severity."""
         page.goto(f"{server}{GALLERY}")
         page.wait_for_load_state("networkidle")
-        span = page.locator('.hl.lean .has-info', has_text='"three"').last
+        span = page.locator(".hl.lean .has-info", has_text='"three"').last
         assert span.count() > 0
         msg = span.locator(".verso-message").first.inner_text()
         assert "Type mismatch" in msg
@@ -139,7 +139,9 @@ class TestGalleryContents:
         page.goto(f"{server}{GALLERY}")
         page.wait_for_load_state("networkidle")
         # The deprecated use site's tooltip message links to both constants.
-        page.locator(".hl.lean .has-info.warning > a > .token", has_text="oldGallerySort").first.hover()
+        page.locator(
+            ".hl.lean .has-info.warning > a > .token", has_text="oldGallerySort"
+        ).first.hover()
         box = page.locator(".tippy-box").first
         box.wait_for(state="visible")
         assert box.locator("a").count() > 0
@@ -147,7 +149,6 @@ class TestGalleryContents:
             "() => getComputedStyle(document.querySelector('.tippy-box a')).textDecorationLine"
         )
         assert deco == "none"
-
 
     def test_nested_message_regions(self, server: str, page: Page):
         """A warning region nested inside an informational region keeps its own text and
@@ -302,7 +303,9 @@ class TestGalleryContents:
         label.hover()
         page.locator(".tippy-box[data-theme~='tactic']").first.wait_for(state="visible")
         label.click()
-        page.locator(".tippy-box[data-theme~='warning']").first.wait_for(state="visible")
+        page.locator(".tippy-box[data-theme~='warning']").first.wait_for(
+            state="visible"
+        )
         label.click()
         page.locator(".tippy-box[data-theme~='tactic']").first.wait_for(state="visible")
 

--- a/browser-tests/literate/test_gallery.py
+++ b/browser-tests/literate/test_gallery.py
@@ -5,18 +5,12 @@ these tests check that each one is present in the generated page and that hoveri
 produces the right tooltip theme.
 """
 
-import pytest
 from playwright.sync_api import Page
+
+from hover_media import require_hover_media
 
 
 GALLERY = "/LitConfig/Gallery/"
-
-
-def require_hover_media(page: Page):
-    # Linux headless Firefox can report no hover support, so CSS guarded by
-    # @media (hover: hover) is disabled: https://bugzilla.mozilla.org/show_bug.cgi?id=2037020
-    if not page.evaluate("matchMedia('(hover: hover)').matches"):
-        pytest.skip("Browser does not enable CSS guarded by @media (hover: hover)")
 
 
 class TestGalleryContents:

--- a/browser-tests/literate/test_gallery.py
+++ b/browser-tests/literate/test_gallery.py
@@ -1,0 +1,345 @@
+"""Tests for the code rendering gallery page (LitConfig.Gallery).
+
+The gallery module contains at least one instance of every kind of code rendering, so
+these tests check that each one is present in the generated page and that hovering
+produces the right tooltip theme.
+"""
+
+from playwright.sync_api import Page
+
+
+GALLERY = "/LitConfig/Gallery/"
+
+
+class TestGalleryContents:
+    def test_all_renderings_present(self, server: str, page: Page):
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        counts = page.evaluate(
+            """() => ({
+                warning: document.querySelectorAll('.hl.lean .has-info.warning').length,
+                information: document.querySelectorAll('.hl.lean .has-info.information').length,
+                tactics: document.querySelectorAll('.hl.lean .tactic').length,
+                tacticStates: document.querySelectorAll('.hl.lean .tactic-state').length,
+                outputs: document.querySelectorAll('.lean-output').length,
+                docHovers: document.querySelectorAll('.hl.lean [data-verso-hover]').length,
+                nestedStates: document.querySelectorAll('.hl.lean .has-info.warning .tactic-state').length,
+            })"""
+        )
+        # sorry definition, deprecated use, and a sorry proof
+        assert counts["warning"] >= 3, counts
+        # the flag_proof theorem nests proof states inside a warning span
+        assert counts["nestedStates"] >= 1, counts
+        # #eval and #check hovers
+        assert counts["information"] >= 2, counts
+        assert counts["tactics"] >= 2, counts
+        assert counts["tacticStates"] >= 2, counts
+        # #eval and #check output blocks
+        assert counts["outputs"] >= 2, counts
+        assert counts["docHovers"] >= 1, counts
+
+    def test_expected_error_block_attaches_diagnostic(self, server: str, page: Page):
+        """The `+error` code block's diagnostic is attached to the failing code. Lean
+        re-logs expected errors as silent information messages, so the span carries
+        information severity."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        span = page.locator('.hl.lean .has-info', has_text='"three"').last
+        assert span.count() > 0
+        msg = span.locator(".verso-message").first.inner_text()
+        assert "Type mismatch" in msg
+
+    def test_proof_state_css_nests_under_warning(self, server: str, page: Page):
+        """Warning code colors inherit into a warning-wrapped proof but stop at the
+        proof states nested inside it, which use their own variables."""
+        page.add_init_script(
+            """document.addEventListener('DOMContentLoaded', () => {
+                const s = document.documentElement.style;
+                s.setProperty('--verso-code-warning-color', 'rgb(10, 20, 30)');
+                s.setProperty('--verso-tactic-state-color', 'rgb(1, 2, 3)');
+                s.setProperty('--verso-tactic-state-bg-color', 'rgb(4, 5, 6)');
+            })"""
+        )
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        result = page.evaluate(
+            """() => {
+                const span = document.querySelector('.hl.lean .has-info.warning:has(.tactic-state)');
+                const label = span.querySelector('.tactic > label');
+                const state = span.querySelector('.tactic-state');
+                return {
+                    spanColor: getComputedStyle(span).color,
+                    labelColor: getComputedStyle(label).color,
+                    stateColor: getComputedStyle(state).color,
+                    stateBg: getComputedStyle(state).backgroundColor,
+                };
+            }"""
+        )
+        assert result["spanColor"] == "rgb(10, 20, 30)"
+        assert result["labelColor"] == "rgb(10, 20, 30)"
+        assert result["stateColor"] == "rgb(1, 2, 3)"
+        assert result["stateBg"] == "rgb(4, 5, 6)"
+
+    def test_warning_hover_uses_warning_theme(self, server: str, page: Page):
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        page.locator(".hl.lean .has-info.warning").first.hover()
+        box = page.locator(".tippy-box[data-theme~='warning']").first
+        box.wait_for(state="visible")
+        assert "declaration uses" in box.inner_text()
+
+    def test_warning_hover_highlights_whole_span(self, server: str, page: Page):
+        """Hovering warning-carrying code shows the warning hover background across the
+        whole span; the token hover highlight is removed so it reads as one region."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        token = page.locator(".hl.lean .has-info.warning > .token").first
+        token.hover()
+        span_bg = page.evaluate(
+            "() => getComputedStyle(document.querySelector('.hl.lean .has-info.warning')).backgroundColor"
+        )
+        token_bg = page.evaluate(
+            "() => getComputedStyle(document.querySelector('.hl.lean .has-info.warning > .token')).backgroundColor"
+        )
+        assert span_bg == "rgb(255, 243, 205)"
+        assert token_bg == "rgba(0, 0, 0, 0)"
+
+    def test_sorry_name_shows_single_merged_hover(self, server: str, page: Page):
+        """The warning span around a sorry definition's name shares the name token's
+        extent, so one tooltip shows both the warning and the documentation."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        page.locator(".hl.lean .has-info.warning > .token").first.hover()
+        box = page.locator(".tippy-box").first
+        box.wait_for(state="visible")
+        page.wait_for_timeout(400)
+        boxes = page.locator(".tippy-box")
+        assert boxes.count() == 1
+        text = boxes.first.inner_text()
+        assert "declaration uses" in text
+        assert "Sorts a list, eventually." in text
+        # The warning keeps its severity accent, distinguishing it from the documentation
+        accent = page.evaluate(
+            """() => {
+                const msg = document.querySelector('.tippy-box .hover-info.messages > code.warning');
+                const style = getComputedStyle(msg);
+                return { width: style.borderLeftWidth, color: style.borderLeftColor };
+            }"""
+        )
+        assert accent["width"] != "0px"
+        assert accent["color"] == "rgb(255, 243, 205)"
+        # The message block is separated from the documentation below it
+        margin = page.evaluate(
+            "() => getComputedStyle(document.querySelector('.tippy-box .hl.lean.mixed > .hover-info.messages')).marginBottom"
+        )
+        assert margin != "0px"
+
+    def test_tooltip_links_not_underlined(self, server: str, page: Page):
+        """Constant links inside tooltip content show no underline until hovered."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        # The deprecated use site's tooltip message links to both constants.
+        page.locator(".hl.lean .has-info.warning > a > .token", has_text="oldGallerySort").first.hover()
+        box = page.locator(".tippy-box").first
+        box.wait_for(state="visible")
+        assert box.locator("a").count() > 0
+        deco = page.evaluate(
+            "() => getComputedStyle(document.querySelector('.tippy-box a')).textDecorationLine"
+        )
+        assert deco == "none"
+
+
+    def test_nested_message_regions(self, server: str, page: Page):
+        """A warning region nested inside an informational region keeps its own text and
+        underline colors, and the informational region continues past it."""
+        page.add_init_script(
+            """document.addEventListener('DOMContentLoaded', () => {
+                const s = document.documentElement.style;
+                s.setProperty('--verso-code-info-color', 'rgb(1, 2, 3)');
+                s.setProperty('--verso-code-warning-color', 'rgb(4, 5, 6)');
+                s.setProperty('--verso-info-indicator-color', 'rgb(7, 8, 9)');
+                s.setProperty('--verso-warning-indicator-color', 'rgb(10, 11, 12)');
+            })"""
+        )
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        result = page.evaluate(
+            """() => {
+                const outer = document.querySelector(
+                    '.hl.lean .has-info.information:has(.has-info.warning)');
+                if (!outer) return null;
+                const inner = outer.querySelector('.has-info.warning');
+                const tokenIn = (region) =>
+                    Array.from(region.querySelectorAll('.token')).find(t =>
+                        t.closest('.has-info') === region && !t.closest('.tactic-state'));
+                const codeText = (el) => {
+                    const c = el.cloneNode(true);
+                    c.querySelectorAll('.hover-container, .tactic-state').forEach(x => x.remove());
+                    return c.textContent;
+                };
+                return {
+                    outerColor: getComputedStyle(outer).color,
+                    innerColor: getComputedStyle(inner).color,
+                    outerUnderline: getComputedStyle(tokenIn(outer)).textDecorationColor,
+                    innerUnderline: getComputedStyle(tokenIn(inner)).textDecorationColor,
+                    outerText: codeText(outer),
+                };
+            }"""
+        )
+        assert result is not None, "expected a warning region nested in an info region"
+        assert result["outerColor"] == "rgb(1, 2, 3)"
+        assert result["innerColor"] == "rgb(4, 5, 6)"
+        assert result["outerUnderline"] == "rgb(7, 8, 9)"
+        assert result["innerUnderline"] == "rgb(10, 11, 12)"
+        # The informational region includes the branch after the warning
+        assert "succ" in result["outerText"]
+
+    def test_hover_highlight_matches_tooltip(self, server: str, page: Page):
+        """Hovering a documented token inside a message region shows the token's tooltip,
+        so only the token is highlighted: the region and the enclosing tactic label are
+        not."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        token = page.locator(
+            ".hl.lean .has-info.warning .token", has_text="flag_proof"
+        ).first
+        token.hover()
+        box = page.locator(".tippy-box").first
+        box.wait_for(state="visible")
+        assert "Runs a tactic sequence" in box.inner_text()
+        result = page.evaluate(
+            """() => {
+                const token = Array.from(document.querySelectorAll('.hl.lean .has-info.warning .token'))
+                    .find(t => t.textContent === 'flag_proof');
+                const label = token.closest('label');
+                return {
+                    token: getComputedStyle(token).backgroundColor,
+                    label: label ? getComputedStyle(label).backgroundColor : null,
+                    region: getComputedStyle(token.closest('.has-info')).backgroundColor,
+                };
+            }"""
+        )
+        assert result["token"] == "rgb(238, 238, 238)"
+        assert result["label"] in (None, "rgba(0, 0, 0, 0)")
+        assert result["region"] == "rgba(0, 0, 0, 0)"
+
+    def test_same_range_messages_share_a_region(self, server: str, page: Page):
+        """Messages of different severities with exactly the same range share one region,
+        styled by the most severe message. Its tooltip carries both messages, each with
+        its own severity accent."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        result = page.evaluate(
+            """() => {
+                const span = Array.from(document.querySelectorAll('.hl.lean .has-info.warning'))
+                    .find(s =>
+                        s.querySelector(':scope > .hover-container code.verso-message.warning') &&
+                        s.querySelector(':scope > .hover-container code.verso-message.information'));
+                if (!span || !span._tippy) return null;
+                const inst = span._tippy;
+                inst.show();
+                const box = inst.popper.querySelector('.tippy-box');
+                const accent = (sel) => {
+                    const st = getComputedStyle(box.querySelector(sel));
+                    return { width: st.borderLeftWidth, color: st.borderLeftColor };
+                };
+                const res = {
+                    theme: box.dataset.theme,
+                    warn: accent('code.verso-message.warning'),
+                    info: accent('code.verso-message.information'),
+                };
+                inst.hide();
+                return res;
+            }"""
+        )
+        assert result is not None, "expected a region carrying both severities"
+        assert "warning" in result["theme"]
+        assert result["warn"]["width"] != "0px"
+        assert result["warn"]["color"] == "rgb(255, 243, 205)"
+        assert result["info"]["width"] != "0px"
+        assert result["info"]["color"] == "rgb(207, 226, 255)"
+
+    def test_enclosing_tooltip_hides_nested_tooltip(self, server: str, page: Page):
+        """Showing an enclosing region's tooltip hides a tooltip that is already visible
+        on content nested inside it, so only one tooltip is on screen at a time."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        # The #check command's information span contains the documented List.length token.
+        shown = page.evaluate(
+            """() => {
+                const span = Array.from(document.querySelectorAll('.hl.lean .has-info.information'))
+                    .find(s => s._tippy && s.querySelector('[data-verso-hover]')?._tippy);
+                if (!span) return false;
+                window._nestedTooltips = { span, tok: span.querySelector('[data-verso-hover]') };
+                window._nestedTooltips.tok._tippy.show();
+                return true;
+            }"""
+        )
+        assert shown, "expected an information span containing a documented token"
+        # The nested tooltip only registers as visible once its transition finishes.
+        page.wait_for_function("() => window._nestedTooltips.tok._tippy.state.isShown")
+        result = page.evaluate(
+            """() => {
+                const { span, tok } = window._nestedTooltips;
+                span._tippy.show();
+                return {
+                    span: span._tippy.state.isVisible,
+                    tok: tok._tippy.state.isVisible,
+                };
+            }"""
+        )
+        assert result["span"]
+        assert not result["tok"]
+
+    def test_tooltip_follows_toggle_under_pointer(self, server: str, page: Page):
+        """Clicking a proof-state label nested in a warning span switches the tooltip in
+        place: expanding shows the warning span's tooltip, collapsing shows the proof
+        state again. The pointer never leaves the span, so no hover event fires; the
+        toggle itself must update the tooltip."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        label = page.locator(".hl.lean .has-info.warning .tactic > label").first
+        label.hover()
+        page.locator(".tippy-box[data-theme~='tactic']").first.wait_for(state="visible")
+        label.click()
+        page.locator(".tippy-box[data-theme~='warning']").first.wait_for(state="visible")
+        label.click()
+        page.locator(".tippy-box[data-theme~='tactic']").first.wait_for(state="visible")
+
+    def test_message_tooltip_after_expanding_proof(self, server: str, page: Page):
+        """A message span inside a collapsed proof gains its tooltip when the proof is
+        expanded."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        result = page.evaluate(
+            """() => {
+                const span = Array.from(document.querySelectorAll('.hl.lean .has-info.warning'))
+                    .find(s => s.textContent.includes('oldGallerySort') &&
+                        s.closest('.tactic') && s.closest('.tactic') !== s);
+                if (!span) return null;
+                const before = !!span._tippy;
+                const toggle = span.closest('.tactic').querySelector(':scope > input.tactic-toggle');
+                toggle.click();
+                return { before, after: !!span._tippy };
+            }"""
+        )
+        assert result is not None, "expected a warning span inside a proof"
+        assert not result["before"]
+        assert result["after"]
+
+    def test_no_duplicate_proof_states(self, server: str, page: Page):
+        """No proof state appears twice with the same goals at the same position."""
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        keys = page.evaluate(
+            """() => Array.from(document.querySelectorAll('input.tactic-toggle[id]'))
+                .map(e => e.id.split('-').slice(0, -1).join('-'))"""
+        )
+        assert len(keys) == len(set(keys)), keys
+
+    def test_tactic_hover_uses_tactic_theme(self, server: str, page: Page):
+        page.goto(f"{server}{GALLERY}")
+        page.wait_for_load_state("networkidle")
+        page.locator(".hl.lean .tactic > label").first.hover()
+        box = page.locator(".tippy-box[data-theme~='tactic']").first
+        box.wait_for(state="visible")

--- a/browser-tests/literate/test_nested_tactics.py
+++ b/browser-tests/literate/test_nested_tactics.py
@@ -1,5 +1,6 @@
-import pytest
 from playwright.sync_api import Page
+
+from hover_media import require_hover_media
 
 
 # `rw [h1, h2, h3]` in `LitConfig.lean` highlights as nested tactic regions: the whole-invocation
@@ -81,12 +82,6 @@ class TestNestedTacticStates:
         assert "All goals completed" not in text
         assert "Nat" in text  # a real intermediate goal
 
-    def _require_hover_media(self, page: Page):
-        # Linux headless Firefox can report no hover support, so the guarded CSS rule is disabled:
-        # https://bugzilla.mozilla.org/show_bug.cgi?id=2037020
-        if not page.evaluate("matchMedia('(hover: hover)').matches"):
-            pytest.skip("Browser does not enable CSS guarded by @media (hover: hover)")
-
     @staticmethod
     def _region_label_backgrounds(tok):
         """Backgrounds of the labels of every tactic region enclosing `tok`, innermost first."""
@@ -104,7 +99,7 @@ class TestNestedTacticStates:
     def test_hover_highlights_own_region_label(self, server: str, page: Page):
         """Hovering a region's plain content highlights that region's label."""
         self._load(server, page)
-        self._require_hover_media(page)
+        require_hover_media(page)
         # The `rw` keyword is direct content of the whole-`rw` region.
         tok = self._rw_keyword(page)
         tok.hover()
@@ -121,7 +116,7 @@ class TestNestedTacticStates:
         token: the region's proof state is the tooltip shown there, so the token itself stays
         plain and enclosing regions' labels stay unhighlighted."""
         self._load(server, page)
-        self._require_hover_media(page)
+        require_hover_media(page)
         # The first rewrite rule (`h1`, a documented token) is nested inside its own step region,
         # which is nested inside the whole-`rw` region.
         tok = self._rw_keyword(page).locator(

--- a/browser-tests/literate/test_nested_tactics.py
+++ b/browser-tests/literate/test_nested_tactics.py
@@ -141,13 +141,18 @@ class TestNestedTacticStates:
         )
 
         regions = self._region_label_backgrounds(tok)
-        assert tok.evaluate("el => getComputedStyle(el).backgroundColor") == self.TRANSPARENT
+        assert (
+            tok.evaluate("el => getComputedStyle(el).backgroundColor")
+            == self.TRANSPARENT
+        )
         # The example really is nested, so the outer-region assertion is meaningful.
         assert len(regions) > 1
         assert regions[0] == self.HIGHLIGHT
         assert all(bg == self.TRANSPARENT for bg in regions[1:]), regions
 
-    def test_collapsed_step_owns_tooltip_inside_expanded_region(self, server: str, page: Page):
+    def test_collapsed_step_owns_tooltip_inside_expanded_region(
+        self, server: str, page: Page
+    ):
         """Expanding the whole-`rw` region attaches tippy instances to the content of the step
         regions nested inside it, which stay collapsed. Hovering a documented token in a
         collapsed step still shows that step's proof state, tippy instance notwithstanding."""
@@ -159,7 +164,9 @@ class TestNestedTacticStates:
         tok = self._rw_keyword(page).locator(
             "xpath=following::span[contains(@class,'var') and contains(@class,'token')][1]"
         )
-        assert tok.evaluate("el => !!el._tippy"), "expansion should attach a tippy to the token"
+        assert tok.evaluate("el => !!el._tippy"), (
+            "expansion should attach a tippy to the token"
+        )
         tok.hover()
         box = page.locator(".tippy-box[data-theme~='tactic']").first
         box.wait_for(state="visible")

--- a/browser-tests/literate/test_nested_tactics.py
+++ b/browser-tests/literate/test_nested_tactics.py
@@ -8,8 +8,9 @@ from playwright.sync_api import Page
 # be trivially true must be checked:
 #   1. each region's hover shows that region's *own* state, not a nested descendant's (the original
 #      bug showed the first rewrite step's state on the whole `rw`), and
-#   2. hovering highlights only the most specific region under the pointer, even though `label:hover`
-#      bubbles up to every enclosing region.
+#   2. hovering highlights only the innermost region under the pointer, even though `label:hover`
+#      bubbles up to every enclosing region. A collapsed region's proof state is the tooltip for
+#      everything in its label, documented tokens included, so the label is what highlights.
 class TestNestedTacticStates:
     """Hover behavior for nested tactic regions (multi-step `rw`)."""
 
@@ -80,46 +81,88 @@ class TestNestedTacticStates:
         assert "All goals completed" not in text
         assert "Nat" in text  # a real intermediate goal
 
-    def test_hover_highlights_most_specific_region(self, server: str, page: Page):
-        """Hovering lights up only the most specific region containing the pointer; the enclosing
-        regions, whose labels also receive `:hover`, stay unhighlighted."""
-        self._load(server, page)
+    def _require_hover_media(self, page: Page):
         # Linux headless Firefox can report no hover support, so the guarded CSS rule is disabled:
         # https://bugzilla.mozilla.org/show_bug.cgi?id=2037020
         if not page.evaluate("matchMedia('(hover: hover)').matches"):
             pytest.skip("Browser does not enable CSS guarded by @media (hover: hover)")
-        rw = self._rw_keyword(page)
-        rw.hover()
 
-        # The highlight is a live CSS `:hover` effect (see the `:has(.tactic > label:hover)` rule in
-        # `Highlighted.lean`). Hovering also spawns the proof-state tooltip and makes Firefox
-        # recompute `:has(:hover)` on the next paint, so the background is not reliably settled on the
-        # first read. Poll until the region's own label is highlighted before reading the rest. The
-        # mouse stays put, so `:hover` persists across polls.
-        handle = rw.element_handle()
-        page.wait_for_function(
+    @staticmethod
+    def _region_label_backgrounds(tok):
+        """Backgrounds of the labels of every tactic region enclosing `tok`, innermost first."""
+        return tok.evaluate(
             """el => {
-                const region = el.closest('.tactic');
-                const bg = getComputedStyle(region.querySelector(':scope > label')).backgroundColor;
-                return bg === 'rgb(238, 238, 238)';
-            }""",
+                const bg = t => getComputedStyle(t.querySelector(':scope > label')).backgroundColor;
+                const regions = [];
+                for (let a = el.closest('.tactic'); a; a = a.parentElement.closest('.tactic')) {
+                    regions.push(bg(a));
+                }
+                return regions;
+            }"""
+        )
+
+    def test_hover_highlights_own_region_label(self, server: str, page: Page):
+        """Hovering a region's plain content highlights that region's label."""
+        self._load(server, page)
+        self._require_hover_media(page)
+        # The `rw` keyword is direct content of the whole-`rw` region.
+        tok = self._rw_keyword(page)
+        tok.hover()
+        # The highlight is a live CSS `:hover` effect that Firefox settles on the next paint,
+        # so poll until it lands. The mouse stays put, so `:hover` persists across polls.
+        page.wait_for_function(
+            """el => getComputedStyle(el.closest('.tactic').querySelector(':scope > label'))
+                .backgroundColor === 'rgb(238, 238, 238)'""",
+            arg=tok.element_handle(),
+        )
+
+    def test_hover_highlights_most_specific_region(self, server: str, page: Page):
+        """Hovering lights up only the innermost tactic region's label, even for a documented
+        token: the region's proof state is the tooltip shown there, so the token itself stays
+        plain and enclosing regions' labels stay unhighlighted."""
+        self._load(server, page)
+        self._require_hover_media(page)
+        # The first rewrite rule (`h1`, a documented token) is nested inside its own step region,
+        # which is nested inside the whole-`rw` region.
+        tok = self._rw_keyword(page).locator(
+            "xpath=following::span[contains(@class,'var') and contains(@class,'token')][1]"
+        )
+        tok.hover()
+
+        # The highlight is a live CSS `:hover` effect. Hovering also spawns a tooltip and makes
+        # Firefox recompute `:has(:hover)` on the next paint, so the background is not reliably
+        # settled on the first read. Poll until the step label is highlighted before reading the
+        # rest. The mouse stays put, so `:hover` persists across polls.
+        handle = tok.element_handle()
+        page.wait_for_function(
+            """el => getComputedStyle(el.closest('.tactic').querySelector(':scope > label'))
+                .backgroundColor === 'rgb(238, 238, 238)'""",
             arg=handle,
         )
 
-        result = rw.evaluate(
-            """el => {
-                const bg = t => getComputedStyle(t.querySelector(':scope > label')).backgroundColor;
-                const region = el.closest('.tactic');
-                const ancestors = [];
-                for (let a = region.parentElement.closest('.tactic'); a; a = a.parentElement.closest('.tactic')) {
-                    ancestors.push(bg(a));
-                }
-                return { own: bg(region), ancestors };
-            }"""
+        regions = self._region_label_backgrounds(tok)
+        assert tok.evaluate("el => getComputedStyle(el).backgroundColor") == self.TRANSPARENT
+        # The example really is nested, so the outer-region assertion is meaningful.
+        assert len(regions) > 1
+        assert regions[0] == self.HIGHLIGHT
+        assert all(bg == self.TRANSPARENT for bg in regions[1:]), regions
+
+    def test_collapsed_step_owns_tooltip_inside_expanded_region(self, server: str, page: Page):
+        """Expanding the whole-`rw` region attaches tippy instances to the content of the step
+        regions nested inside it, which stay collapsed. Hovering a documented token in a
+        collapsed step still shows that step's proof state, tippy instance notwithstanding."""
+        self._load(server, page)
+        # Expand the whole-`rw` region; the step regions inside stay collapsed.
+        self._rw_keyword(page).evaluate(
+            "el => el.closest('.tactic').querySelector(':scope > input.tactic-toggle').click()"
         )
-        assert result["own"] == self.HIGHLIGHT
-        # The example really is nested, so this assertion is meaningful.
-        assert len(result["ancestors"]) > 0
-        assert all(bg == self.TRANSPARENT for bg in result["ancestors"]), result[
-            "ancestors"
-        ]
+        tok = self._rw_keyword(page).locator(
+            "xpath=following::span[contains(@class,'var') and contains(@class,'token')][1]"
+        )
+        assert tok.evaluate("el => !!el._tippy"), "expansion should attach a tippy to the token"
+        tok.hover()
+        box = page.locator(".tippy-box[data-theme~='tactic']").first
+        box.wait_for(state="visible")
+        # The step's own intermediate goal, not the whole `rw`'s final state.
+        assert "All goals completed" not in box.inner_text()
+        assert "Nat" in box.inner_text()

--- a/browser-tests/verso-html/test_css_variables.py
+++ b/browser-tests/verso-html/test_css_variables.py
@@ -11,6 +11,8 @@ is injected so the elements' styles are computed from the overridden values.
 import pytest
 from playwright.sync_api import Page
 
+from hover_media import require_hover_media
+
 # (CSS class, variable infix, tippy theme token) for each severity
 SEVERITIES = [
     ("error", "error", "error"),
@@ -94,6 +96,8 @@ class TestSeverityVariables:
         assert (
             computed(page, "#vt-token", "text-decoration-color") == "rgb(100, 110, 120)"
         )
+        # The hover background reads CSS that is guarded by @media (hover: hover).
+        require_hover_media(page)
         page.locator("#vt-span").hover()
         assert computed(page, "#vt-span", "background-color") == "rgb(70, 80, 90)"
 
@@ -145,6 +149,7 @@ class TestNestedSeverityHover:
         span's own severity assignment must be the one in effect."""
         page.goto(f"{server}/LitConfig/")
         page.wait_for_load_state("networkidle")
+        require_hover_media(page)
         page.evaluate(
             """() => {
                 const s = document.documentElement.style;

--- a/browser-tests/verso-html/test_css_variables.py
+++ b/browser-tests/verso-html/test_css_variables.py
@@ -1,0 +1,324 @@
+"""Checks that the documented --verso-* CSS variables drive the computed styles of
+Verso's code output.
+
+Each test sets variables to distinctive values on the root element, injects synthetic
+markup reproducing the nestings that occur in generated pages (severity spans around
+tokens, proof states nested in severity spans, message popups, output blocks, tooltip
+boxes), and asserts the resulting computed styles. Variables are set before the markup
+is injected so the elements' styles are computed from the overridden values.
+"""
+
+import pytest
+from playwright.sync_api import Page
+
+# (CSS class, variable infix, tippy theme token) for each severity
+SEVERITIES = [
+    ("error", "error", "error"),
+    ("warning", "warning", "warning"),
+    ("information", "info", "info"),
+]
+
+
+def markup(cls: str, theme: str) -> str:
+    return f"""
+    <div class="hl lean block" id="vt-root">
+      <span class="has-info {cls}" id="vt-span">
+        <span class="hover-container">
+          <span class="hover-info messages">
+            <code class="verso-message {cls}" id="vt-msg">msg</code>
+          </span>
+        </span>
+        <span class="token const" id="vt-token">tok</span>
+        <span class="tactic">
+          <label id="vt-label">simp</label>
+          <span class="tactic-state" id="vt-state">goal</span>
+        </span>
+      </span>
+    </div>
+    <pre class="lean-output {cls}" id="vt-output">out</pre>
+    <div class="tippy-box" data-theme="{theme} message" data-placement="top" id="vt-tippy">tip</div>
+    <div class="tippy-box" data-theme="lean" data-placement="top" id="vt-tippy-lean">doc</div>
+    <div class="tippy-box" data-theme="tactic" data-placement="top" id="vt-tippy-tactic">state</div>
+    """
+
+
+def setup(page: Page, server: str, vars: dict, cls: str, theme: str):
+    page.goto(f"{server}/LitConfig/")
+    page.wait_for_load_state("networkidle")
+    page.evaluate(
+        """vars => {
+            for (const [k, v] of Object.entries(vars)) {
+                document.documentElement.style.setProperty(k, v);
+            }
+        }""",
+        vars,
+    )
+    page.evaluate(
+        "html => document.body.insertAdjacentHTML('beforeend', html)",
+        markup(cls, theme),
+    )
+
+
+def computed(page: Page, selector: str, prop: str) -> str:
+    return page.evaluate(
+        "([sel, prop]) => getComputedStyle(document.querySelector(sel)).getPropertyValue(prop)",
+        [selector, prop],
+    )
+
+
+def computed_pseudo(page: Page, selector: str, pseudo: str, prop: str) -> str:
+    return page.evaluate(
+        "([sel, pseudo, prop]) => getComputedStyle(document.querySelector(sel), pseudo).getPropertyValue(prop)",
+        [selector, pseudo, prop],
+    )
+
+
+class TestSeverityVariables:
+    @pytest.mark.parametrize(("cls", "v", "theme"), SEVERITIES)
+    def test_affected_code(self, server: str, page: Page, cls: str, v: str, theme: str):
+        setup(
+            page,
+            server,
+            {
+                f"--verso-code-{v}-color": "rgb(10, 20, 30)",
+                f"--verso-code-{v}-bg-color": "rgb(40, 50, 60)",
+                f"--verso-code-{v}-hover-bg-color": "rgb(70, 80, 90)",
+                f"--verso-{v}-indicator-color": "rgb(100, 110, 120)",
+            },
+            cls,
+            theme,
+        )
+        assert computed(page, "#vt-span", "color") == "rgb(10, 20, 30)"
+        assert computed(page, "#vt-span", "background-color") == "rgb(40, 50, 60)"
+        # The wavy underline marking the message's presence
+        assert computed(page, "#vt-token", "text-decoration-color") == "rgb(100, 110, 120)"
+        page.locator("#vt-span").hover()
+        assert computed(page, "#vt-span", "background-color") == "rgb(70, 80, 90)"
+
+    @pytest.mark.parametrize(("cls", "v", "theme"), SEVERITIES)
+    def test_message_and_output(self, server: str, page: Page, cls: str, v: str, theme: str):
+        setup(
+            page,
+            server,
+            {
+                f"--verso-message-{v}-color": "rgb(130, 140, 150)",
+                f"--verso-output-{v}-color": "rgb(160, 170, 180)",
+            },
+            cls,
+            theme,
+        )
+        assert computed(page, "#vt-msg", "color") == "rgb(130, 140, 150)"
+        assert computed(page, "#vt-output", "border-left-color") == "rgb(160, 170, 180)"
+
+    @pytest.mark.parametrize(("cls", "v", "theme"), SEVERITIES)
+    def test_tooltip_chrome(self, server: str, page: Page, cls: str, v: str, theme: str):
+        setup(
+            page,
+            server,
+            {
+                f"--verso-tooltip-{v}-color": "rgb(190, 200, 210)",
+                f"--verso-tooltip-{v}-bg-color": "rgb(220, 230, 240)",
+                f"--verso-tooltip-{v}-border-color": "rgb(5, 15, 25)",
+            },
+            cls,
+            theme,
+        )
+        assert computed(page, "#vt-tippy", "color") == "rgb(190, 200, 210)"
+        assert computed(page, "#vt-tippy", "background-color") == "rgb(220, 230, 240)"
+        assert computed(page, "#vt-tippy", "border-top-color") == "rgb(5, 15, 25)"
+        # The no-script message box uses the same tooltip colors
+        assert computed(page, "#vt-msg", "background-color") == "rgb(220, 230, 240)"
+        assert computed(page, "#vt-msg", "border-left-color") == "rgb(5, 15, 25)"
+
+
+class TestNestedSeverityHover:
+    def test_nearest_severity_hover_colors_win(self, server: str, page: Page):
+        """The hover highlight of a message span comes from its own severity's variables,
+        for a span nested inside one of another severity as well as for the outer span.
+        The single hover rule reads `--verso--region-hover-*`, which inherit, so each
+        span's own severity assignment must be the one in effect."""
+        page.goto(f"{server}/LitConfig/")
+        page.wait_for_load_state("networkidle")
+        page.evaluate(
+            """() => {
+                const s = document.documentElement.style;
+                s.setProperty('--verso-code-info-bg-color', 'rgb(40, 50, 60)');
+                s.setProperty('--verso-code-info-hover-bg-color', 'rgb(70, 80, 90)');
+                s.setProperty('--verso-code-warning-bg-color', 'rgb(61, 62, 63)');
+                s.setProperty('--verso-code-warning-hover-bg-color', 'rgb(91, 92, 93)');
+            }"""
+        )
+        page.evaluate(
+            """html => document.body.insertAdjacentHTML('beforeend', html)""",
+            '<div class="hl lean block" id="vt-nested-root">'
+            '<span class="has-info information" id="vt-outer">outer text '
+            '<span class="has-info warning" id="vt-inner">inner</span>'
+            "</span></div>",
+        )
+        # Hovering the nested warning span: its own hover colors, while the outer span
+        # keeps its base background because the nested span's tooltip is the one shown.
+        page.locator("#vt-inner").hover()
+        assert computed(page, "#vt-inner", "background-color") == "rgb(91, 92, 93)"
+        assert computed(page, "#vt-outer", "background-color") == "rgb(40, 50, 60)"
+        # Hovering the outer span's own text: the outer span's hover colors.
+        box = page.locator("#vt-outer").bounding_box()
+        page.mouse.move(box["x"] + 5, box["y"] + box["height"] / 2)
+        assert computed(page, "#vt-outer", "background-color") == "rgb(70, 80, 90)"
+        assert computed(page, "#vt-inner", "background-color") == "rgb(61, 62, 63)"
+
+
+class TestTacticStateIsland:
+    def test_severity_color_stops_at_proof_state(self, server: str, page: Page):
+        """A severity code color inherits into the affected code but not into a proof
+        state nested within it, which uses its own variables."""
+        setup(
+            page,
+            server,
+            {
+                "--verso-code-error-color": "rgb(10, 20, 30)",
+                "--verso-tactic-state-color": "rgb(1, 2, 3)",
+                "--verso-tactic-state-bg-color": "rgb(4, 5, 6)",
+                "--verso-tactic-state-border-color": "rgb(7, 8, 9)",
+            },
+            "error",
+            "error",
+        )
+        # The tactic's label is affected code and inherits the severity color
+        assert computed(page, "#vt-label", "color") == "rgb(10, 20, 30)"
+        # The proof state does not
+        assert computed(page, "#vt-state", "color") == "rgb(1, 2, 3)"
+        assert computed(page, "#vt-state", "background-color") == "rgb(4, 5, 6)"
+        assert computed(page, "#vt-state", "border-top-color") == "rgb(7, 8, 9)"
+
+
+# (tippy theme, background variable, border variable) for every themed tooltip
+ARROW_THEMES = [
+    ("error message", "--verso-tooltip-error-bg-color", "--verso-tooltip-error-border-color"),
+    ("warning message", "--verso-tooltip-warning-bg-color", "--verso-tooltip-warning-border-color"),
+    ("info message", "--verso-tooltip-info-bg-color", "--verso-tooltip-info-border-color"),
+    ("lean", "--verso-tooltip-bg-color", "--verso-tooltip-border-color"),
+    ("tactic", "--verso-tactic-state-bg-color", "--verso-tactic-state-border-color"),
+]
+
+PLACEMENTS = ["top", "bottom", "left", "right"]
+
+
+def arrow_markup(theme: str) -> str:
+    return "".join(
+        f'<div class="tippy-box" data-theme="{theme}" data-placement="{p}" id="vt-box-{p}">'
+        f'<div class="tippy-arrow" id="vt-arrow-{p}"></div></div>'
+        for p in PLACEMENTS
+    )
+
+
+class TestTooltipArrows:
+    """The arrow of a tooltip is filled with the tooltip's background color and outlined
+    with its border color, at every placement. Tippy paints the fill from the arrow
+    element's `color` and the outline from the box's border color, so each theme sets
+    only `color` on its arrow."""
+
+    @pytest.mark.parametrize(("theme", "bg_var", "border_var"), ARROW_THEMES)
+    def test_arrow_follows_variables(self, server: str, page: Page, theme: str, bg_var: str, border_var: str):
+        page.goto(f"{server}/LitConfig/")
+        page.wait_for_load_state("networkidle")
+        page.evaluate(
+            """([bgVar, borderVar]) => {
+                document.documentElement.style.setProperty(bgVar, 'rgb(21, 22, 23)');
+                document.documentElement.style.setProperty(borderVar, 'rgb(31, 32, 33)');
+            }""",
+            [bg_var, border_var],
+        )
+        page.evaluate(
+            "html => document.body.insertAdjacentHTML('beforeend', html)",
+            arrow_markup(theme),
+        )
+        for p in PLACEMENTS:
+            fill = computed_pseudo(page, f"#vt-arrow-{p}", "::before", f"border-{p}-color")
+            outline = computed_pseudo(page, f"#vt-arrow-{p}", "::after", f"border-{p}-color")
+            assert fill == "rgb(21, 22, 23)", f"{theme} {p} arrow fill"
+            assert outline == "rgb(31, 32, 33)", f"{theme} {p} arrow outline"
+
+    def test_arrow_matches_tooltip_by_default(self, server: str, page: Page):
+        """With no customization, every theme's arrow fill equals its box background and
+        its outline equals its box border, at every placement."""
+        page.goto(f"{server}/LitConfig/")
+        page.wait_for_load_state("networkidle")
+        for theme, _, _ in ARROW_THEMES:
+            page.evaluate("() => document.querySelectorAll('.tippy-box').forEach(e => e.remove())")
+            page.evaluate(
+                "html => document.body.insertAdjacentHTML('beforeend', html)",
+                arrow_markup(theme),
+            )
+            for p in PLACEMENTS:
+                box_bg = computed(page, f"#vt-box-{p}", "background-color")
+                box_border = computed(page, f"#vt-box-{p}", f"border-{p}-color")
+                fill = computed_pseudo(page, f"#vt-arrow-{p}", "::before", f"border-{p}-color")
+                outline = computed_pseudo(page, f"#vt-arrow-{p}", "::after", f"border-{p}-color")
+                assert fill == box_bg, f"{theme} {p}: fill {fill} != box bg {box_bg}"
+                assert outline == box_border, f"{theme} {p}: outline {outline} != box border {box_border}"
+
+    def test_real_tooltip_arrow(self, server: str, page: Page):
+        """Hovering a real token produces a tooltip whose arrow fill matches its
+        background."""
+        page.goto(f"{server}/LitConfig/Core/")
+        page.wait_for_load_state("networkidle")
+        token = page.locator(".hl.lean .const.token").first
+        token.hover()
+        box = page.locator(".tippy-box").first
+        box.wait_for(state="visible")
+        page.wait_for_function(
+            "() => document.querySelector('.tippy-box')?.getAttribute('data-placement')"
+        )
+        placement = box.get_attribute("data-placement").split("-")[0]
+        result = page.evaluate(
+            """side => {
+                const box = document.querySelector('.tippy-box');
+                const arrow = box.querySelector('.tippy-arrow');
+                return {
+                    boxBg: getComputedStyle(box).backgroundColor,
+                    fill: getComputedStyle(arrow, '::before').getPropertyValue('border-' + side + '-color'),
+                };
+            }""",
+            placement,
+        )
+        assert result["fill"] == result["boxBg"]
+
+
+class TestDerivedDefaults:
+    def test_generic_tooltip_colors_flow_to_severities(self, server: str, page: Page):
+        setup(
+            page,
+            server,
+            {
+                "--verso-tooltip-color": "rgb(11, 12, 13)",
+                "--verso-tooltip-bg-color": "rgb(14, 15, 16)",
+            },
+            "warning",
+            "warning",
+        )
+        # Severity tooltips default to the generic tooltip colors
+        assert computed(page, "#vt-tippy", "color") == "rgb(11, 12, 13)"
+        assert computed(page, "#vt-tippy", "background-color") == "rgb(14, 15, 16)"
+        # The documentation tooltip uses them directly
+        assert computed(page, "#vt-tippy-lean", "color") == "rgb(11, 12, 13)"
+        assert computed(page, "#vt-tippy-lean", "background-color") == "rgb(14, 15, 16)"
+
+    def test_output_bar_defaults_to_indicator(self, server: str, page: Page):
+        setup(page, server, {"--verso-warning-indicator-color": "rgb(17, 18, 19)"}, "warning", "warning")
+        assert computed(page, "#vt-output", "border-left-color") == "rgb(17, 18, 19)"
+
+    def test_tactic_tooltip_uses_proof_state_colors(self, server: str, page: Page):
+        setup(
+            page,
+            server,
+            {
+                "--verso-tactic-state-color": "rgb(1, 2, 3)",
+                "--verso-tactic-state-bg-color": "rgb(4, 5, 6)",
+                "--verso-tactic-state-border-color": "rgb(7, 8, 9)",
+            },
+            "warning",
+            "warning",
+        )
+        assert computed(page, "#vt-tippy-tactic", "color") == "rgb(1, 2, 3)"
+        assert computed(page, "#vt-tippy-tactic", "background-color") == "rgb(4, 5, 6)"
+        assert computed(page, "#vt-tippy-tactic", "border-top-color") == "rgb(7, 8, 9)"

--- a/browser-tests/verso-html/test_css_variables.py
+++ b/browser-tests/verso-html/test_css_variables.py
@@ -91,12 +91,16 @@ class TestSeverityVariables:
         assert computed(page, "#vt-span", "color") == "rgb(10, 20, 30)"
         assert computed(page, "#vt-span", "background-color") == "rgb(40, 50, 60)"
         # The wavy underline marking the message's presence
-        assert computed(page, "#vt-token", "text-decoration-color") == "rgb(100, 110, 120)"
+        assert (
+            computed(page, "#vt-token", "text-decoration-color") == "rgb(100, 110, 120)"
+        )
         page.locator("#vt-span").hover()
         assert computed(page, "#vt-span", "background-color") == "rgb(70, 80, 90)"
 
     @pytest.mark.parametrize(("cls", "v", "theme"), SEVERITIES)
-    def test_message_and_output(self, server: str, page: Page, cls: str, v: str, theme: str):
+    def test_message_and_output(
+        self, server: str, page: Page, cls: str, v: str, theme: str
+    ):
         setup(
             page,
             server,
@@ -111,7 +115,9 @@ class TestSeverityVariables:
         assert computed(page, "#vt-output", "border-left-color") == "rgb(160, 170, 180)"
 
     @pytest.mark.parametrize(("cls", "v", "theme"), SEVERITIES)
-    def test_tooltip_chrome(self, server: str, page: Page, cls: str, v: str, theme: str):
+    def test_tooltip_chrome(
+        self, server: str, page: Page, cls: str, v: str, theme: str
+    ):
         setup(
             page,
             server,
@@ -193,9 +199,21 @@ class TestTacticStateIsland:
 
 # (tippy theme, background variable, border variable) for every themed tooltip
 ARROW_THEMES = [
-    ("error message", "--verso-tooltip-error-bg-color", "--verso-tooltip-error-border-color"),
-    ("warning message", "--verso-tooltip-warning-bg-color", "--verso-tooltip-warning-border-color"),
-    ("info message", "--verso-tooltip-info-bg-color", "--verso-tooltip-info-border-color"),
+    (
+        "error message",
+        "--verso-tooltip-error-bg-color",
+        "--verso-tooltip-error-border-color",
+    ),
+    (
+        "warning message",
+        "--verso-tooltip-warning-bg-color",
+        "--verso-tooltip-warning-border-color",
+    ),
+    (
+        "info message",
+        "--verso-tooltip-info-bg-color",
+        "--verso-tooltip-info-border-color",
+    ),
     ("lean", "--verso-tooltip-bg-color", "--verso-tooltip-border-color"),
     ("tactic", "--verso-tactic-state-bg-color", "--verso-tactic-state-border-color"),
 ]
@@ -218,7 +236,9 @@ class TestTooltipArrows:
     only `color` on its arrow."""
 
     @pytest.mark.parametrize(("theme", "bg_var", "border_var"), ARROW_THEMES)
-    def test_arrow_follows_variables(self, server: str, page: Page, theme: str, bg_var: str, border_var: str):
+    def test_arrow_follows_variables(
+        self, server: str, page: Page, theme: str, bg_var: str, border_var: str
+    ):
         page.goto(f"{server}/LitConfig/")
         page.wait_for_load_state("networkidle")
         page.evaluate(
@@ -233,8 +253,12 @@ class TestTooltipArrows:
             arrow_markup(theme),
         )
         for p in PLACEMENTS:
-            fill = computed_pseudo(page, f"#vt-arrow-{p}", "::before", f"border-{p}-color")
-            outline = computed_pseudo(page, f"#vt-arrow-{p}", "::after", f"border-{p}-color")
+            fill = computed_pseudo(
+                page, f"#vt-arrow-{p}", "::before", f"border-{p}-color"
+            )
+            outline = computed_pseudo(
+                page, f"#vt-arrow-{p}", "::after", f"border-{p}-color"
+            )
             assert fill == "rgb(21, 22, 23)", f"{theme} {p} arrow fill"
             assert outline == "rgb(31, 32, 33)", f"{theme} {p} arrow outline"
 
@@ -244,7 +268,9 @@ class TestTooltipArrows:
         page.goto(f"{server}/LitConfig/")
         page.wait_for_load_state("networkidle")
         for theme, _, _ in ARROW_THEMES:
-            page.evaluate("() => document.querySelectorAll('.tippy-box').forEach(e => e.remove())")
+            page.evaluate(
+                "() => document.querySelectorAll('.tippy-box').forEach(e => e.remove())"
+            )
             page.evaluate(
                 "html => document.body.insertAdjacentHTML('beforeend', html)",
                 arrow_markup(theme),
@@ -252,10 +278,16 @@ class TestTooltipArrows:
             for p in PLACEMENTS:
                 box_bg = computed(page, f"#vt-box-{p}", "background-color")
                 box_border = computed(page, f"#vt-box-{p}", f"border-{p}-color")
-                fill = computed_pseudo(page, f"#vt-arrow-{p}", "::before", f"border-{p}-color")
-                outline = computed_pseudo(page, f"#vt-arrow-{p}", "::after", f"border-{p}-color")
+                fill = computed_pseudo(
+                    page, f"#vt-arrow-{p}", "::before", f"border-{p}-color"
+                )
+                outline = computed_pseudo(
+                    page, f"#vt-arrow-{p}", "::after", f"border-{p}-color"
+                )
                 assert fill == box_bg, f"{theme} {p}: fill {fill} != box bg {box_bg}"
-                assert outline == box_border, f"{theme} {p}: outline {outline} != box border {box_border}"
+                assert outline == box_border, (
+                    f"{theme} {p}: outline {outline} != box border {box_border}"
+                )
 
     def test_real_tooltip_arrow(self, server: str, page: Page):
         """Hovering a real token produces a tooltip whose arrow fill matches its
@@ -304,7 +336,13 @@ class TestDerivedDefaults:
         assert computed(page, "#vt-tippy-lean", "background-color") == "rgb(14, 15, 16)"
 
     def test_output_bar_defaults_to_indicator(self, server: str, page: Page):
-        setup(page, server, {"--verso-warning-indicator-color": "rgb(17, 18, 19)"}, "warning", "warning")
+        setup(
+            page,
+            server,
+            {"--verso-warning-indicator-color": "rgb(17, 18, 19)"},
+            "warning",
+            "warning",
+        )
         assert computed(page, "#vt-output", "border-left-color") == "rgb(17, 18, 19)"
 
     def test_tactic_tooltip_uses_proof_state_colors(self, server: str, page: Page):

--- a/doc/UsersGuide/Releases/Entries.lean
+++ b/doc/UsersGuide/Releases/Entries.lean
@@ -7,6 +7,7 @@ module
 
 public import UsersGuide.Releases.Entries.BlogLeanRole
 public import UsersGuide.Releases.Entries.BuildLog
+public import UsersGuide.Releases.Entries.CodeColorVariables
 public import UsersGuide.Releases.Entries.DevelopmentServer
 public import UsersGuide.Releases.Entries.Diagrams
 public import UsersGuide.Releases.Entries.DocSourceRanges

--- a/doc/UsersGuide/Releases/Entries/CodeColorVariables.lean
+++ b/doc/UsersGuide/Releases/Entries/CodeColorVariables.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+
+public import UsersGuide.Releases.Entry
+
+open Verso.Genre Manual InlineLean UsersGuide.Releases
+
+release_note
+  version := ⟨4, 34, 0⟩
+  breaking := true
+  tag := "css-color-vars"
+  prs := []
+
+#doc (Manual) "Color Customization" =>
+
+All colors in rendered Lean code are now controlled by CSS variables, and the message text color variables have new names.
+
+All colors in Verso's rendering of Lean code are controlled by CSS custom properties, documented in `verso-vars.css`.
+Each message severity (info, warning, error) styles four surfaces:
+
+* the affected code itself, via the `--verso-code-error-color`, `--verso-code-error-bg-color`, and `--verso-code-error-hover-color` and `--verso-code-error-hover-bg-color` families, plus `--verso-error-indicator-color` for the wavy underline,
+* the text of the message, via `--verso-message-error-color`,
+* the tooltip that displays the message, via `--verso-tooltip-error-color`, `--verso-tooltip-error-bg-color`, and `--verso-tooltip-error-border-color`, and
+* the marker bar on output blocks, via `--verso-output-error-color`,
+
+with analogous variables for `warning` and `info`.
+Tooltips share a generic palette (`--verso-tooltip-color`, `--verso-tooltip-bg-color`, `--verso-tooltip-border-color`, and `--verso-tooltip-separator-color`) that the severity-specific tooltip colors default to.
+Proof states are styled by the `--verso-tactic-state-` and `--verso-tactic-toggle-` variable families, and the hover highlight on interactive code by `--verso-code-hover-bg-color`.
+
+Breaking change: the variables `--verso-error-color`, `--verso-warning-color`, and `--verso-info-color` no longer exist.
+Sites that override them to recolor diagnostics should set `--verso-message-error-color`, `--verso-message-warning-color`, and `--verso-message-info-color` instead.

--- a/doc/UsersGuide/Releases/Entries/CodeColorVariables.lean
+++ b/doc/UsersGuide/Releases/Entries/CodeColorVariables.lean
@@ -13,21 +13,21 @@ release_note
   version := ⟨4, 34, 0⟩
   breaking := true
   tag := "css-color-vars"
-  prs := []
+  prs := [954]
 
 #doc (Manual) "Color Customization" =>
 
 All colors in rendered Lean code are now controlled by CSS variables, and the message text color variables have new names.
 
 All colors in Verso's rendering of Lean code are controlled by CSS custom properties, documented in `verso-vars.css`.
-Each message severity (info, warning, error) styles four surfaces:
+Each message severity (info, warning, error) has four configurations (here exemplified for the `error` severity, but also present for `warning` and `info`):
 
-* the affected code itself, via the `--verso-code-error-color`, `--verso-code-error-bg-color`, and `--verso-code-error-hover-color` and `--verso-code-error-hover-bg-color` families, plus `--verso-error-indicator-color` for the wavy underline,
-* the text of the message, via `--verso-message-error-color`,
-* the tooltip that displays the message, via `--verso-tooltip-error-color`, `--verso-tooltip-error-bg-color`, and `--verso-tooltip-error-border-color`, and
-* the marker bar on output blocks, via `--verso-output-error-color`,
+* variables for the affected code itself, via the `--verso-code-error-color`, `--verso-code-error-bg-color`, and `--verso-code-error-hover-color` and `--verso-code-error-hover-bg-color` families, plus `--verso-error-indicator-color` for the wavy underline,
+* a variable for the text of the message, via `--verso-message-error-color`,
+* variables for the tooltip that displays the message, via `--verso-tooltip-error-color`, `--verso-tooltip-error-bg-color`, and `--verso-tooltip-error-border-color`, and
+* a variable for the marker bar on output blocks, via `--verso-output-error-color`,
 
-with analogous variables for `warning` and `info`.
+
 Tooltips share a generic palette (`--verso-tooltip-color`, `--verso-tooltip-bg-color`, `--verso-tooltip-border-color`, and `--verso-tooltip-separator-color`) that the severity-specific tooltip colors default to.
 Proof states are styled by the `--verso-tactic-state-` and `--verso-tactic-toggle-` variable families, and the hover highlight on interactive code by `--verso-code-hover-bg-color`.
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -35,7 +35,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "3a75ede05278806fd3249bb0c97a6fb5777a4f7d",
+   "rev": "847084e80500726e4331dded5f17007ddaf89c31",
    "name": "subverso",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",

--- a/src/tests/Tests.lean
+++ b/src/tests/Tests.lean
@@ -41,6 +41,7 @@ import Tests.Refs
 import Tests.SearchJs
 import Tests.ExtensionResolution
 import Tests.Serialization
+import Tests.HoverMerge
 import Tests.TeX
 import Tests.TexUnit
 import Tests.TexUtil

--- a/src/tests/Tests/HoverMerge.lean
+++ b/src/tests/Tests/HoverMerge.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+import all Verso.Code.Highlighted
+meta import Verso.Output.Html
+meta import SubVerso.Highlighting
+
+open SubVerso.Highlighting (Highlighted)
+open Verso.Code (takeAttr)
+open Verso.Output (Html)
+
+namespace Verso.HoverMergeTest
+
+/-!
+These helpers support merging a documented token's hover content into a message span that
+shares the token's extent: `Highlighted.normalize` makes the sole-token shape recognizable,
+and `takeAttr` moves the token's hover attributes up to the span.
+-/
+
+def tok : Html := .tag "span" #[("class", "token"), ("data-verso-hover", "5")] (.text true "x")
+def tokNoHover : Html := .tag "span" #[("class", "token")] (.text true "x")
+
+-- The attribute is taken from a bare element.
+#guard takeAttr "data-verso-hover" tok == (some "5", tokNoHover)
+
+-- The attribute is found through a wrapping element, such as a link.
+#guard takeAttr "data-verso-hover" (.tag "a" #[("href", "x.html")] tok) ==
+  (some "5", .tag "a" #[("href", "x.html")] tokNoHover)
+
+-- Other attributes are found where they live, such as extra links on the wrapping element.
+#guard takeAttr "data-verso-links" (.tag "a" #[("data-verso-links", "[]")] tok) ==
+  (some "[]", .tag "a" #[] tok)
+
+-- The outermost attribute wins, and inner ones are left in place.
+#guard takeAttr "data-verso-hover" (.tag "a" #[("data-verso-hover", "9")] tok) ==
+  (some "9", .tag "a" #[] tok)
+
+-- Empty content around a sole element does not block the search.
+#guard takeAttr "data-verso-hover" (.seq #[.text true "", tok, .seq #[]]) == (some "5", tokNoHover)
+
+-- Adjacent content blocks the search, including whitespace.
+#guard takeAttr "data-verso-hover" (.seq #[tok, .text true "y"]) == (none, .seq #[tok, .text true "y"])
+#guard takeAttr "data-verso-hover" (.seq #[tok, tokNoHover]) == (none, .seq #[tok, tokNoHover])
+#guard takeAttr "data-verso-hover" (.seq #[.text true " ", tok]) == (none, .seq #[.text true " ", tok])
+
+-- Adjacent content inside a wrapper blocks the search.
+#guard takeAttr "data-verso-hover" (.tag "a" #[] (.seq #[tok, tokNoHover])) ==
+  (none, .tag "a" #[] (.seq #[tok, tokNoHover]))
+
+-- Content without the attribute is unchanged.
+#guard takeAttr "data-verso-hover" tokNoHover == (none, tokNoHover)
+#guard takeAttr "data-verso-hover" (.text true "x") == (none, .text true "x")
+#guard takeAttr "data-verso-hover" (.seq #[]) == (none, .seq #[])
+
+def hlTok : Highlighted := .token ⟨.keyword none none none, "rfl"⟩
+def hlTok' : Highlighted := .token ⟨.keyword none none none, "skip"⟩
+
+-- A sequence around a single element becomes that element, through nesting and empty text.
+#guard (Highlighted.seq #[hlTok]).normalize == hlTok
+#guard (Highlighted.seq #[.seq #[hlTok]]).normalize == hlTok
+#guard (Highlighted.seq #[.text "", hlTok, .seq #[]]).normalize == hlTok
+
+-- Whitespace is content, and sequences with several elements keep their structure.
+#guard (Highlighted.seq #[.text " ", hlTok]).normalize == .seq #[.text " ", hlTok]
+#guard (Highlighted.seq #[hlTok, hlTok']).normalize == .seq #[hlTok, hlTok']
+
+-- Normalization reaches inside spans and proof states.
+#guard (Highlighted.span #[] (.seq #[hlTok])).normalize == .span #[] hlTok
+#guard (Highlighted.tactics #[] 5 10 (.seq #[.text "", hlTok])).normalize ==
+  .tactics #[] 5 10 hlTok
+
+end Verso.HoverMergeTest

--- a/src/tests/Tests/HoverMerge.lean
+++ b/src/tests/Tests/HoverMerge.lean
@@ -9,7 +9,7 @@ meta import Verso.Output.Html
 meta import SubVerso.Highlighting
 
 open SubVerso.Highlighting (Highlighted)
-open Verso.Code (takeAttr)
+open Verso.Code (takeAttrs)
 open Verso.Output (Html)
 
 namespace Verso.HoverMergeTest
@@ -17,43 +17,68 @@ namespace Verso.HoverMergeTest
 /-!
 These helpers support merging a documented token's hover content into a message span that
 shares the token's extent: `Highlighted.normalize` makes the sole-token shape recognizable,
-and `takeAttr` moves the token's hover attributes up to the span.
+and `takeAttrs` moves the token's hover attributes up to the span.
 -/
 
 def tok : Html := .tag "span" #[("class", "token"), ("data-verso-hover", "5")] (.text true "x")
 def tokNoHover : Html := .tag "span" #[("class", "token")] (.text true "x")
 
 -- The attribute is taken from a bare element.
-#guard takeAttr "data-verso-hover" tok == (some "5", tokNoHover)
+#guard takeAttrs #["data-verso-hover"] tok == (#[("data-verso-hover", "5")], tokNoHover)
 
 -- The attribute is found through a wrapping element, such as a link.
-#guard takeAttr "data-verso-hover" (.tag "a" #[("href", "x.html")] tok) ==
-  (some "5", .tag "a" #[("href", "x.html")] tokNoHover)
+#guard takeAttrs #["data-verso-hover"] (.tag "a" #[("href", "x.html")] tok) ==
+  (#[("data-verso-hover", "5")], .tag "a" #[("href", "x.html")] tokNoHover)
 
--- Other attributes are found where they live, such as extra links on the wrapping element.
-#guard takeAttr "data-verso-links" (.tag "a" #[("data-verso-links", "[]")] tok) ==
-  (some "[]", .tag "a" #[] tok)
+-- Attributes are gathered across the wrappers of a sole element: the hover from the token
+-- and the extra links from the link element around it.
+#guard takeAttrs #["data-verso-hover", "data-verso-links"]
+    (.tag "a" #[("data-verso-links", "[]")] tok) ==
+  (#[("data-verso-links", "[]"), ("data-verso-hover", "5")], .tag "a" #[] tokNoHover)
+
+-- Only the attributes that are present appear in the result.
+#guard takeAttrs #["data-verso-hover", "data-verso-links"]
+    (.tag "a" #[("data-verso-links", "[]")] tokNoHover) ==
+  (#[("data-verso-links", "[]")], .tag "a" #[] tokNoHover)
+
+def tokLinked : Html :=
+  .tag "span" #[("class", "token"), ("data-verso-hover", "5"), ("data-verso-links", "[2]")]
+    (.text true "x")
+
+-- Each attribute is taken from the outermost element that carries it, and repeats on
+-- elements nested inside stay in place.
+#guard takeAttrs #["data-verso-hover", "data-verso-links"]
+    (.tag "a" #[("data-verso-hover", "9")] tokLinked) ==
+  (#[("data-verso-hover", "9"), ("data-verso-links", "[2]")],
+   .tag "a" #[] (.tag "span" #[("class", "token"), ("data-verso-hover", "5")] (.text true "x")))
+#guard takeAttrs #["data-verso-hover", "data-verso-links"]
+    (.tag "a" #[("data-verso-links", "[1]")] tokLinked) ==
+  (#[("data-verso-links", "[1]"), ("data-verso-hover", "5")],
+   .tag "a" #[] (.tag "span" #[("class", "token"), ("data-verso-links", "[2]")] (.text true "x")))
 
 -- The outermost attribute wins, and inner ones are left in place.
-#guard takeAttr "data-verso-hover" (.tag "a" #[("data-verso-hover", "9")] tok) ==
-  (some "9", .tag "a" #[] tok)
+#guard takeAttrs #["data-verso-hover"] (.tag "a" #[("data-verso-hover", "9")] tok) ==
+  (#[("data-verso-hover", "9")], .tag "a" #[] tok)
 
 -- Empty content around a sole element does not block the search.
-#guard takeAttr "data-verso-hover" (.seq #[.text true "", tok, .seq #[]]) == (some "5", tokNoHover)
+#guard takeAttrs #["data-verso-hover"] (.seq #[.text true "", tok, .seq #[]]) ==
+  (#[("data-verso-hover", "5")], tokNoHover)
 
 -- Adjacent content blocks the search, including whitespace.
-#guard takeAttr "data-verso-hover" (.seq #[tok, .text true "y"]) == (none, .seq #[tok, .text true "y"])
-#guard takeAttr "data-verso-hover" (.seq #[tok, tokNoHover]) == (none, .seq #[tok, tokNoHover])
-#guard takeAttr "data-verso-hover" (.seq #[.text true " ", tok]) == (none, .seq #[.text true " ", tok])
+#guard takeAttrs #["data-verso-hover"] (.seq #[tok, .text true "y"]) ==
+  (#[], .seq #[tok, .text true "y"])
+#guard takeAttrs #["data-verso-hover"] (.seq #[tok, tokNoHover]) == (#[], .seq #[tok, tokNoHover])
+#guard takeAttrs #["data-verso-hover"] (.seq #[.text true " ", tok]) ==
+  (#[], .seq #[.text true " ", tok])
 
 -- Adjacent content inside a wrapper blocks the search.
-#guard takeAttr "data-verso-hover" (.tag "a" #[] (.seq #[tok, tokNoHover])) ==
-  (none, .tag "a" #[] (.seq #[tok, tokNoHover]))
+#guard takeAttrs #["data-verso-hover"] (.tag "a" #[] (.seq #[tok, tokNoHover])) ==
+  (#[], .tag "a" #[] (.seq #[tok, tokNoHover]))
 
--- Content without the attribute is unchanged.
-#guard takeAttr "data-verso-hover" tokNoHover == (none, tokNoHover)
-#guard takeAttr "data-verso-hover" (.text true "x") == (none, .text true "x")
-#guard takeAttr "data-verso-hover" (.seq #[]) == (none, .seq #[])
+-- Content without the attributes is unchanged.
+#guard takeAttrs #["data-verso-hover"] tokNoHover == (#[], tokNoHover)
+#guard takeAttrs #["data-verso-hover"] (.text true "x") == (#[], .text true "x")
+#guard takeAttrs #["data-verso-hover"] (.seq #[]) == (#[], .seq #[])
 
 def hlTok : Highlighted := .token ⟨.keyword none none none, "rfl"⟩
 def hlTok' : Highlighted := .token ⟨.keyword none none none, "skip"⟩

--- a/src/tests/Tests/NestedTacticHtml.lean
+++ b/src/tests/Tests/NestedTacticHtml.lean
@@ -222,3 +222,46 @@ def checkElision : CommandElabM Unit := do
 
 #guard_msgs in
 #eval checkElision
+
+/-!
+## Duplicated proof states
+
+Elaboration can record the same tactic more than once, producing nested proof states with
+identical goals at identical positions. These render as adjacent duplicate toggle widgets, so
+the elision pass also removes them.
+-/
+
+/-- Whether `hl` contains a proof state nested in one with the same goals and position. -/
+partial def hlHasDuplicate (hl : Highlighted)
+    (seen : List (Array (Highlighted.Goal Highlighted) × Nat × Nat) := []) : Bool :=
+  match hl with
+  | .seq xs => xs.any (hlHasDuplicate · seen)
+  | .span _ x => hlHasDuplicate x seen
+  | .tactics info s e content =>
+    seen.contains (info, s, e) || hlHasDuplicate content ((info, s, e) :: seen)
+  | _ => false
+
+/-- The number of proof state displays in `hl`. -/
+partial def tacticNodeCount : Highlighted → Nat
+  | .seq xs => xs.foldl (fun n x => n + tacticNodeCount x) 0
+  | .span _ x => tacticNodeCount x
+  | .tactics _ _ _ x => 1 + tacticNodeCount x
+  | _ => 0
+
+/-- A proof state with the same goals and position nested directly inside another. -/
+def duplicated : Highlighted :=
+  let goal : Highlighted.Goal Highlighted :=
+    { name := none, goalPrefix := "⊢ ", hypotheses := #[], conclusion := .text "1 + 1 = 2" }
+  .tactics #[goal] 5 10 (.tactics #[goal] 5 10 (.token ⟨.keyword none none none, "rfl"⟩))
+
+def checkDuplicateElision : CommandElabM Unit := do
+  unless hlHasDuplicate duplicated do
+    throwError "expected the example to contain duplicated proof states"
+  let elided := duplicated.elideRedundantProofStates
+  if hlHasDuplicate elided then
+    throwError "`elideRedundantProofStates` left a duplicated proof state behind"
+  unless tacticNodeCount elided == 1 do
+    throwError "expected exactly one proof state to remain, but found {tacticNodeCount elided}"
+
+#guard_msgs in
+#eval checkDuplicateElision

--- a/src/verso-html/VersoHtmlMain.lean
+++ b/src/verso-html/VersoHtmlMain.lean
@@ -7,6 +7,7 @@ module
 public import VersoLiterateCode
 public import VersoSearch.DomainSearch
 public import Verso.Code.Highlighted.WebAssets
+public import Verso.Output.Html.CssVars
 
 public section
 
@@ -45,6 +46,7 @@ private def headContents : Html := {{
   <script src="tippy.js"></script>
   <script>{{Html.text false highlightingJs}}</script>
   <style>{{Html.text false highlightingStyle}}</style>
+  <link rel="stylesheet" href="verso-vars.css"/>
   <link rel="stylesheet" href="tippy-border.css"/>
   <link rel="stylesheet" href="code.css"/>
 
@@ -152,6 +154,7 @@ def main (args : List String) : IO UInt32 := do
     IO.FS.writeFile (config.outputDir / "tippy.js") Verso.Code.Highlighted.WebAssets.tippy
     IO.FS.writeFile (config.outputDir / "tippy-border.css") Verso.Code.Highlighted.WebAssets.tippy.border.css
     IO.FS.writeFile (config.outputDir / "code.css") code.css
+    IO.FS.writeFile (config.outputDir / "verso-vars.css") «verso-vars.css»
     emitSearchBox (config.outputDir / "-verso-search") (searchPagePath := some "search/")
     let dir ← loadDir config.inputDir
     let dir := dir.sort

--- a/src/verso-literate-html/LiterateHtmlMain.lean
+++ b/src/verso-literate-html/LiterateHtmlMain.lean
@@ -7,6 +7,7 @@ module
 public import VersoLiterateCode
 public import VersoSearch.DomainSearch
 public import Verso.Code.Highlighted.WebAssets
+import Verso.Output.Html.CssVars
 import Verso.Output.Html.KaTeX
 
 public section
@@ -205,6 +206,7 @@ private def mkHeadContents (litConfig : LiterateConfig) (includeCodeAssets : Boo
     {{ descTag }}
     {{ katexAssets }}
     {{ codeAssets }}
+    <link rel="stylesheet" href="verso-vars.css"/>
     <link rel="stylesheet" href="literate.css"/>
     {{ themeCssTag }}
     {{ copyButtonTag }}
@@ -491,6 +493,7 @@ def main (args : List String) : IO UInt32 := do
     IO.FS.writeFile (config.outputDir / "tippy.js") Verso.Code.Highlighted.WebAssets.tippy
     IO.FS.writeFile (config.outputDir / "tippy-border.css") Verso.Code.Highlighted.WebAssets.tippy.border.css
     IO.FS.writeFile (config.outputDir / "marked.js") Verso.Code.Highlighted.WebAssets.marked
+    IO.FS.writeFile (config.outputDir / "verso-vars.css") Verso.Output.Html.«verso-vars.css»
     IO.FS.writeFile (config.outputDir / "literate.css") literate.css
     -- Copy KaTeX dependencies
     IO.FS.createDirAll (config.outputDir / "katex")

--- a/src/verso-literate-html/literate.css
+++ b/src/verso-literate-html/literate.css
@@ -128,7 +128,6 @@
     .hl.lean .hover-info.messages > code.information {
         background-color: #1a1a2e;
     }
-
 }
 
 /* Reset and base styles */

--- a/src/verso-literate-html/literate.css
+++ b/src/verso-literate-html/literate.css
@@ -50,16 +50,16 @@
     --verso-hamburger-border: #dee2e6;
     --verso-hamburger-bar-color: #333;
 
-    /* Diagnostic colors */
-    --verso-warning-color: #fff3cd;
-    --verso-error-color: #cc0000;
-    --verso-warning-indicator-color: #b8860b;
-    --verso-error-indicator-color: #dc3545;
+    /* Diagnostic colors (all others come from verso-vars.css) */
+    --verso-code-info-hover-bg-color: #cfe2ff;
     --verso-info-indicator-color: #0066cc;
-
-    /* Syntax highlighting weight/style */
-    --verso-code-keyword-weight: bold;
-    --verso-code-keyword-style: normal;
+    --verso-tooltip-info-border-color: #cfe2ff;
+    --verso-code-warning-hover-bg-color: #fff3cd;
+    --verso-warning-indicator-color: #b8860b;
+    --verso-tooltip-warning-border-color: #fff3cd;
+    --verso-code-error-hover-bg-color: #f8d7da;
+    --verso-error-indicator-color: #dc3545;
+    --verso-tooltip-error-border-color: #f8d7da;
 }
 
 /* Dark mode defaults */
@@ -93,66 +93,33 @@
         --verso-hamburger-bg: #16213e;
         --verso-hamburger-border: #2a2a4a;
         --verso-hamburger-bar-color: #e0e0e0;
-        --verso-warning-color: #3d3000;
-        --verso-error-color: #ff6b6b;
-        --verso-warning-indicator-color: #ffc107;
-        --verso-error-indicator-color: #ff6b6b;
+        --verso-code-hover-bg-color: #3a3a5a;
+        --verso-tooltip-color: #e0e0e0;
+        --verso-tooltip-bg-color: #2a2a4a;
+        --verso-tooltip-border-color: #4a4a6a;
+        --verso-tooltip-separator-color: #4a4a6a;
+        --verso-code-info-hover-bg-color: #0c2a4d;
         --verso-info-indicator-color: #64b5f6;
+        --verso-message-info-color: #e0e0e0;
+        --verso-tooltip-info-border-color: #4a4a6a;
+        --verso-code-warning-hover-bg-color: #3d3000;
+        --verso-warning-indicator-color: #ffc107;
+        --verso-message-warning-color: #e0e0e0;
+        --verso-tooltip-warning-border-color: #4a4a6a;
+        --verso-code-error-hover-bg-color: #3d0f12;
+        --verso-error-indicator-color: #ff6b6b;
+        --verso-message-error-color: #ff6b6b;
+        --verso-tooltip-error-border-color: #4a4a6a;
+        --verso-tactic-state-color: #e0e0e0;
+        --verso-tactic-state-bg-color: #2a2a4a;
+        --verso-tactic-state-border-color: #4a4a6a;
         --verso-selected-color: #1a2744;
-    }
-
-    /* Hover tooltips (tippy) */
-    .tippy-box[data-theme~="lean"],
-    .tippy-box[data-theme~="error"],
-    .tippy-box[data-theme~="warning"],
-    .tippy-box[data-theme~="info"] {
-        background-color: #2a2a4a;
-        color: #e0e0e0;
-        border-color: #4a4a6a;
-    }
-    .tippy-box[data-theme~="lean"] > .tippy-arrow::before,
-    .tippy-box[data-theme~="error"] > .tippy-arrow::before,
-    .tippy-box[data-theme~="warning"] > .tippy-arrow::before,
-    .tippy-box[data-theme~="info"] > .tippy-arrow::before {
-        border-color: #2a2a4a;
-    }
-    .tippy-box[data-theme~="tactic"] {
-        background-color: #2a2a4a;
-        color: #e0e0e0;
-        border-color: #4a4a6a;
-    }
-    .tippy-box[data-theme~="tactic"] > .tippy-arrow::before {
-        border-color: #2a2a4a;
-    }
-    .tippy-box[data-theme~="message"] > .tippy-arrow::before {
-        border-color: #2a2a4a;
-    }
-
-    /* Binding highlight on hover */
-    .hl.lean .token.binding-hl,
-    .hl.lean .literal.string:hover,
-    .hl.lean .token.typed:hover {
-        background-color: #3a3a5a;
-    }
-
-    /* Tactic/proof state hover */
-    .hl.lean .tactic:has(.tactic-toggle:not(:checked)) > label:hover {
-        background-color: #3a3a5a;
     }
 
     /* Popup content inside tooltips */
     .hl.lean.popup {
         background-color: #2a2a4a;
         color: #e0e0e0;
-    }
-    .hl.lean .hover-info {
-        color: #e0e0e0;
-    }
-    .hl.lean .hover-info code {
-        color: #e0e0e0;
-    }
-    .hl.lean .hover-info .sep {
-        border-top-color: #4a4a6a;
     }
 
     /* Diagnostic message backgrounds */
@@ -162,13 +129,6 @@
         background-color: #1a1a2e;
     }
 
-    /* Tactic state */
-    .hl.lean .tactic-state,
-    .hl.lean.popup .tactic-state {
-        background-color: #2a2a4a;
-        color: #e0e0e0;
-        border-color: #4a4a6a;
-    }
 }
 
 /* Reset and base styles */

--- a/src/verso-manual/VersoManual/Html/Style.lean
+++ b/src/verso-manual/VersoManual/Html/Style.lean
@@ -962,18 +962,18 @@ main section li ol {
     overflow-x: auto;
     margin: 0px;
     margin: 0.5em .85em;
-    border-left: 0.2em solid red;
+    border-left: 0.2em solid var(--verso-output-error-color);
     padding: 0 0.45em;
 }
 
 /* Different color for warning */
 .lean-output.warning {
-    border-color: var(--verso-warning-color);
+    border-color: var(--verso-output-warning-color);
 }
 
 /* Different color for information */
 .lean-output.information {
-    border-color: #0000c0;
+    border-color: var(--verso-output-info-color);
 }
 
 

--- a/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
+++ b/src/verso-manual/VersoManual/InlineLean/SyntaxError.lean
@@ -61,7 +61,7 @@ block_extension Block.syntaxError via withHighlighting where
 }
 
 :is(.syntax-error > .line):has(.parse-message)::before {
-  color: red;
+  color: var(--verso-message-error-color);
   font-weight: bold;
 }
 
@@ -72,7 +72,7 @@ block_extension Block.syntaxError via withHighlighting where
 .syntax-error .parse-message {
   white-space: pre;
   text-decoration-skip-ink: none;
-  color: red;
+  color: var(--verso-message-error-color);
   font-weight: 600;
 }
 "

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -625,13 +625,13 @@ partial def takeAttr (attr : String) : Html → Option String × Html
       | (some v, contents) => (some v, .tag name attrs contents)
       | (none, _) => (none, html)
   | html@(.seq xs) =>
-    let trimmed := xs.toList.dropWhile isEmptyHtml |>.reverse.dropWhile isEmptyHtml |>.reverse
-    match trimmed with
-    | [x] =>
-      match takeAttr attr x with
+    let trimmed := xs.popWhile isEmptyHtml
+    let trimmed := trimmed.extract (trimmed.findIdx (!isEmptyHtml ·)) trimmed.size
+    if h : trimmed.size = 1 then
+      match takeAttr attr trimmed[0] with
       | (some v, x) => (some v, x)
       | (none, _) => (none, html)
-    | _ => (none, html)
+    else (none, html)
   | html => (none, html)
 
 /--

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -640,11 +640,10 @@ of each sequence, and a sequence around a single element becomes that element.
 -/
 public partial defmethod Highlighted.normalize : Highlighted → Highlighted
   | .seq xs =>
-    let xs := xs.map normalize
-    let xs := xs.toList.dropWhile (·.isEmpty) |>.reverse.dropWhile (·.isEmpty) |>.reverse
-    match xs with
-    | [x] => x
-    | xs => .seq xs.toArray
+    let xs := (xs.map normalize).popWhile (·.isEmpty)
+    let xs := xs.extract (xs.findIdx (!·.isEmpty)) xs.size
+    if h : xs.size = 1 then xs[0]
+    else .seq xs
   | .span infos hl => .span infos hl.normalize
   | .tactics i s e hl => .tactics i s e hl.normalize
   | hl => hl

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -611,28 +611,28 @@ partial def isEmptyHtml : Html → Bool
   | .tag .. => false
 
 /--
-Removes the attribute `attr` from the outermost element of `html`, returning its value
-alongside the remaining HTML. The attribute is taken only when it is unambiguous: a
-sequence is searched only when trimming its empty prefix and suffix leaves a single element,
-and the search stops at the first occurrence found.
+Removes the attributes named in `attrs` from `html`, returning their values alongside the
+remaining HTML. The search descends while unambiguous (through tags, and through sequences
+that hold a single element once empty text is trimmed), and takes each attribute from the
+outermost element that carries it.
 -/
-partial def takeAttr (attr : String) : Html → Option String × Html
-  | html@(.tag name attrs contents) =>
-    if let some (_, v) := attrs.find? (·.1 == attr) then
-      (some v, .tag name (attrs.filter (·.1 != attr)) contents)
-    else
-      match takeAttr attr contents with
-      | (some v, contents) => (some v, .tag name attrs contents)
-      | (none, _) => (none, html)
-  | html@(.seq xs) =>
-    let trimmed := xs.popWhile isEmptyHtml
-    let trimmed := trimmed.extract (trimmed.findIdx (!isEmptyHtml ·)) trimmed.size
-    if h : trimmed.size = 1 then
-      match takeAttr attr trimmed[0] with
-      | (some v, x) => (some v, x)
-      | (none, _) => (none, html)
-    else (none, html)
-  | html => (none, html)
+partial def takeAttrs (attrs : Array String) (html : Html) : Array (String × String) × Html :=
+  go attrs html
+where
+  go (remaining : Array String) : Html → Array (String × String) × Html
+    | html@(.tag name as contents) =>
+      let here := as.filter (remaining.contains ·.1)
+      let (found, contents') := go (remaining.filter (fun r => !here.any (·.1 == r))) contents
+      if here.isEmpty && found.isEmpty then (#[], html)
+      else (here ++ found, .tag name (as.filter (!remaining.contains ·.1)) contents')
+    | html@(.seq xs) =>
+      let trimmed := xs.popWhile isEmptyHtml
+      let trimmed := trimmed.extract (trimmed.findIdx (!isEmptyHtml ·)) trimmed.size
+      if h : trimmed.size = 1 then
+        let (found, x) := go remaining trimmed[0]
+        if found.isEmpty then (#[], html) else (found, x)
+      else (#[], html)
+    | html => (#[], html)
 
 /--
 Normalizes the sequence structure of highlighted code: empty text is removed from the ends
@@ -660,12 +660,7 @@ public partial defmethod Highlighted.toHtml : Highlighted → HighlightHtmlM g H
       let inner ← toHtml hl
       let (spanAttrs, inner) :=
         if let .token _ := hl then
-          let (hoverVal, inner) := takeAttr "data-verso-hover" inner
-          let (linksVal, inner) := takeAttr "data-verso-links" inner
-          let attrs :=
-            (hoverVal.map (("data-verso-hover", ·))).toArray ++
-            (linksVal.map (("data-verso-links", ·))).toArray
-          (attrs, inner)
+          takeAttrs #["data-verso-hover", "data-verso-links"] inner
         else (#[], inner)
       pure {{<span class={{"has-info " ++ cls}} {{spanAttrs}}>
           <span class="hover-container">

--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -345,24 +345,26 @@ Removes leading and trailing whitespace from highlighted code.
 public defmethod Highlighted.trim (hl : Highlighted) : Highlighted := hl.trimLeft.trimRight
 
 /--
-Removes proof states in which all goals are solved that are the last element of a surrounding proof
-state. This relies on the positions tracked for the goal states being accurate, as it compares end
-position markers.
+Removes redundant proof states. A proof state is redundant if either it has no open goals and ends
+at the same position as a surrounding state, or when it has the same goals and source range as a
+surrounding state. This relies on the positions tracked for the goal states being accurate.
 
-This is to prevent extra nested highlight widgets for tactics that themselves contain tactic
-scripts.
+This is to prevent extra nested widgets for tactics that themselves contain tactic scripts or that
+elaboration records more than once at the same position.
 -/
 public partial defmethod Highlighted.elideRedundantProofStates
-    (hl : Highlighted) (goalEnds : Array Nat := #[]) : Highlighted :=
+    (hl : Highlighted) (goalEnds : Array Nat := #[])
+    (seen : Array (Array (Highlighted.Goal Highlighted) × Nat × Nat) := #[]) : Highlighted :=
   match hl with
-  | .seq hls => .seq (hls.map (·.elideRedundantProofStates goalEnds))
-  | .span infos hl => .span infos (hl.elideRedundantProofStates goalEnds)
+  | .seq hls => .seq (hls.map (·.elideRedundantProofStates goalEnds seen))
+  | .span infos hl => .span infos (hl.elideRedundantProofStates goalEnds seen)
   | .tactics info startPos endPos hl =>
-    if info.isEmpty && goalEnds.contains endPos then
-      hl.elideRedundantProofStates goalEnds
+    if (info.isEmpty && goalEnds.contains endPos) || seen.contains (info, startPos, endPos) then
+      hl.elideRedundantProofStates goalEnds seen
     else
       let goalEnds := if info.isEmpty then goalEnds else goalEnds.push endPos
-      .tactics info startPos endPos (hl.elideRedundantProofStates goalEnds)
+      .tactics info startPos endPos
+        (hl.elideRedundantProofStates goalEnds (seen.push (info, startPos, endPos)))
   | .token .. | .text .. | .unparsed .. | .point .. => hl
 
 public defmethod Highlighted.trimOneLeadingNl : Highlighted → Highlighted
@@ -511,9 +513,8 @@ defmethod Token.htmlContent (tok : Token) : HighlightHtmlM g Html := do
     return content
 
 public defmethod Token.toHtml (tok : Token) : HighlightHtmlM g Html := do
-  let hoverId ← tok.kind.hover?
   let idAttr ← tok.kind.idAttr
-  let hoverAttr := hoverId.map (fun i => #[("data-verso-hover", toString i)]) |>.getD #[]
+  let hoverAttr := (← tok.kind.hover?).map (fun i => #[("data-verso-hover", toString i)]) |>.getD #[]
   tok.kind.addLink {{
     <span class={{tok.kind.«class» ++ " token"}} data-binding={{tok.kind.data}} {{hoverAttr}} {{idAttr}}>{{← tok.htmlContent}}</span>
   }}
@@ -603,12 +604,71 @@ where
     | .warning, _ => .warning
     | .info, other => other
 
+/-- HTML that renders no visible content. -/
+partial def isEmptyHtml : Html → Bool
+  | .text _ s => s.isEmpty
+  | .seq xs => xs.all isEmptyHtml
+  | .tag .. => false
+
+/--
+Removes the attribute `attr` from the outermost element of `html`, returning its value
+alongside the remaining HTML. The attribute is taken only when it is unambiguous: a
+sequence is searched only when trimming its empty prefix and suffix leaves a single element,
+and the search stops at the first occurrence found.
+-/
+partial def takeAttr (attr : String) : Html → Option String × Html
+  | html@(.tag name attrs contents) =>
+    if let some (_, v) := attrs.find? (·.1 == attr) then
+      (some v, .tag name (attrs.filter (·.1 != attr)) contents)
+    else
+      match takeAttr attr contents with
+      | (some v, contents) => (some v, .tag name attrs contents)
+      | (none, _) => (none, html)
+  | html@(.seq xs) =>
+    let trimmed := xs.toList.dropWhile isEmptyHtml |>.reverse.dropWhile isEmptyHtml |>.reverse
+    match trimmed with
+    | [x] =>
+      match takeAttr attr x with
+      | (some v, x) => (some v, x)
+      | (none, _) => (none, html)
+    | _ => (none, html)
+  | html => (none, html)
+
+/--
+Normalizes the sequence structure of highlighted code: empty text is removed from the ends
+of each sequence, and a sequence around a single element becomes that element.
+-/
+public partial defmethod Highlighted.normalize : Highlighted → Highlighted
+  | .seq xs =>
+    let xs := xs.map normalize
+    let xs := xs.toList.dropWhile (·.isEmpty) |>.reverse.dropWhile (·.isEmpty) |>.reverse
+    match xs with
+    | [x] => x
+    | xs => .seq xs.toArray
+  | .span infos hl => .span infos hl.normalize
+  | .tactics i s e hl => .tactics i s e hl.normalize
+  | hl => hl
+
 public partial defmethod Highlighted.toHtml : Highlighted → HighlightHtmlM g Html
   | .token t => t.toHtml
   | .text str | .unparsed str => pure {{<span class="inter-text">{{str}}</span>}}
   | .span infos hl =>
     if let some cls := spanClass infos then do
-      pure {{<span class={{"has-info " ++ cls}}>
+      -- A span around a single token shares the token's extent, so the token's documentation
+      -- and extra link targets become part of the span's hover, which shows all of the
+      -- content for that extent in one place.
+      let hl := hl.normalize
+      let inner ← toHtml hl
+      let (spanAttrs, inner) :=
+        if let .token _ := hl then
+          let (hoverVal, inner) := takeAttr "data-verso-hover" inner
+          let (linksVal, inner) := takeAttr "data-verso-links" inner
+          let attrs :=
+            (hoverVal.map (("data-verso-hover", ·))).toArray ++
+            (linksVal.map (("data-verso-links", ·))).toArray
+          (attrs, inner)
+        else (#[], inner)
+      pure {{<span class={{"has-info " ++ cls}} {{spanAttrs}}>
           <span class="hover-container">
             <span class={{"hover-info messages"}}>
               {{←  infos.mapM fun (s, info) => do return {{
@@ -616,7 +676,7 @@ public partial defmethod Highlighted.toHtml : Highlighted → HighlightHtmlM g H
               }}
             </span>
           </span>
-          {{← toHtml hl}}
+          {{inner}}
         </span>
       }}
     else
@@ -743,6 +803,11 @@ public def highlightingStyle : String := "
   text-decoration: currentcolor underline solid;
 }
 
+/* Links inside tooltips show their underline only when hovered. */
+.tippy-box .hl.lean a {
+  text-decoration: none;
+}
+
 .hl.lean .hover-info {
   white-space: normal;
 }
@@ -750,8 +815,9 @@ public def highlightingStyle : String := "
 .hl.lean .token .hover-info {
   display: none;
   position: absolute;
-  background-color: #e5e5e5;
-  border: 1px solid black;
+  color: var(--verso-tooltip-color, black);
+  background-color: var(--verso-tooltip-bg-color, #e5e5e5);
+  border: 1px solid var(--verso-tooltip-border-color, black);
   padding: 0.5rem;
   z-index: 300;
 }
@@ -768,7 +834,10 @@ public def highlightingStyle : String := "
 .hl.lean .hover-info code {
   white-space: pre-wrap;
   background: none;
-  color: black;
+}
+
+.hl.lean .hover-info code:not(.verso-message) {
+  color: var(--verso-tooltip-color, black);
 }
 
 .hl.lean .hover-info.messages > code {
@@ -809,10 +878,24 @@ public def highlightingStyle : String := "
 }
 
 @media (hover: hover) {
-  .hl.lean .token.binding-hl, .hl.lean .literal:hover, .hl.lean .token.typed:hover {
-    background-color: #eee;
+  /* Hovered content nested in a collapsed tactic region keeps its plain background: the
+     region's proof state is the tooltip that appears there, and its label is what
+     highlights. `:where` keeps the exclusion out of the specificity computation. */
+  .hl.lean .token.binding-hl,
+  .hl.lean :is(.literal, .token.typed, .token[data-verso-hover]):hover:not(:where(.tactic:has(> .tactic-toggle:not(:checked)) > label *)) {
+    background-color: var(--verso-code-hover-bg-color, #eeeeee);
     border-radius: 2px;
     transition: none;
+  }
+
+  /* Within a hovered message span, token hover backgrounds are removed so the span's own
+     hover background shows across the whole span. The exception is a hovered documented
+     token, which keeps its background because its tooltip is the one shown. */
+  .hl.lean .has-info:hover .token.binding-hl:not(:hover),
+  .hl.lean .has-info:hover .token.binding-hl:not([data-verso-hover]),
+  .hl.lean .has-info:hover .literal:hover:not([data-verso-hover]),
+  .hl.lean .has-info:hover .token.typed:hover:not([data-verso-hover]) {
+    background-color: transparent;
   }
 }
 
@@ -824,56 +907,93 @@ public def highlightingStyle : String := "
   text-decoration-skip-ink: none;
 }
 
+/*
+The underline color comes from the nearest enclosing message span: each severity's span rule
+sets `--verso--region-indicator-color`, which inherits, so a region nested inside one of
+another severity keeps its own indicator color.
+*/
+.hl.lean .has-info :not(.tactic-state):not(.tactic-state *) {
+  text-decoration-color: var(--verso--region-indicator-color);
+}
+
 .hl.lean .has-info .hover-info {
   display: none;
   position: absolute;
   transform: translate(0.25rem, 0.3rem);
-  border: 1px solid black;
+  color: var(--verso-tooltip-color, black);
+  border: 1px solid var(--verso-tooltip-border-color, black);
   padding: 0.5rem;
   z-index: 400;
   text-align: left;
 }
 
-.hl.lean .has-info.error :not(.tactic-state):not(.tactic-state *){
-  text-decoration-color: red;
+.hl.lean .has-info.error {
+  --verso--region-indicator-color: var(--verso-error-indicator-color, #ff0000);
+  --verso--region-hover-color: var(--verso-code-error-hover-color, currentcolor);
+  --verso--region-hover-bg-color: var(--verso-code-error-hover-bg-color, #ffb3b3);
+  color: var(--verso-code-error-color, currentcolor);
+  background-color: var(--verso-code-error-bg-color, transparent);
 }
 
+/*
+The hover highlight follows the tooltip: a message span highlights only when its own tooltip
+is the one that appears. When a hovered nested message span, a hovered documented token, or
+a hovered collapsed tactic label shows its own tooltip instead, the message span does not
+highlight. A span nested in a collapsed tactic region likewise stays plain, because hovering
+it shows the region's proof state; `:where` keeps that exclusion out of the specificity
+computation.
+
+The hover colors come from `--verso--region-hover-color` and `--verso--region-hover-bg-color`,
+which each severity's span rule sets. This keeps the hover conditions in this one rule, and
+because the properties inherit, a region nested inside one of another severity keeps its own
+hover colors.
+*/
 @media (hover: hover) {
-  .hl.lean .has-info.error:hover {
-    background-color: #ffb3b3;
+  .hl.lean .has-info:hover:not(:has(.has-info:hover)):not(:has([data-verso-hover]:hover)):not(:has(.tactic > label:hover + .tactic-toggle:not(:checked))):not(:where(.tactic:has(> .tactic-toggle:not(:checked)) > label *)) {
+    color: var(--verso--region-hover-color, currentcolor);
+    background-color: var(--verso--region-hover-bg-color, transparent);
   }
 }
 
 .hl.lean .hover-info.messages > code.error {
-  background-color: #e5e5e5;
-  border-left: 0.2rem solid #ffb3b3;
+  background-color: var(--verso-tooltip-error-bg-color, #e5e5e5);
+  border-left: 0.2rem solid var(--verso-tooltip-error-border-color, #ffb3b3);
 }
 
-.tippy-box[data-theme~='error'] .hl.lean .hover-info.messages > code.error {
+/*
+A tooltip that shows only messages of the box's own severity leaves severity styling to the
+box itself. When messages of several severities share the tooltip, or a `mixed` tooltip
+combines messages with other content (such as documentation), each message keeps its
+severity accent to distinguish them.
+*/
+.tippy-box .hl.lean.mixed > .hover-info.messages {
+  margin-bottom: 0.5rem;
+}
+
+.tippy-box[data-theme~='error'] .hl.lean:not(.mixed) .hover-info.messages:not(:has(> code.warning)):not(:has(> code.information)) > code.error {
   background: none;
   border: none;
 }
 
 .error .verso-message, .error .verso-message .token, .error .verso-message label {
-  color: var(--verso-error-color);
+  color: var(--verso-message-error-color, #cc0000);
 }
 
 .error .verso-message .case-label:has(input[type=\"checkbox\"])::before {
-  background-color: var(--verso-error-color) !important;
+  background-color: var(--verso-message-error-color, #cc0000) !important;
 }
 
-.hl.lean .has-info.warning :not(.tactic-state):not(.tactic-state *) {
-  text-decoration-color: var(--verso-warning-indicator-color);
-}
-
-@media (hover: hover) {
-  .hl.lean .has-info.warning:hover {
-    background-color:var(--verso-warning-color);
-  }
+.hl.lean .has-info.warning {
+  --verso--region-indicator-color: var(--verso-warning-indicator-color, #e7a71d);
+  --verso--region-hover-color: var(--verso-code-warning-hover-color, currentcolor);
+  --verso--region-hover-bg-color: var(--verso-code-warning-hover-bg-color, #ffd580);
+  color: var(--verso-code-warning-color, currentcolor);
+  background-color: var(--verso-code-warning-bg-color, transparent);
 }
 
 .hl.lean .hover-info.messages > code.warning {
-  background-color: var(--verso-warning-color);
+  background-color: var(--verso-tooltip-warning-bg-color, #e5e5e5);
+  border-left: 0.2rem solid var(--verso-tooltip-warning-border-color, #ffd580);
 }
 
 .lean-output {
@@ -884,47 +1004,56 @@ public def highlightingStyle : String := "
 }
 
 .lean-output.error {
-  border-color: var(--verso-error-indicator-color);
+  border-color: var(--verso-output-error-color, var(--verso-error-indicator-color, #ff0000));
 }
 
 .lean-output.information {
-  border-color: var(--verso-info-indicator-color);
+  border-color: var(--verso-output-info-color, var(--verso-info-indicator-color, #4777ff));
 }
 
 .lean-output.warning {
-  border-color: var(--verso-warning-indicator-color);
+  border-color: var(--verso-output-warning-color, var(--verso-warning-indicator-color, #e7a71d));
 }
 
-.hl.lean .hover-info.messages > code.error {
-  background-color: #e5e5e5;
-  border-left: 0.2rem solid var(--verso-warning-color);
-}
-
-.tippy-box[data-theme~='warning'] .hl.lean .hover-info.messages > code.warning {
+.tippy-box[data-theme~='warning'] .hl.lean:not(.mixed) .hover-info.messages:not(:has(> code.error)):not(:has(> code.information)) > code.warning {
   background: none;
   border: none;
 }
 
-
-.hl.lean .has-info.information :not(.tactic-state):not(.tactic-state *) {
-  text-decoration-color: var(--verso-info-indicator-color, blue);
+.warning .verso-message, .warning .verso-message .token, .warning .verso-message label {
+  color: var(--verso-message-warning-color, black);
 }
 
-@media (hover: hover) {
-  .hl.lean .has-info.information:hover {
-    background-color: #4777ff;
-  }
+.warning .verso-message .case-label:has(input[type=\"checkbox\"])::before {
+  background-color: var(--verso-message-warning-color, black) !important;
+}
+
+
+.hl.lean .has-info.information {
+  --verso--region-indicator-color: var(--verso-info-indicator-color, #4777ff);
+  --verso--region-hover-color: var(--verso-code-info-hover-color, currentcolor);
+  --verso--region-hover-bg-color: var(--verso-code-info-hover-bg-color, #4777ff);
+  color: var(--verso-code-info-color, currentcolor);
+  background-color: var(--verso-code-info-bg-color, transparent);
 }
 
 
 .hl.lean .hover-info.messages > code.information {
-  background-color: #e5e5e5;
-  border-left: 0.2rem solid #4777ff;
+  background-color: var(--verso-tooltip-info-bg-color, #e5e5e5);
+  border-left: 0.2rem solid var(--verso-tooltip-info-border-color, #4777ff);
 }
 
-.tippy-box[data-theme~='info'] .hl.lean .hover-info.messages > code.information {
+.tippy-box[data-theme~='info'] .hl.lean:not(.mixed) .hover-info.messages:not(:has(> code.error)):not(:has(> code.warning)) > code.information {
   background: none;
   border: none;
+}
+
+.information .verso-message, .information .verso-message .token, .information .verso-message label {
+  color: var(--verso-message-info-color, black);
+}
+
+.information .verso-message .case-label:has(input[type=\"checkbox\"])::before {
+  background-color: var(--verso-message-info-color, black) !important;
 }
 
 .hl.lean div.docstring {
@@ -951,7 +1080,7 @@ public def highlightingStyle : String := "
   margin-bottom: 0.5rem;
   padding: 0;
   height: 1px;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid var(--verso-tooltip-separator-color, #ccc);
 }
 
 .hl.lean code {
@@ -962,11 +1091,12 @@ public def highlightingStyle : String := "
   display: none;
   position: relative;
   width: fit-content;
-  border: 1px solid #888888;
+  border: 1px solid var(--verso-tactic-state-border-color, #888888);
   border-radius: 0.1rem;
   padding: 0.5rem;
   font-family: sans-serif;
-  background-color: #ffffff;
+  color: var(--verso-tactic-state-color, black);
+  background-color: var(--verso-tactic-state-bg-color, white);
 }
 
 .hl.lean.popup .tactic-state {
@@ -976,7 +1106,7 @@ public def highlightingStyle : String := "
   border: none;
   padding: 0.5rem;
   font-family: sans-serif;
-  background-color: #ffffff;
+  background-color: var(--verso-tactic-state-bg-color, white);
 }
 
 
@@ -1010,9 +1140,11 @@ public def highlightingStyle : String := "
 @media (hover: hover) {
   /* Highlight a region on hover only when its own toggle is unchecked, and only the innermost
      hovered region: `label:hover` bubbles to ancestor labels, so suppress the highlight on a region
-     whose label contains a more deeply nested hovered tactic label. */
+     whose label contains a more deeply nested hovered tactic label. The region's proof state is the
+     tooltip for everything else in its label, so the label keeps its highlight while any of that
+     content is hovered. */
   .hl.lean .tactic:has(> .tactic-toggle:not(:checked)) > label:hover:not(:has(.tactic > label:hover)) {
-    background-color: #eeeeee;
+    background-color: var(--verso-code-hover-bg-color, #eeeeee);
   }
 }
 
@@ -1028,7 +1160,7 @@ public def highlightingStyle : String := "
 
 .hl.lean .tactic > label::after {
   content: \"\";
-  border: 1px solid #bbbbbb;
+  border: 1px solid var(--verso-tactic-toggle-color, #bbbbbb);
   /* These need to be em, not rem, to scale with the font */
   border-radius: 1em;
   height: 0.25em;
@@ -1051,8 +1183,8 @@ public def highlightingStyle : String := "
 */
 
 .hl.lean .tactic > label:has(+ .tactic-toggle:checked)::after {
-  border: 1px solid #999999;
-  background-color: #999999;
+  border: 1px solid var(--verso-tactic-toggle-checked-color, #999999);
+  background-color: var(--verso-tactic-toggle-checked-color, #999999);
   transition: all 0.5s;
 }
 
@@ -1130,7 +1262,7 @@ Some CSS frameworks customize details/summary in ways not compatible with Verso'
 
 .hl.lean .case-label:has(input[type=\"checkbox\"])::before {
   display: inline-block;
-  background-color: black;
+  background-color: currentcolor;
   content: ' ';
   transition: ease 0.2s;
   margin-right: 0.7em;
@@ -1214,26 +1346,22 @@ Some CSS frameworks customize details/summary in ways not compatible with Verso'
   text-size-adjust: 100%;
 }
 
+/*
+Tippy's stylesheet paints each arrow's fill triangle with the arrow element's `color` (its
+placement-specific `::before` rules use `border-color: initial`, which is `currentcolor`),
+and its border extension paints the outline triangle with the box's border color. Setting
+`color` on the arrow therefore matches it to the tooltip background for every placement.
+*/
 .tippy-box[data-theme~='lean'] {
-  background-color: #e5e5e5;
-  color: black;
-  border: 1px solid black;
+  background-color: var(--verso-tooltip-bg-color, #e5e5e5);
+  color: var(--verso-tooltip-color, black);
+  border: 1px solid var(--verso-tooltip-border-color, black);
 }
-.tippy-box[data-theme~='lean'][data-placement^='top'] > .tippy-arrow::before {
-  border-top-color: #e5e5e5;
-}
-.tippy-box[data-theme~='lean'][data-placement^='bottom'] > .tippy-arrow::before {
-  border-bottom-color: #e5e5e5;
-}
-.tippy-box[data-theme~='lean'][data-placement^='left'] > .tippy-arrow::before {
-  border-left-color: #e5e5e5;
-}
-.tippy-box[data-theme~='lean'][data-placement^='right'] > .tippy-arrow::before {
-  border-right-color: #e5e5e5;
+.tippy-box[data-theme~='lean'] > .tippy-arrow {
+  color: var(--verso-tooltip-bg-color, #e5e5e5);
 }
 
 .tippy-box[data-theme~='message'][data-placement^='top'] > .tippy-arrow::before {
-  border-top-color: #e5e5e5;
   border-width: 11px 11px 0;
 }
 .tippy-box[data-theme~='message'][data-placement^='top'] > .tippy-arrow::after {
@@ -1248,7 +1376,6 @@ Some CSS frameworks customize details/summary in ways not compatible with Verso'
   border-width: 0 11px 11px;
 }
 .tippy-box[data-theme~='message'][data-placement^='left'] > .tippy-arrow::before {
-  border-left-color: #e5e5e5;
   border-width: 11px 0 11px 11px;
 }
 .tippy-box[data-theme~='message'][data-placement^='left'] > .tippy-arrow::after {
@@ -1257,7 +1384,6 @@ Some CSS frameworks customize details/summary in ways not compatible with Verso'
 }
 
 .tippy-box[data-theme~='message'][data-placement^='right'] > .tippy-arrow::before {
-  border-right-color: #e5e5e5;
   border-width: 11px 11px 11px 0;
 }
 .tippy-box[data-theme~='message'][data-placement^='right'] > .tippy-arrow::after {
@@ -1268,39 +1394,39 @@ Some CSS frameworks customize details/summary in ways not compatible with Verso'
 
 
 .tippy-box[data-theme~='warning'] {
-  background-color: #e5e5e5;
-  color: black;
-  border: 3px solid var(--verso-warning-color);
+  background-color: var(--verso-tooltip-warning-bg-color, #e5e5e5);
+  color: var(--verso-tooltip-warning-color, black);
+  border: 3px solid var(--verso-tooltip-warning-border-color, #ffd580);
+}
+.tippy-box[data-theme~='warning'] > .tippy-arrow {
+  color: var(--verso-tooltip-warning-bg-color, #e5e5e5);
 }
 
 .tippy-box[data-theme~='error'] {
-  background-color: #e5e5e5;
-  color: black;
-  border: 3px solid #f7a7af;
+  background-color: var(--verso-tooltip-error-bg-color, #e5e5e5);
+  color: var(--verso-tooltip-error-color, black);
+  border: 3px solid var(--verso-tooltip-error-border-color, #ffb3b3);
+}
+.tippy-box[data-theme~='error'] > .tippy-arrow {
+  color: var(--verso-tooltip-error-bg-color, #e5e5e5);
 }
 
 .tippy-box[data-theme~='info'] {
-  background-color: #e5e5e5;
-  color: black;
-  border: 3px solid #99b3c2;
+  background-color: var(--verso-tooltip-info-bg-color, #e5e5e5);
+  color: var(--verso-tooltip-info-color, black);
+  border: 3px solid var(--verso-tooltip-info-border-color, #4777ff);
+}
+.tippy-box[data-theme~='info'] > .tippy-arrow {
+  color: var(--verso-tooltip-info-bg-color, #e5e5e5);
 }
 
 .tippy-box[data-theme~='tactic'] {
-  background-color: white;
-  color: black;
-  border: 1px solid black;
+  background-color: var(--verso-tactic-state-bg-color, white);
+  color: var(--verso-tactic-state-color, black);
+  border: 1px solid var(--verso-tactic-state-border-color, #888888);
 }
-.tippy-box[data-theme~='tactic'][data-placement^='top'] > .tippy-arrow::before {
-  border-top-color: white;
-}
-.tippy-box[data-theme~='tactic'][data-placement^='bottom'] > .tippy-arrow::before {
-  border-bottom-color: white;
-}
-.tippy-box[data-theme~='tactic'][data-placement^='left'] > .tippy-arrow::before {
-  border-left-color: white;
-}
-.tippy-box[data-theme~='tactic'][data-placement^='right'] > .tippy-arrow::before {
-  border-right-color: white;
+.tippy-box[data-theme~='tactic'] > .tippy-arrow {
+  color: var(--verso-tactic-state-bg-color, white);
 }
 
 .extra-doc-links {
@@ -1324,7 +1450,7 @@ Some CSS frameworks customize details/summary in ways not compatible with Verso'
 }
 
 .verso-message .trace > summary::marker {
-  color: var(--verso-text-color);
+  color: var(--verso-text-color, black);
 }
 
 .verso-message .trace-children {
@@ -1383,10 +1509,39 @@ window.onload = async () => {
       return false;
     }
 
-    // Track whether any tippy is visible (O(1) check instead of DOM scan)
-    let visibleTippyCount = 0;
+    // The innermost element under the pointer, used to show only the most specific hover
+    let hoverTarget = null;
+    document.addEventListener('mouseover', (e) => { hoverTarget = e.target; }, true);
+
+    // Visible tippy references; a tooltip is blocked while an unrelated one is visible
+    const visibleTippies = new Set();
     function blockedByTippy(elem) {
-      return visibleTippyCount > 0;
+      for (const ref of visibleTippies) {
+        if (!ref.contains(elem) && !elem.contains(ref)) return true;
+      }
+      return false;
+    }
+
+    // Whether the element's tooltip would have content to show. Content nested in a
+    // collapsed tactic region is covered by the region's proof-state tooltip, whether or
+    // not a tippy instance is currently attached to it.
+    function showsContent(el) {
+      if (!el._tippy) return false;
+      if (el.classList.contains('tactic')) {
+        const toggle = el.querySelector(':scope > input.tactic-toggle');
+        return !!toggle && !toggle.checked;
+      }
+      return (!!el.querySelector('.hover-info') || 'versoHover' in el.dataset) &&
+        !blockedByTactic(el);
+    }
+
+    // The nearest enclosing element whose tooltip has content
+    function innermostShowable(el) {
+      while (el && el.nodeType === Node.ELEMENT_NODE) {
+        if (showsContent(el)) return el;
+        el = el.parentElement;
+      }
+      return null;
     }
 
     // Binding highlights via event delegation with cached lookups
@@ -1453,6 +1608,40 @@ window.onload = async () => {
       }
     }
 
+    function hideDescendantTooltips(element) {
+      for (const ref of visibleTippies) {
+        if (ref !== element && element.contains(ref)) {
+          ref._tippy.hide();
+        }
+      }
+    }
+
+    // Renders the documentation for a hover ID from the doc table
+    function docHoverContent(hoverId) {
+      const info = document.createElement('span');
+      info.className = 'hover-info';
+      info.style.display = 'block';
+      const data = versoDocData[hoverId];
+      if (data) {
+        info.innerHTML = data;
+        /* Render docstrings - TODO server-side */
+        if ('undefined' !== typeof marked) {
+          for (const d of info.querySelectorAll('code.docstring, pre.docstring')) {
+            const str = d.innerText;
+            const html = marked.parse(str);
+            const rendered = document.createElement('div');
+            rendered.classList.add('docstring');
+            rendered.innerHTML = html;
+            d.parentNode.replaceChild(rendered, d);
+          }
+        }
+      } else {
+        info.innerHTML = 'Failed to load doc ID: ' + hoverId;
+      }
+      return info;
+    }
+
+
 
 
     const defaultTippyProps = {
@@ -1468,23 +1657,27 @@ window.onload = async () => {
       /* ignoreAttributes: true, */
       followCursor: 'initial',
       onShow(inst) {
-        if (inst.reference.className == 'tactic') {
-          const toggle = inst.reference.querySelector(\":scope > input.tactic-toggle\");
+        const ref = inst.reference;
+        if (ref.className == 'tactic') {
+          const toggle = ref.querySelector(\":scope > input.tactic-toggle\");
           if (toggle && toggle.checked) {
             return false;
           }
-          hideParentTooltips(inst.reference);
-          if (blockedByTippy(inst.reference)) { return false; }
-
-        } else if (inst.reference.querySelector(\".hover-info\") || \"versoHover\" in inst.reference.dataset) {
-          if (blockedByTactic(inst.reference)) { return false };
-          if (blockedByTippy(inst.reference)) { return false; }
+        } else if (ref.querySelector(\".hover-info\") || \"versoHover\" in ref.dataset) {
+          if (blockedByTactic(ref)) { return false };
         } else { // Nothing to show here!
           return false;
         }
+        // Show only the most specific hover under the pointer
+        if (hoverTarget && ref.contains(hoverTarget) && innermostShowable(hoverTarget) !== ref) {
+          return false;
+        }
+        hideParentTooltips(ref);
+        hideDescendantTooltips(ref);
+        if (blockedByTippy(ref)) { return false; }
       },
-      onShown(inst) { visibleTippyCount++; },
-      onHidden(inst) { visibleTippyCount = Math.max(0, visibleTippyCount - 1); },
+      onShown(inst) { visibleTippies.add(inst.reference); },
+      onHidden(inst) { visibleTippies.delete(inst.reference); },
       content (tgt) {
         const content = document.createElement(\"span\");
         if (tgt.className == 'tactic') {
@@ -1499,35 +1692,22 @@ window.onload = async () => {
           content.style.maxHeight = \"300px\";
           content.style.overflowY = \"auto\";
           content.style.overflowX = \"hidden\";
+          // Messages come from the inline hover-info; documentation comes from the doc
+          // table. An element with both (a message span sharing a documented token's
+          // extent) shows both in one tooltip.
           const hoverId = tgt.dataset.versoHover;
           const hoverInfo = tgt.querySelector(\".hover-info\");
-          if (hoverId) { // Docstrings from the table
-            // TODO stop doing an implicit conversion from string to number here
-            let data = versoDocData[hoverId];
-            if (data) {
-              const info = document.createElement(\"span\");
-              info.className = \"hover-info\";
-              info.style.display = \"block\";
-              info.innerHTML = data;
-              content.appendChild(info);
-              /* Render docstrings - TODO server-side */
-              if ('undefined' !== typeof marked) {
-                  for (const d of content.querySelectorAll(\"code.docstring, pre.docstring\")) {
-                      const str = d.innerText;
-                      const html = marked.parse(str);
-                      const rendered = document.createElement(\"div\");
-                      rendered.classList.add(\"docstring\");
-                      rendered.innerHTML = html;
-                      d.parentNode.replaceChild(rendered, d);
-                  }
-              }
-            } else {
-              content.innerHTML = \"Failed to load doc ID: \" + hoverId;
-            }
-          } else if (hoverInfo) { // The inline info, still used for compiler messages
+          if (hoverInfo) {
             content.appendChild(hoverInfo.cloneNode(true));
           }
-          const extraLinks = tgt.parentElement.dataset['versoLinks'];
+          if (hoverId) {
+            // TODO stop doing an implicit conversion from string to number here
+            content.appendChild(docHoverContent(hoverId));
+          }
+          if (hoverInfo && hoverId) {
+            content.classList.add('mixed');
+          }
+          const extraLinks = tgt.dataset['versoLinks'] || tgt.parentElement.dataset['versoLinks'];
           if (extraLinks) {
             try {
               const extras = JSON.parse(extraLinks);
@@ -1585,17 +1765,26 @@ window.onload = async () => {
       if (toggle) toggle.addEventListener('change', () => {
         if (toggle.checked) {
           closedTactics.delete(tactic);
-          tactic.querySelectorAll('.token').forEach(tok => {
-            if (!tok._tippy && tok.matches(tacticTippySelector)) {
-              tippy(tok, defaultTippyProps);
+          tactic.querySelectorAll(tacticTippySelector).forEach(el => {
+            if (!el._tippy) {
+              tippy(el, defaultTippyProps);
             }
           });
         } else {
           closedTactics.add(tactic);
-          tactic.querySelectorAll('.token').forEach(tok => {
-            if (tok._tippy) tok._tippy.destroy();
+          tactic.querySelectorAll(tacticTippySelector).forEach(el => {
+            if (el._tippy) el._tippy.destroy();
           });
         }
+        // The toggle changes which element's tooltip belongs to the pointer's position,
+        // but the pointer stays put, so no hover event announces the change. Show the
+        // right tooltip once the click that flipped the toggle has hidden the old one.
+        setTimeout(() => {
+          if (hoverTarget && hoverTarget.isConnected) {
+            const showable = innermostShowable(hoverTarget);
+            if (showable && showable._tippy) showable._tippy.show();
+          }
+        }, 0);
       });
   });
 }

--- a/static-web/verso-vars.css
+++ b/static-web/verso-vars.css
@@ -15,19 +15,76 @@
     /** Selected items (e.g. search results) */
     --verso-selected-color: #def;
 
+    /** Tooltips **/
+    /*
+    These colors are used for the tooltips that display documentation and messages for code,
+    and for the equivalent popups that are shown when scripts are unavailable. The
+    severity-specific tooltip colors below default to the foreground and background given
+    here. The separator color draws the rule between sections of a tooltip's content.
+    */
+    --verso-tooltip-color: black;
+    --verso-tooltip-bg-color: #e5e5e5;
+    --verso-tooltip-border-color: black;
+    --verso-tooltip-separator-color: #ccc;
+
     /** Message colors **/
     /*
-    These colors are used to render Lean's feedback. They come in three severities and two
-    variants. The raw color itself is used for the text of a message of the indicated severity,
-    while the presence of such a message is indicated using the indicator color (e.g. via a
-    wavy underline or a bar in the margin).
+    These colors are used to render Lean's feedback. Each severity (info, warning, error)
+    colors four surfaces:
+
+    - The affected code itself: foreground and background, both at rest and while hovered,
+      plus the indicator color, which draws the wavy underline marking that a message is
+      present.
+    - The text of the message, via the message color.
+    - The tooltip that displays the message: foreground, background, and border. The border
+      color also draws the accent bar next to a message when it is shown without scripts,
+      and the background also colors the tooltip's arrow.
+    - The marker bar in the margin of output blocks, via the output color.
     */
-    --verso-info-color: black;
+    --verso-code-info-color: currentcolor;
+    --verso-code-info-bg-color: transparent;
+    --verso-code-info-hover-color: currentcolor;
+    --verso-code-info-hover-bg-color: #4777ff;
     --verso-info-indicator-color: #4777ff;
-    --verso-warning-color: black;
+    --verso-message-info-color: black;
+    --verso-tooltip-info-color: var(--verso-tooltip-color);
+    --verso-tooltip-info-bg-color: var(--verso-tooltip-bg-color);
+    --verso-tooltip-info-border-color: #4777ff;
+    --verso-output-info-color: var(--verso-info-indicator-color);
+
+    --verso-code-warning-color: currentcolor;
+    --verso-code-warning-bg-color: transparent;
+    --verso-code-warning-hover-color: currentcolor;
+    --verso-code-warning-hover-bg-color: #ffd580;
     --verso-warning-indicator-color: #e7a71d; /* 2.11 contrast ratio for white, 9.94 for black */
-    --verso-error-color: #cc0000;
+    --verso-message-warning-color: black;
+    --verso-tooltip-warning-color: var(--verso-tooltip-color);
+    --verso-tooltip-warning-bg-color: var(--verso-tooltip-bg-color);
+    --verso-tooltip-warning-border-color: #ffd580;
+    --verso-output-warning-color: var(--verso-warning-indicator-color);
+
+    --verso-code-error-color: currentcolor;
+    --verso-code-error-bg-color: transparent;
+    --verso-code-error-hover-color: currentcolor;
+    --verso-code-error-hover-bg-color: #ffb3b3;
     --verso-error-indicator-color: #ff0000;
+    --verso-message-error-color: #cc0000;
+    --verso-tooltip-error-color: var(--verso-tooltip-color);
+    --verso-tooltip-error-bg-color: var(--verso-tooltip-bg-color);
+    --verso-tooltip-error-border-color: #ffb3b3;
+    --verso-output-error-color: var(--verso-error-indicator-color);
+
+    /** Proof states **/
+    /*
+    These colors are used for the proof state displays that can be expanded inside of proofs
+    and shown in tooltips. The toggle colors are used for the control that expands and
+    collapses a proof state.
+    */
+    --verso-tactic-state-color: black;
+    --verso-tactic-state-bg-color: white;
+    --verso-tactic-state-border-color: #888888;
+    --verso-tactic-toggle-color: #bbbbbb;
+    --verso-tactic-toggle-checked-color: #999999;
 
     /** Code Highlighting **/
     /*
@@ -51,4 +108,8 @@
     --verso-code-var-weight: normal;
     --verso-code-var-style: italic;
     --verso-code-kw-font-family: var(--verso-code-font-family);
+
+    /* The background of interactive code while hovered (hoverable tokens, occurrences of a
+       hovered binding, and the tactics that expand to a proof state) */
+    --verso-code-hover-bg-color: #eeeeee;
 }

--- a/test-projects/anchor-examples/lake-manifest.json
+++ b/test-projects/anchor-examples/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "e0df519e7fc6e8ff9c669f2036e35b2fc9671fa9",
+      "rev": "ea0dc0d7f5c725f64f20aecb44d90c6fbf59ee14",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/documented-package/lake-manifest.json
+++ b/test-projects/documented-package/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "e0df519e7fc6e8ff9c669f2036e35b2fc9671fa9",
+      "rev": "ea0dc0d7f5c725f64f20aecb44d90c6fbf59ee14",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/literate-config/LitConfig.lean
+++ b/test-projects/literate-config/LitConfig.lean
@@ -2,6 +2,7 @@ import LitConfig.Core
 import LitConfig.NoDocstrings
 import LitConfig.Builtins
 import LitConfig.UserExt
+import LitConfig.Gallery
 import Verso
 
 /-!

--- a/test-projects/literate-config/LitConfig/Gallery.lean
+++ b/test-projects/literate-config/LitConfig/Gallery.lean
@@ -1,0 +1,139 @@
+import Lean.Elab.Tactic
+
+/-!
+# Code Rendering Gallery
+
+This module exercises every kind of code rendering that Verso produces: messages of
+each severity with their hover tooltips, proof states both collapsed and expanded,
+output blocks, and documentation hovers. Browser tests and visual inspection use this
+page, so it should contain at least one instance of every rendering.
+
+## Warnings
+
+The unfinished definition below carries a {lit}`sorry` warning: its name is underlined,
+and hovering it shows the warning tooltip.
+-/
+
+/-- Sorts a list, eventually. -/
+def gallerySort (xs : List Nat) : List Nat := sorry
+
+/-!
+A deprecated constant's use site also warns.
+-/
+
+/-- The old name for {name}`gallerySort`. -/
+@[deprecated gallerySort (since := "2026-08-10")]
+def oldGallerySort (xs : List Nat) : List Nat := gallerySort xs
+
+example : List Nat → List Nat := oldGallerySort
+
+/-!
+## Information
+
+Evaluation and elaboration commands produce informational messages, shown both as
+hovers on the command and as output blocks.
+-/
+
+#eval 2 + 2
+
+#check List.length
+
+/-!
+## Errors
+
+The code block below fails to elaborate; the diagnostic is attached to the erroneous
+code and shown on hover.
+
+```lean +error
+example : Nat := "three"
+```
+-/
+
+/-!
+## Proof States
+
+Tactic proofs carry proof states: hover a tactic to see its state, or click it to
+expand the state inline. Case analysis also shows case labels.
+-/
+
+theorem galleryAddZero (n : Nat) : n + 0 = n := by
+  induction n with
+  | zero => rfl
+  | succ k ih => rfl
+
+/-!
+A proof that uses {kw (cat := tactic)}`sorry` mixes a warning with proof states.
+-/
+
+theorem gallerySorted : 1 + 1 = 2 := by
+  have h : 2 = 2 := by rfl
+  sorry
+
+open Lean Elab Tactic in
+/-- Runs a tactic sequence, first logging a warning that covers the whole proof. -/
+elab "flag_proof" ts:tacticSeq : tactic => do
+  logWarning "This proof is flagged for review."
+  evalTactic ts
+
+/-!
+A message can also cover an entire proof, so that the tactics and their proof states are
+nested inside the message's span. The {tactic}`flag_proof` tactic warns with the whole
+proof as its range.
+-/
+
+theorem galleryFlagged (n : Nat) : n + 0 = n := by
+  flag_proof
+    induction n with
+    | zero => rfl
+    | succ k ih => rfl
+
+open Lean Elab Tactic in
+/-- Runs a tactic sequence, first logging an informational note that covers the whole proof. -/
+elab "note_proof" ts:tacticSeq : tactic => do
+  logInfo "This proof is worth reading."
+  evalTactic ts
+
+/-!
+Message regions nest: the whole proof below carries an informational note, and a warning
+covers one of its branches.
+-/
+
+theorem galleryNoted (n : Nat) : n + 0 = n := by
+  note_proof
+    induction n with
+    | zero => flag_proof rfl
+    | succ k ih => rfl
+
+open Lean Elab Tactic in
+/-- Runs a tactic sequence, first logging a warning and an informational note that both
+cover the whole proof. -/
+elab "flag_and_note_proof" ts:tacticSeq : tactic => do
+  logWarning "This proof is flagged for review."
+  logInfo "This proof is worth reading."
+  evalTactic ts
+
+/-!
+Messages of different severities can also cover exactly the same range. The region is
+styled by the most severe message, and its hover shows both, each with its own severity
+styling.
+-/
+
+theorem galleryFlaggedAndNoted (n : Nat) : n + 0 = n := by
+  flag_and_note_proof rfl
+
+/-!
+Messages can also sit inside a proof: the warning below is shown within the tactics, and
+its tooltip is also available when the surrounding proof state is expanded.
+-/
+
+def galleryOldInProof : List Nat := by
+  exact oldGallerySort []
+
+/-!
+## Documentation Hovers
+
+Constants with docstrings show them on hover: {name}`gallerySort` has one, and so do
+the standard-library names below.
+-/
+
+example : Nat := Nat.succ (List.length [1, 2, 3])

--- a/test-projects/website-examples/lake-manifest.json
+++ b/test-projects/website-examples/lake-manifest.json
@@ -6,7 +6,7 @@
       "url": "https://github.com/leanprover/subverso",
       "type": "git",
       "subDir": null,
-      "rev": "e0df519e7fc6e8ff9c669f2036e35b2fc9671fa9",
+      "rev": "ea0dc0d7f5c725f64f20aecb44d90c6fbf59ee14",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",

--- a/test-projects/website-literate/lake-manifest.json
+++ b/test-projects/website-literate/lake-manifest.json
@@ -7,7 +7,7 @@
       "type": "git",
       "subDir": null,
       "scope": "",
-      "rev": "e0df519e7fc6e8ff9c669f2036e35b2fc9671fa9",
+      "rev": "ea0dc0d7f5c725f64f20aecb44d90c6fbf59ee14",
       "name": "subverso",
       "manifestFile": "lake-manifest.json",
       "inputRev": "main",


### PR DESCRIPTION
This PR fixes limitations in highlighting behavior:

* The colors of messages are more consistently controlled by variables, elminating a problem with warning hovers and making it easier to configure all colors.

* Hover highlights for nested messages are fixed, and their CSS simplified.

* When message and token hover spans coincide, they are collapsed, rather than having one of them win over the other. Before, this was done only for multiple message spans.

* Some edge cases related to tooltip precedence are fixed.

An added gallery page in the tests demonstrates these combinations.