### PR TITLE
fix: preserve section anchors on manual headings

### DIFF
--- a/doc/UsersGuide/Releases/Entries.lean
+++ b/doc/UsersGuide/Releases/Entries.lean
@@ -24,5 +24,6 @@ public import UsersGuide.Releases.Entries.MethodInMultiVerso
 public import UsersGuide.Releases.Entries.ReleaseNotesChapter
 public import UsersGuide.Releases.Entries.RoleDiagnostics
 public import UsersGuide.Releases.Entries.SearchPriority
+public import UsersGuide.Releases.Entries.SectionAnchors
 public import UsersGuide.Releases.Entries.TestFramework
 public import UsersGuide.Releases.Entries.VersionedReleaseNotes

--- a/doc/UsersGuide/Releases/Entries/SectionAnchors.lean
+++ b/doc/UsersGuide/Releases/Entries/SectionAnchors.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+module
+
+public import UsersGuide.Releases.Entry
+
+open Verso.Genre Manual InlineLean UsersGuide.Releases
+
+release_note
+  version := ⟨4, 34, 0⟩
+  breaking := true
+  tag := "manual-heading-anchors"
+  prs := [983]
+
+#doc (Manual) "Manual Heading Anchors" =>
+
+Manual title pages and chapters rendered on separate pages now emit their registered section IDs on their headings, so references to these sections resolve correctly.
+The fix also applies to the document title in single-page output.
+
+Breaking change: {name}`Verso.Genre.Manual.Html.titlePage` now takes a {name}`Verso.Genre.Manual.Heading` as its first argument instead of plain title HTML.
+Callers must supply the heading's level, optional ID, and HTML content.
+Manual renderers can use {name}`Verso.Genre.Manual.partHeading` to construct a heading with the registered anchor, section number, and permalink.

--- a/src/tests/VersoTests/Integration/SectionAnchors.lean
+++ b/src/tests/VersoTests/Integration/SectionAnchors.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Emilio J. Gallego Arias
+-/
+module
+public import Verso
+public import VersoManual
+public meta import Verso
+public meta import VersoManual
+import Errata
+
+namespace Verso.Integration.SectionAnchors
+
+open Lean Verso Genre Manual
+
+#docs (Manual) doc "Section Anchors" :=
+:::::::
+%%%
+tag := "manual-root"
+%%%
+
+See {ref "tagged-chapter"}[the chapter] and {ref "nested-section"}[its section].
+
+# Tagged Chapter
+%%%
+tag := "tagged-chapter"
+%%%
+
+Return to {ref "manual-root"}[the title page].
+
+## Nested Section
+%%%
+tag := "nested-section"
+%%%
+
+This section stays on its chapter's page.
+
+# Automatic Chapter
+
+This chapter gets an automatically generated tag.
+:::::::
+
+/-- Every exported section target must occur exactly once, on a heading in its declared page. -/
+private def checkAnchors (mode : Mode) (htmlDepth : Nat := 1) : IO Unit := IO.FS.withTempDir fun destination => do
+  let cfg : RenderConfig := { destination, htmlDepth, features := {} }
+  let (traverse, emit, directory) := match mode with
+    | .single => (traverseHtmlSingle, emitHtmlSingle, "html-single")
+    | .multi => (traverseHtmlMulti, emitHtmlMulti, "html-multi")
+  let site := destination / directory
+  let exitCode ← withLogger fun logger => do
+    let (part, state) ← (traverse cfg doc.toPart).run extension_impls% |>.run logger
+    emitXrefsJson site state
+    (emit cfg part state).run extension_impls% |>.run logger
+  unless exitCode == 0 do
+    throw <| IO.userError "Section anchor document generation logged errors"
+  let xrefs ← IO.ofExcept <| Json.parse (← IO.FS.readFile (site / "xref.json"))
+  let sections ← IO.ofExcept <| xrefs.getObjVal? "Verso.Genre.Manual.section"
+  let contents ← IO.ofExcept <| sections.getObjVal? "contents"
+  let entries ← IO.ofExcept contents.getObj?
+  unless entries.size == 4 do
+    throw <| IO.userError s!"Expected four section targets, got {entries.size}"
+  for tag in ["manual-root", "tagged-chapter", "nested-section"] do
+    discard <| IO.ofExcept <| contents.getObjVal? tag
+  for (tag, targets) in entries.toArray do
+    let targets ← IO.ofExcept targets.getArr?
+    unless targets.size == 1 do
+      throw <| IO.userError s!"Expected one destination for {tag}"
+    let target := targets[0]!
+    let address ← IO.ofExcept <| target.getObjValAs? String "address"
+    let id ← IO.ofExcept <| target.getObjValAs? String "id"
+    let page := (address.splitOn "/").filter (!·.isEmpty) |>.foldl (· / ·) site
+    let html ← IO.FS.readFile (page / "index.html")
+    let count := (html.splitOn s!" id=\"{id}\"").length - 1
+    unless count == 1 do
+      throw <| IO.userError s!"{tag}: expected exactly one id=\"{id}\" in {address}, got {count}"
+    unless (List.range 6).any (fun n => (html.splitOn s!"<h{n + 1} id=\"{id}\">").length == 2) do
+      throw <| IO.userError s!"{tag}: expected id=\"{id}\" on a heading in {address}"
+
+/-- Single-page manual headings contain every exported section target exactly once. -/
+@[test]
+def singlePageSectionAnchors : Errata.Test := do
+  checkAnchors .single
+
+/-- Multi-page manual headings retain their anchors at each splitting depth. -/
+@[test]
+def multiPageSectionAnchors : Errata.Test := do
+  for depth in [0, 1, 2] do
+    checkAnchors .multi depth

