### PR TITLE
feat: re-enable `precompileModules`

### DIFF
--- a/doc/UsersGuide/Elab.lean
+++ b/doc/UsersGuide/Elab.lean
@@ -67,6 +67,15 @@ Each genre provides a `main` function that will carry out the remainder of the s
 Usually, this `main` function can be applied to the part that represents the whole document; however, genres that don't have a strict linear order (such as the {ref "website"}[website genre]) will provide their own means of configuring the document's layout.
 The `main` function typically also takes configuration parameters both in the code and on the command line, such as which output formats to generate or customizations to the generated output.
 
+Tip: for projects with large dependencies such as mathlib,
+compiling the document to a native executable can take a long time.
+For faster rebuilds,
+you can try running the `main` function through the Lean interpreter instead:
+invoke `lake lean Main.lean --run Main.lean` in your shell,
+where `Main.lean` is the file in which the genre `main` function is called
+with your document as an argument.
+Future updates to the Verso build process may make this the default.
+
 # Traversal
 %%%
 tag := "traversal"

--- a/doc/UsersGuide/Elab.lean
+++ b/doc/UsersGuide/Elab.lean
@@ -67,13 +67,9 @@ Each genre provides a `main` function that will carry out the remainder of the s
 Usually, this `main` function can be applied to the part that represents the whole document; however, genres that don't have a strict linear order (such as the {ref "website"}[website genre]) will provide their own means of configuring the document's layout.
 The `main` function typically also takes configuration parameters both in the code and on the command line, such as which output formats to generate or customizations to the generated output.
 
-Tip: for projects with large dependencies such as mathlib,
-compiling the document to a native executable can take a long time.
-For faster rebuilds,
-you can try running the `main` function through the Lean interpreter instead:
-invoke `lake lean Main.lean --run Main.lean` in your shell,
-where `Main.lean` is the file in which the genre `main` function is called
-with your document as an argument.
+Tip: for projects with large dependencies such as Mathlib, compiling the document to a native executable can take a long time.
+It is often faster to run the `main` function through the Lean interpreter instead.
+To do so, invoke `lake lean Main.lean --run Main.lean` in your shell, where `Main.lean` is the file in which the genre's `main` function is called with your document as an argument.
 Future updates to the Verso build process may make this the default.
 
 # Traversal

--- a/doc/UsersGuide/Serve.lean
+++ b/doc/UsersGuide/Serve.lean
@@ -31,7 +31,7 @@ tag := "serve-running"
 The `verso-serve` command takes an optional port (8000 by default) and an optional directory (the current directory by default).
 
 ```
-$ lake exe serve --port 8000 _out/html
+$ lake exe verso-serve --port 8000 _out/html
 ```
 :::
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -7,7 +7,7 @@ require plausible from git "https://github.com/leanprover-community/plausible"@"
 require illuminate from git "https://github.com/leanprover/illuminate"@"main"
 
 package verso where
-  precompileModules := false -- temporarily disabled to work around an issue with nightly-2025-03-30
+  precompileModules := true
   leanOptions := #[⟨`experimental.module, true⟩]
 
 @[default_target]


### PR DESCRIPTION
This PR re-enables `precompileModules` and documents how this can be leveraged to speed up rebuilds as a tip.

No-Changelog: internal optimization detail.

We do not change Verso's benchmarking configuration at this time - it will continue to measure build times for the default setup (with native-compiled `Main` executables), as experienced by most users (though [leanprover/verso-blueprint](https://github.com/leanprover/verso-blueprint)'s `vbp build` CLI should immediately benefit from this).

Benchmark results *with interpreted `Main`* and `precompileModules`:
- Cold build (from scratch to HTML via CLI) times increase or reduce depending on specifics of the project and hardware. They are more likely to increase on highly parallel hardware since the build graph is now more serial (and the critical path longer). They are more likely to reduce when many modules (e.g. Mathlib) are imported by `Main` since we don't compile these when interpreting `Main`.
- Rebuild (from editing the doc to HTML via CLI) and LSP re-elaboration (from editing the doc interactively to LSP server quiescence) reduce by 10–30%.

