### PR TITLE
fix: restore syntax highlighting

### DIFF
--- a/src/verso/Verso/Code/Highlighted.lean
+++ b/src/verso/Verso/Code/Highlighted.lean
@@ -975,7 +975,7 @@ severity accent to distinguish them.
   border: none;
 }
 
-.error .verso-message, .error .verso-message .token, .error .verso-message label {
+.error .verso-message, .error .verso-message label {
   color: var(--verso-message-error-color, #cc0000);
 }
 
@@ -1020,7 +1020,7 @@ severity accent to distinguish them.
   border: none;
 }
 
-.warning .verso-message, .warning .verso-message .token, .warning .verso-message label {
+.warning .verso-message, .warning .verso-message label {
   color: var(--verso-message-warning-color, black);
 }
 
@@ -1048,7 +1048,7 @@ severity accent to distinguish them.
   border: none;
 }
 
-.information .verso-message, .information .verso-message .token, .information .verso-message label {
+.information .verso-message, .information .verso-message label {
   color: var(--verso-message-info-color, black);
 }
 


### PR DESCRIPTION
It seems pull request #954 broke syntax highlighting in message outputs (at least in the latest verso-slides)? 

The entire text would be `--verso-message-info-color` and would default to black:
<img width="334" height="147" alt="Image" src="https://github.com/user-attachments/assets/eb0d48cf-b732-4feb-83b7-51b4c41ab738" />

I used an LLM to find and write this fix, and in conjunction with a patch to `verso-slides` ([verso-slides#71](https://github.com/leanprover/verso-slides/pull/71)) to use the new CSS variables, this restores the old behavior:
<img width="592" height="272" alt="image" src="https://github.com/user-attachments/assets/ac381b04-bd28-45c0-b3e8-22b3b4277be3" />