--- a/src/verso-manual/VersoManual.lean
+++ b/src/verso-manual/VersoManual.lean
@@ -763,6 +763,8 @@ where
     let definitionIds := state.definitionIds ctxt
     let linkTargets := config.linkTargets state (← readThe AllRemotes)
     let titleHtml ← Html.seq <$> text.title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets {})
+    let heading :=
+      partHeading state ctxt (text.metadata.bind (·.id)) 1 titleHtml (showNumber := false) (showPermalink := false)
     let introHtml ← Html.seq <$> text.content.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets {})
     let bookToc ← text.subParts.mapM (fun p => toc 0 opts (ctxt.inPart p) state definitionIds linkTargets p)
     let bookTocHtml := open Verso.Output.Html in
@@ -778,7 +780,7 @@ where
         Manual.toHtml { opts with headerLevel := 2 } (ctxt.inPart p) state definitionIds linkTargets {} p
     let pageContent := open Verso.Output.Html in
       {{<section>
-          {{Html.titlePage titleHtml authors authorshipNote introHtml}}
+          {{Html.titlePage heading authors authorshipNote introHtml}}
           {{bookTocHtml}}
           {{contents}}
         </section>}}
@@ -890,13 +892,8 @@ where
       (root : Bool) (depth : Nat) (dir : System.FilePath) (part : Part Manual) : StateT (State Html) (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) Unit := do
     let thisFile := part.metadata.bind (·.file) |>.getD (part.titleString.sluggify.toString)
     let dir := if root then dir else dir.join thisFile
-    let sectionNum := sectionHtml ctxt
-    let pageTitleHtml := sectionNum ++ (← Html.seq <$> part.title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets codeOptions))
-    let titleHtml :=
-      pageTitleHtml ++
-      if let some id := part.metadata.bind (·.id) then
-        permalink id state
-      else .empty
+    let titleHtml ← Html.seq <$> part.title.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets codeOptions)
+    let heading := partHeading state ctxt (part.metadata.bind (·.id)) 1 titleHtml
     let introHtml ← Html.seq <$> part.content.mapM (Manual.toHtml opts ctxt state definitionIds linkTargets codeOptions)
     let contents ←
       if depth == 0 || part.htmlSplit == .never then
@@ -925,13 +922,13 @@ where
             </section>
           }}
         else .empty
-        {{<section>{{Html.titlePage titleHtml authors authorshipNote introHtml ++ contents}} {{subTocHtml}}</section>}}
+        {{<section>{{Html.titlePage heading authors authorshipNote introHtml ++ contents}} {{subTocHtml}}</section>}}
       else
         let subTocHtml :=
           if (depth > 0 && part.htmlSplit != .never) && subToc.size > 0 && part.htmlToc then
             {{<ol class="section-toc">{{subToc.map (·.html config.sectionTocDepth)}}</ol>}}
           else .empty
-        {{<section><h1>{{titleHtml}}</h1> {{introHtml}} {{contents}} {{subTocHtml}}</section>}}
+        {{<section>{{heading.toHtml}} {{introHtml}} {{contents}} {{subTocHtml}}</section>}}
 
     ensureDir dir
     IO.FS.withFile (dir.join "index.html") .write fun h => do

--- a/src/verso-manual/VersoManual/Basic.lean
+++ b/src/verso-manual/VersoManual/Basic.lean
@@ -1606,20 +1606,39 @@ def permalink (id : InternalId) (st : TraverseState) (inline : Bool := true) : H
       </span>
     }}
 