Raw radar data:
- `runner-leanN` with `nproc` (48?) cores
  - [Cold build](https://radar.lean-lang.org/repos/verso/commits/cdab24cbc7afe9103b305e42e54bea5ee9f320b8?s=/build/.total//wall)
  
| Metric | Submetric | Value | Ref | Delta | Delta% |
|---|---|---|---|---|---|
| blueprint-natson-o0/build/.total | wall clock time | 2m 6s | 2m 9s | -2s | -1.8% |
| blueprint-natson/build/.total | wall clock time | 2m 6s | 2m 18s | -11s | -8.4% |
| lean4cs1-o0/build/.total | wall clock time | 1m 21s | 53s | +28s | +53.3% |
| lean4cs1/build/.total | wall clock time | 1m 21s | 53s | +28s | +52.8% |
| refman/build/.total | wall clock time | 2m 42s | 2m 1s | +41s | +34.5% |
| sherlock-o0/build/.total | wall clock time | 1m 25s | 49s | +35s | +71.4% |
| sherlock/build/.total | wall clock time | 1m 25s | 50s | +34s | +68.0% |

  - [Rebuild](https://radar.lean-lang.org/repos/verso/commits/cdab24cbc7afe9103b305e42e54bea5ee9f320b8?s=/rebuild/.total//wall)

| Metric | Submetric | Value | Ref | Delta | Delta% |
|---|---|---|---|---|---|
| blueprint-natson-o0/rebuild/.total | wall clock time | 28s | 33s | -4s | -14.1% |
| blueprint-natson/rebuild/.total | wall clock time | 29s | 42s | -13s | -30.8% |
| lean4cs1-o0/rebuild/.total | wall clock time | 3s | 4s | -1s | -22.2% |
| lean4cs1/rebuild/.total | wall clock time | 3s | 4s | -1s | -23.3% |
| refman/rebuild/.total | wall clock time | 9s | 11s | -1s | -12.6% |
| sherlock-o0/rebuild/.total | wall clock time | 3s | 3s | -268ms | -7.2% |
| sherlock/rebuild/.total | wall clock time | 3s | 3s | -199ms | -5.4% |

  - [LSP re-elaboration (from interactive doc edit to LSP server quiescence)](https://radar.lean-lang.org/repos/verso/commits/cdab24cbc7afe9103b305e42e54bea5ee9f320b8?s=/lsp-elab/.%2B//wall)

| Metric | Submetric | Value | Ref | Delta | Delta% |
|---|---|---|---|---|---|
| blueprint-natson-o0/lsp-elab/CarlesonBlueprint.Chapters.Main | wall clock time | 15s | 19s | -3s | -17.1% |
| blueprint-natson/lsp-elab/CarlesonBlueprint.Chapters.Main | wall clock time | 15s | 19s | -3s | -17.8% |
| lean4cs1-o0/lsp-elab/FPCourse.Unit1.Week00_AlgebraicTypes | wall clock time | 829ms | 1s | -348ms | -29.6% |
| lean4cs1/lsp-elab/FPCourse.Unit1.Week00_AlgebraicTypes | wall clock time | 824ms | 1s | -358ms | -30.3% |
| refman/lsp-elab/Manual.Tactics | wall clock time | 3s | 3s | -388ms | -10.7% |
| sherlock-o0/lsp-elab/Sherlock.Study001 | wall clock time | 698ms | 1s | -334ms | -32.4% |
| sherlock/lsp-elab/Sherlock.Study001 | wall clock time | 701ms | 1s | -342ms | -32.8% |

- `runner-leanN` limited to 4 cores (emulating GitHub's CI runners or a small laptop)
  - [Cold build](https://radar.lean-lang.org/repos/verso/commits/bd22bce7c915aceeeb3de93736dd01f217099f8a?reference=6007d0593205661a4cb7db4afc54f61439aa4697&s=/build/.total//wall)

| Metric | Submetric | Value | Ref | Delta | Delta% |
|---|---|---|---|---|---|
| blueprint-natson-o0/build/.total | wall clock time | 2m 28s | 4m 20s | -1m 51s | -43.0% |
| blueprint-natson/build/.total | wall clock time | 2m 27s | 4m 31s | -2m 4s | -45.9% |
| lean4cs1-o0/build/.total | wall clock time | 1m 38s | 2m 7s | -28s | -22.5% |
| lean4cs1/build/.total | wall clock time | 1m 38s | 2m 7s | -29s | -22.9% |
| refman/build/.total | wall clock time | 5m 3s | 4m 59s | +3s | +1.2% |
| sherlock-o0/build/.total | wall clock time | 1m 49s | 1m 33s | +16s | +17.2% |
| sherlock/build/.total | wall clock time | 1m 49s | 1m 37s | +12s | +12.4% |

  - [Rebuild](https://radar.lean-lang.org/repos/verso/commits/bd22bce7c915aceeeb3de93736dd01f217099f8a?reference=6007d0593205661a4cb7db4afc54f61439aa4697&s=/rebuild/.total//wall)

| Metric | Submetric | Value | Ref | Delta | Delta% |
|---|---|---|---|---|---|
| blueprint-natson-o0/rebuild/.total | wall clock time | 29s | 33s | -4s | -13.7% |
| blueprint-natson/rebuild/.total | wall clock time | 29s | 42s | -13s | -31.4% |
| lean4cs1-o0/rebuild/.total | wall clock time | 3s | 4s | -1s | -22.7% |
| lean4cs1/rebuild/.total | wall clock time | 3s | 4s | -1s | -24.8% |
| refman/rebuild/.total | wall clock time | 9s | 11s | -1s | -11.2% |
| sherlock-o0/rebuild/.total | wall clock time | 3s | 3s | -274ms | -7.5% |
| sherlock/rebuild/.total | wall clock time | 3s | 3s | -279ms | -7.6% |

  - [LSP re-elaboration](https://radar.lean-lang.org/repos/verso/commits/bd22bce7c915aceeeb3de93736dd01f217099f8a?reference=6007d0593205661a4cb7db4afc54f61439aa4697&s=/lsp-elab.%2Bwall)


| Metric | Submetric | Value | Ref | Delta | Delta% |
|---|---|---|---|---|---|
| blueprint-natson-o0/lsp-elab/CarlesonBlueprint.Chapters.Main | wall clock time | 15s | 19s | -3s | -18.6% |
| blueprint-natson/lsp-elab/CarlesonBlueprint.Chapters.Main | wall clock time | 16s | 19s | -3s | -17.7% |
| lean4cs1-o0/lsp-elab/FPCourse.Unit1.Week00_AlgebraicTypes | wall clock time | 831ms | 1s | -347ms | -29.5% |
| lean4cs1/lsp-elab/FPCourse.Unit1.Week00_AlgebraicTypes | wall clock time | 829ms | 1s | -359ms | -30.2% |
| refman/lsp-elab/Manual.Tactics | wall clock time | 3s | 3s | -431ms | -11.9% |
| sherlock-o0/lsp-elab/Sherlock.Study001 | wall clock time | 716ms | 1s | -335ms | -31.9% |
| sherlock/lsp-elab/Sherlock.Study001 | wall clock time | 725ms | 1s | -338ms | -31.8% |