+/-- A manual heading whose level, anchor, and contents are rendered together. -/
+structure Heading where
+  /-- The HTML heading level. -/
+  level : Nat
+  /-- The registered HTML anchor, or none for an unanchored heading. -/
+  id : Option Slug
+  /-- The heading contents, including any section number and permalink widget. -/
+  content : Html
+
+/-- Renders the heading element and its optional anchor. -/
+def Heading.toHtml (heading : Heading) : Html :=
+  let attrs := heading.id.map (fun id => #[("id", id.toString)]) |>.getD #[]
+  .tag s!"h{heading.level}" attrs heading.content
+
+/--
+Constructs a manual heading with its registered anchor, section number, and permalink.
+The single-page document title omits numbering and the permalink by setting
+{name}`showNumber` and {name}`showPermalink` to false.
+-/
+def partHeading (state : TraverseState) (ctxt : TraverseContext) (id : Option InternalId)
+    (level : Nat) (title : Html) (showNumber : Bool := true) (showPermalink : Bool := true) : Heading :=
+  let numberHtml := if showNumber then sectionHtml ctxt else .empty
+  let permalinkHtml := if showPermalink then id.map (permalink · state) |>.getD .empty else .empty
+  { level,
+    id := id.bind (fun id => state.externalTags[id]?) |>.map (·.htmlId),
+    content := numberHtml ++ title ++ permalinkHtml }
 
 open Verso.Output.Html in
 instance : Html.GenreHtml Manual (ReaderT AllRemotes (ReaderT ExtensionImpls (BuildLogT IO))) where
   part go «meta» txt := do
     let st ← Verso.Doc.Html.HtmlT.state
-    let attrs := meta.id.map (st.htmlId) |>.getD #[]
     let ctxt ← Verso.Doc.Html.HtmlT.context
-    let sectionNumber : Html := sectionHtml ctxt
-    let permalink? m :=
-      if let some id := m.id then permalink id st
-      else .empty
-    let mkHeader lvl content :=
-      .tag s!"h{lvl}" attrs (sectionNumber ++ content ++ permalink? «meta»)
-    go txt mkHeader
+    go txt fun level title => (partHeading st ctxt meta.id level title).toHtml
 
   block goI goB b content := do
     let some id := b.id

--- a/src/verso-manual/VersoManual/Html.lean
+++ b/src/verso-manual/VersoManual/Html.lean
@@ -379,9 +379,13 @@ where
       | none => {{<span class="unnumbered"></span>}}
       | some ns => {{<span class="number">{{sectionNumberString ns}}</span>" "}}
 
-public def titlePage (title : Html) (authors : List String) (authorshipNote : Option String) (intro : Html) : Html := {{
+/--
+Renders a manual's title page using the supplied heading's level, anchor, and contents.
+-/
+public def titlePage (heading : Heading) (authors : List String) (authorshipNote : Option String)
+    (intro : Html) : Html := {{
   <div class="titlepage">
-    <h1>{{title}}</h1>
+    {{heading.toHtml}}
     <div class="authors">
       {{authors.toArray.map ({{ <span class="author">{{Coe.coe ·}}</span> }})}}
       {{if let some note := authorshipNote then {{<p class="note">{{note}}</p>}} else .empty }}


### PR DESCRIPTION
This PR restores missing `id` anchors on manual title pages and split chapter pages. We now emit each registered section ID on its heading, matching the existing behavior for sections rendered when in single-page output mode.

For example, render this Verso manual with `htmlDepth := 1`:

```lean
#docs (Manual) doc "Example" :=
:::::::
See {ref "tagged-chapter"}[the chapter].

# Tagged Chapter
%%%
tag := "tagged-chapter"
%%%

Chapter content.
:::::::
```

The reference points to `/Tagged-Chapter/#tagged-chapter`. Previously, the split-page renderer constructed its own heading without the ID. The relevant HTML changes as follows (simplified):

```diff
 <section>
-  <h1>...</h1>
+  <h1 id="tagged-chapter">...</h1>
   ...
 </section>
```

The link now resolves to the chapter heading correctly.

Title pages have the same missing-anchor problem, including in single-page output.

We now share the anchor, numbering, and permalink construction through a `partHeading` helper, used by ordinary sections, split chapters, and title pages. The helper represents the result as a `Heading` with explicit level, optional ID, and content, and render it through `Heading.toHtml`.

Breaking change: `Html.titlePage` now takes a `Heading` as its first argument. Callers passing plain title HTML must instead supply a heading with its level, ID, and content; manual renderers can use `partHeading` to obtain the registered anchor and existing numbering/permalink behavior.

Codex with GPT-6 was used to prepare this PR.